### PR TITLE
TT-7000 Enhance WSAudioPlayer and RecordButton functionality

### DIFF
--- a/src/renderer/src/components/WSAudioPlayer.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.tsx
@@ -288,6 +288,11 @@ function WSAudioPlayer(props: IProps) {
   const recordStartPosition = useRef(0);
   const recordOverwritePosition = useRef<number | undefined>(undefined);
   const recordingRef = useRef(false);
+  // When recording is initiated, `recordingRef` is updated asynchronously
+  // (after `startRecording(...).then(...)` resolves). This ref closes the
+  // timing gap so global play hotkeys can't toggle while recording is
+  // starting/stopping.
+  const recordingStartPendingRef = useRef(false);
   const [recording, setRecordingx] = useState(false);
   const [waitingForAI, setWaitingForAI] = useState(false);
   const [processMsg, setProcessMsg] = useState<string | undefined>(undefined);
@@ -647,7 +652,9 @@ function WSAudioPlayer(props: IProps) {
       wsPause(); //stop if playing
       recordStartPosition.current = wsPosition();
       wsStartRecord();
+      recordingStartPendingRef.current = true;
       startRecording(500).then((value) => {
+        recordingStartPendingRef.current = false;
         setRecording(value);
       });
 
@@ -657,6 +664,7 @@ function WSAudioPlayer(props: IProps) {
         : undefined;
     } else {
       setProcessingRecording(true);
+      recordingStartPendingRef.current = false;
       stopRecording();
       wsStopRecord();
       setRecording(false);
@@ -713,6 +721,12 @@ function WSAudioPlayer(props: IProps) {
     {
       key: PLAY_PAUSE_KEY,
       cb: () => {
+        if (
+          recordingRef.current ||
+          recordingStartPendingRef.current ||
+          processRecordRef.current
+        )
+          return false;
         togglePlayStatus();
         return true;
       },
@@ -741,6 +755,12 @@ function WSAudioPlayer(props: IProps) {
     {
       key: ALT_PLAY_PAUSE_KEY,
       cb: () => {
+        if (
+          recordingRef.current ||
+          recordingStartPendingRef.current ||
+          processRecordRef.current
+        )
+          return false;
         togglePlayStatus();
         return true;
       },
@@ -989,6 +1009,7 @@ function WSAudioPlayer(props: IProps) {
   }
 
   async function onRecordStop(blob: Blob) {
+    recordingStartPendingRef.current = false;
     const newPos = await wsInsertAudio(
       blob,
       undefined,
@@ -1002,6 +1023,7 @@ function WSAudioPlayer(props: IProps) {
   }
 
   function onRecordError(e: any) {
+    recordingStartPendingRef.current = false;
     setProcessingRecording(false);
 
     if (autostartTimer.current && e.error === 'No mediaRecorder') {

--- a/src/renderer/src/control/RecordButton.cy.tsx
+++ b/src/renderer/src/control/RecordButton.cy.tsx
@@ -65,6 +65,28 @@ describe('RecordButton', () => {
     cy.wrap(onClick).should('have.been.calledTwice');
   });
 
+  it('does not call onClick when Space has modifiers', () => {
+    const onClick = cy.stub().as('onClick');
+    mountRecordButton({
+      recording: false,
+      onClick,
+      disabled: false,
+      tooltipTitle: 'Record',
+    });
+
+    cy.get('[role="button"]').trigger('keydown', {
+      key: ' ',
+      ctrlKey: true,
+    });
+    cy.get('[role="button"]').trigger('keydown', {
+      key: ' ',
+      altKey: true,
+      ctrlKey: true,
+    });
+
+    cy.wrap(onClick).should('not.have.been.called');
+  });
+
   it('does not call onClick when disabled', () => {
     const onClick = cy.stub().as('onClick');
     mountRecordButton({

--- a/src/renderer/src/control/RecordButton.tsx
+++ b/src/renderer/src/control/RecordButton.tsx
@@ -42,11 +42,17 @@ export const RecordButton = ({
 }: IRecordButtonProps) => {
   const theme = useTheme();
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    if (e.key === 'Enter') {
       e.preventDefault();
-      if (!disabled) {
-        onClick();
-      }
+      if (!disabled) onClick();
+      return;
+    }
+    if (e.key === ' ') {
+      // Avoid triggering record while the user is using shortcuts like Ctrl+Space.
+      // This button may be keyboard-focused, so we must ignore modified Space.
+      if (e.ctrlKey || e.altKey || e.shiftKey) return;
+      e.preventDefault();
+      if (!disabled) onClick();
     }
   };
   const handleClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
- Introduced `recordingStartPendingRef` in WSAudioPlayer to manage recording state and prevent global play hotkeys from toggling during recording transitions.
- Updated key handling in RecordButton to ignore Space key events when modifiers (Ctrl, Alt, Shift) are pressed, preventing unintended recording actions.
- Added tests to ensure onClick is not triggered when Space has modifiers.

These changes improve user experience by ensuring that recording controls are more reliable and intuitive.