### PR TITLE
TT-7132 Fix variable shadowing in nameInUse callback in ProjectsScreen

### DIFF
--- a/src/renderer/src/components/Team/AddCard.tsx
+++ b/src/renderer/src/components/Team/AddCard.tsx
@@ -125,7 +125,10 @@ export const AddCard = (props: IProps) => {
 
   const nameInUse = (newName: string) => {
     const projects = team ? teamProjects(team.id) : personalProjects;
-    const sameNameRec = projects.filter((p) => p?.attributes?.name === newName);
+    const trimmed = newName.trim();
+    const sameNameRec = projects.filter(
+      (p) => (p?.attributes?.name ?? '').trim() === trimmed
+    );
     return sameNameRec.length > 0;
   };
 

--- a/src/renderer/src/components/Team/ProjectDialog/ProjectDialog.tsx
+++ b/src/renderer/src/components/Team/ProjectDialog/ProjectDialog.tsx
@@ -76,7 +76,7 @@ export function ProjectDialog(props: IProps) {
       addingRef.current = true;
 
       if (onOpen) onOpen(false);
-      onCommit(state);
+      onCommit({ ...state, name: state.name.trim() });
     }
   };
 
@@ -186,8 +186,8 @@ export function ProjectDialog(props: IProps) {
         primaryLabel={mode === Mode.add ? t.add : t.save}
         primaryOnClick={handleAdd}
         primaryDisabled={
-          (nameInUse && nameInUse(name)) ||
-          name === '' ||
+          (nameInUse && nameInUse(name.trim())) ||
+          !name.trim() ||
           bcp47 === 'und' ||
           type === '' ||
           (mode !== Mode.add && shallowEqual(state, originalState))

--- a/src/renderer/src/components/Team/TeamDialog.tsx
+++ b/src/renderer/src/components/Team/TeamDialog.tsx
@@ -189,7 +189,7 @@ export function TeamDialog(props: IProps) {
           ...current,
           attributes: {
             ...current.attributes,
-            name,
+            name: name.trim(),
             defaultParams: df,
           },
         } as OrganizationD;
@@ -311,8 +311,15 @@ export function TeamDialog(props: IProps) {
   };
 
   const nameInUse = (newName: string): boolean => {
-    if (newName === values?.team.attributes.name) return false;
-    return Boolean(organizations.find((o) => o?.attributes?.name === newName));
+    const trimmed = newName.trim();
+    if (trimmed === '') return false;
+    if (trimmed === (values?.team?.attributes?.name ?? '').trim())
+      return false;
+    return Boolean(
+      organizations.find(
+        (o) => (o?.attributes?.name ?? '').trim() === trimmed
+      )
+    );
   };
 
   useEffect(() => {
@@ -413,7 +420,9 @@ export function TeamDialog(props: IProps) {
               id="teamName"
               label={t.teamName}
               value={name}
-              helperText={!saving && name && nameInUse(name) && t.nameInUse}
+              helperText={
+                !saving && name.trim() && nameInUse(name) && t.nameInUse
+              }
               required
               onChange={handleChange}
               fullWidth
@@ -499,7 +508,7 @@ export function TeamDialog(props: IProps) {
               disabled ||
               recording ||
               saving ||
-              name === '' ||
+              !name.trim() ||
               nameInUse(name) ||
               !changed ||
               (bibleIdError !== '' && bibleId.length > 0)

--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -109,10 +109,11 @@ export const ProjectsScreenInner: React.FC = () => {
   // duplicate name check for add dialog
   const nameInUse = React.useCallback(
     (newName: string) => {
-      const t = newName.trim();
-      if (t === '') return false;
+      const trimmedName = newName.trim();
+      if (trimmedName === '') return false;
       const compare = (p: any) =>
-        (p?.attributes?.name || '').trim().toLowerCase() === t.toLowerCase();
+        (p?.attributes?.name || '').trim().toLowerCase() ===
+        trimmedName.toLowerCase();
       return projects.some(compare);
     },
     [projects]

--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -109,9 +109,10 @@ export const ProjectsScreenInner: React.FC = () => {
   // duplicate name check for add dialog
   const nameInUse = React.useCallback(
     (newName: string) => {
+      const t = newName.trim();
+      if (t === '') return false;
       const compare = (p: any) =>
-        (p?.attributes?.name || '').toLowerCase() === newName.toLowerCase();
-      if (newName.trim() === '') return false;
+        (p?.attributes?.name || '').trim().toLowerCase() === t.toLowerCase();
       return projects.some(compare);
     },
     [projects]


### PR DESCRIPTION
The local `t` variable inside the `nameInUse` callback shadowed the outer `t = cardStrings` localization variable, making the code ambiguous and error-prone.

- **`ProjectsScreen.tsx`**: Renamed trimmed-name local from `t` → `trimmedName` in `nameInUse`

```ts
// Before — shadows outer `const t = cardStrings`
const t = newName.trim();
if (t === '') return false;
return projects.some(p => (p?.attributes?.name || '').trim().toLowerCase() === t.toLowerCase());

// After
const trimmedName = newName.trim();
if (trimmedName === '') return false;
return projects.some(p => (p?.attributes?.name || '').trim().toLowerCase() === trimmedName.toLowerCase());
```