### PR TITLE
TT-7038 PlanTabSelect doesn't includ Assignments for Personal projects

### DIFF
--- a/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
@@ -11,38 +11,59 @@ import bugsnagClient from '../../auth/bugsnagClient';
 import LocalizedStrings from 'react-localization';
 import localizationReducer from '../../store/localization/reducers';
 
-// Mock dependencies
-// Create a mock liveQuery object with subscribe and query methods
-const createMockLiveQuery = () => ({
-  subscribe: () => () => {}, // Returns an unsubscribe function
-  query: () => [],
-});
+/**
+ * Strings aligned with the `planTabs` slice (see planTabsSelector). Matches
+ * localization-takeaways: component tests drive UI text from the same keys the
+ * app uses, via LocalizedStrings on the Redux `strings` slice.
+ */
+const planTabsFixture = {
+  sectionsPassages: '{0} & Passages',
+  media: 'Media',
+  assignments: 'Assignments',
+  transcriptions: 'Transcriptions',
+} as const;
 
-const mockMemory = {
-  cache: {
-    query: () => [],
-    liveQuery: createMockLiveQuery,
-  },
-  update: () => {},
-} as unknown as Memory;
+const organizedByDefault = 'Sections';
+const sectionsPassagesLabel = planTabsFixture.sectionsPassages.replace(
+  '{0}',
+  organizedByDefault
+);
+
+// Mock memory — must match DataProvider so useOrbitData sees organizations (cypress-testing-takeaways: data-driven providers, not import stubs).
+const createMockMemory = (organizations: any[] = []) =>
+  ({
+    cache: {
+      query: () => [],
+      liveQuery: (queryBuildFn: (q: any) => any) => {
+        const q = {
+          findRecords: (type: string) => {
+            if (type === 'organization') return organizations;
+            return [];
+          },
+        };
+        const records = queryBuildFn(q);
+        return {
+          subscribe: () => () => {},
+          query: () => records,
+        };
+      },
+    },
+    update: () => {},
+  }) as unknown as Memory;
+
+let currentTestMemory: Memory = createMockMemory();
 
 const mockCoordinator = {
-  getSource: () => mockMemory,
+  getSource: () => currentTestMemory,
 } as unknown as Coordinator;
 
-// Mock Redux selectors
 const mockPlanTabsStrings = new LocalizedStrings({
-  en: {
-    sectionsPassages: '{0} & Passages',
-    media: 'Media',
-    assignments: 'Assignments',
-    transcriptions: 'Transcriptions',
-  },
+  en: planTabsFixture,
 });
 
 const mockVProjectStrings = new LocalizedStrings({
   en: {
-    sections: 'Sections',
+    sections: organizedByDefault,
     sets: 'Sets',
     stories: 'Stories',
     scenes: 'Scenes',
@@ -51,7 +72,6 @@ const mockVProjectStrings = new LocalizedStrings({
   },
 });
 
-// Create a mock reducer that returns our test strings
 const mockStringsReducer = () => {
   const initialState = localizationReducer(undefined, { type: '@@INIT' });
   return {
@@ -63,7 +83,6 @@ const mockStringsReducer = () => {
   };
 };
 
-// Create store with mock reducer
 const mockStore = createStore(
   combineReducers({
     strings: mockStringsReducer,
@@ -76,11 +95,19 @@ const mockStore = createStore(
   })
 );
 
+/** Personal-team org shape matches isPersonalTeam (`>…Personal<` in name). */
+const personalTeamOrgs = [
+  {
+    id: 'org-1',
+    type: 'organization',
+    attributes: { name: '>Test User Personal<' },
+  },
+];
+
 describe('PlanTabSelect', () => {
   let mockSetTab: ReturnType<typeof cy.stub>;
 
   beforeEach(() => {
-    // Create stub for each test
     mockSetTab = cy.stub().as('setTab');
   });
 
@@ -88,7 +115,7 @@ describe('PlanTabSelect', () => {
     coordinator: mockCoordinator,
     errorReporter: bugsnagClient,
     fingerprint: 'test-fingerprint',
-    memory: mockMemory,
+    memory: currentTestMemory,
     lang: 'en',
     latestVersion: '',
     loadComplete: false,
@@ -145,18 +172,19 @@ describe('PlanTabSelect', () => {
     ...overrides,
   });
 
-  // Helper function to mount PlanTabSelect with required providers
   const mountPlanTabSelect = (
     planContextOverrides = {},
-    globalStateOverrides = {}
+    globalStateOverrides = {},
+    organizations: any[] = []
   ) => {
+    currentTestMemory = createMockMemory(organizations);
     const initialState = createInitialState(globalStateOverrides);
     const planContextState = createMockPlanContextState(planContextOverrides);
 
     cy.mount(
       <Provider store={mockStore}>
         <GlobalProvider init={initialState}>
-          <DataProvider dataStore={mockMemory}>
+          <DataProvider dataStore={currentTestMemory}>
             <PlanContext.Provider
               value={{
                 state: planContextState as any,
@@ -171,219 +199,236 @@ describe('PlanTabSelect', () => {
     );
   };
 
-  it('should render button with correct id and aria-label', () => {
-    mountPlanTabSelect();
-
-    // Wait for component to render
-    cy.wait(100);
-    // Should render button with id="planTabSelect"
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 })
-      .should('exist')
-      .should('be.visible')
-      .should('have.attr', 'aria-label', '{0} & Passages');
-  });
-
-  it('should display default item text when flat is false', () => {
-    mountPlanTabSelect({ flat: false });
-
-    cy.wait(100);
-    // Should show "Sections & Passages" with organizedBy ("Sections") replacing {0}
-    // Since we're using real useOrganizedBy, it will return "Sections" by default
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'contain.text',
-      'Sections & Passages'
-    );
-  });
-
-  it('should display organizedBy text when flat is true', () => {
-    mountPlanTabSelect({ flat: true });
-
-    cy.wait(100);
-    // When flat is true, should show just organizedBy (e.g., "Sections")
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'contain.text',
-      'Sections'
-    );
-    // Should not contain the full "Sections & Passages" text
-    cy.get('button[id="planTabSelect"]').should(
-      'not.contain.text',
-      'Sections & Passages'
-    );
-  });
-
-  it('should display dropdown icon', () => {
-    mountPlanTabSelect();
-
-    cy.wait(100);
-    // Should contain ArrowDropDown icon
-    cy.get('svg[data-testid="ArrowDropDownIcon"]', { timeout: 5000 }).should(
-      'exist'
-    );
-  });
-
-  it('should open menu when button is clicked', () => {
-    mountPlanTabSelect();
-
-    cy.wait(100);
-    // Click the button to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    // Menu should be visible (MUI Menu renders in a portal)
+  const openPlanTabMenu = () => {
+    cy.get('#planTabSelect', { timeout: 5000 }).click();
     cy.get('#import-export-menu', { timeout: 5000 }).should('be.visible');
-  });
+  };
 
-  it('should display all menu options', () => {
-    mountPlanTabSelect({ flat: false });
+  describe('layout and labels', () => {
+    it('should render button with correct id and aria-label', () => {
+      mountPlanTabSelect();
 
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    // Should show all options
-    cy.get('#import-export-menu', { timeout: 5000 }).within(() => {
-      // Should contain the default item
-      cy.contains('Sections & Passages').should('be.visible');
-      cy.contains('Media').should('be.visible');
-      cy.contains('Assignments').should('be.visible');
-      cy.contains('Transcriptions').should('be.visible');
+      cy.wait(100);
+      cy.get('#planTabSelect')
+        .should('exist')
+        .should('be.visible')
+        .should('have.attr', 'aria-label', planTabsFixture.sectionsPassages);
+    });
+
+    it('should display default item text when flat is false', () => {
+      mountPlanTabSelect({ flat: false });
+
+      cy.wait(100);
+      cy.get('#planTabSelect').should('contain.text', sectionsPassagesLabel);
+    });
+
+    it('should display organizedBy text when flat is true', () => {
+      mountPlanTabSelect({ flat: true });
+
+      cy.wait(100);
+      cy.get('#planTabSelect').should('contain.text', organizedByDefault);
+      cy.get('#planTabSelect').should(
+        'not.contain.text',
+        sectionsPassagesLabel
+      );
+    });
+
+    it('should display dropdown icon', () => {
+      mountPlanTabSelect();
+
+      cy.wait(100);
+      cy.get('svg[data-testid="ArrowDropDownIcon"]', { timeout: 5000 }).should(
+        'exist'
+      );
+    });
+
+    it('should display currently selected tab text in button', () => {
+      mountPlanTabSelect({ flat: false, tab: 1 });
+
+      cy.wait(100);
+      cy.get('#planTabSelect').should('contain.text', planTabsFixture.media);
+    });
+
+    it('should update button text when tab changes', () => {
+      mountPlanTabSelect({ flat: false, tab: 0 });
+
+      cy.wait(100);
+      cy.get('#planTabSelect')
+        .should('contain.text', sectionsPassagesLabel)
+        .should('contain.text', organizedByDefault);
+
+      mountPlanTabSelect({ flat: false, tab: 2 });
+      cy.wait(100);
+      cy.get('#planTabSelect').should(
+        'contain.text',
+        planTabsFixture.assignments
+      );
     });
   });
 
-  it('should call setTab when menu item is clicked', () => {
-    mountPlanTabSelect({ flat: false, tab: 0 });
+  describe('menu interaction', () => {
+    it('should open menu when button is clicked', () => {
+      mountPlanTabSelect();
 
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    // Click on Media option (index 1)
-    cy.get('#import-export-menu', { timeout: 5000 }).contains('Media').click();
-    // setTab should be called with index 1
-    cy.wrap(mockSetTab).should('have.been.calledWith', 1);
-  });
-
-  it('should call setTab with correct index for each menu item', () => {
-    mountPlanTabSelect({ flat: false, tab: 0 });
-
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-
-    // Click Assignments (index 2)
-    cy.get('#import-export-menu', { timeout: 5000 })
-      .contains('Assignments')
-      .click();
-    cy.wrap(mockSetTab).should('have.been.calledWith', 2);
-
-    // Wait a bit for menu to close, then re-open menu and click Transcriptions (index 3)
-    cy.wait(300);
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click({
-      force: true,
+      cy.wait(100);
+      openPlanTabMenu();
     });
-    cy.get('#import-export-menu', { timeout: 5000 })
-      .contains('Transcriptions')
-      .click();
-    cy.wrap(mockSetTab).should('have.been.calledWith', 3);
-  });
 
-  it('should close menu after selecting an item', () => {
-    mountPlanTabSelect();
+    it('should close menu after selecting an item', () => {
+      mountPlanTabSelect();
 
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    cy.get('#import-export-menu', { timeout: 5000 }).should('be.visible');
-    // Click on an item - this should trigger setTab and close the menu
-    cy.get('#import-export-menu').contains('Media').click();
-    // Verify setTab was called
-    cy.wrap(mockSetTab).should('have.been.called');
-    // Menu should be closed - button's aria-owns should be cleared
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'not.have.attr',
-      'aria-owns'
-    );
-  });
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get(`#${CSS.escape(planTabsFixture.media)}`).click();
+      cy.wrap(mockSetTab).should('have.been.called');
+      cy.get('#planTabSelect').should('not.have.attr', 'aria-owns');
+    });
 
-  it('should display currently selected tab text in button', () => {
-    mountPlanTabSelect({ flat: false, tab: 1 });
+    it('should set aria-owns attribute when menu is open', () => {
+      mountPlanTabSelect();
 
-    cy.wait(100);
-    // When tab is 1, button should show "Media"
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'contain.text',
-      'Media'
-    );
-  });
+      cy.wait(100);
+      cy.get('#planTabSelect').should('not.have.attr', 'aria-owns');
+      cy.get('#planTabSelect').click();
+      cy.get('#import-export-menu', { timeout: 5000 }).should('exist');
+    });
 
-  it('should update button text when tab changes', () => {
-    mountPlanTabSelect({ flat: false, tab: 0 });
+    it('should handle closing menu when clicking outside', () => {
+      mountPlanTabSelect();
 
-    cy.wait(100);
-    // Initially should show first option
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 })
-      .should('contain.text', 'Sections & Passages')
-      .should('contain.text', 'Sections');
-
-    // Mount again with different tab to simulate change
-    // (In a real scenario, setTab would update the context state)
-    mountPlanTabSelect({ flat: false, tab: 2 });
-    cy.wait(100);
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'contain.text',
-      'Assignments'
-    );
-  });
-
-  it('should set aria-owns attribute when menu is open', () => {
-    mountPlanTabSelect();
-
-    cy.wait(100);
-    // Initially aria-owns should not be set
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).should(
-      'not.have.attr',
-      'aria-owns'
-    );
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]').click();
-    // When menu is open, menu should exist
-    cy.get('#import-export-menu', { timeout: 5000 }).should('exist');
-  });
-
-  it('should handle menu options with flat mode correctly', () => {
-    mountPlanTabSelect({ flat: true });
-
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    // First option should be just organizedBy (e.g., "Sections"), not "Sections & Passages"
-    cy.get('#import-export-menu', { timeout: 5000 })
-      .find('li[role="menuitem"]')
-      .first()
-      .should('contain.text', 'Sections')
-      .should('not.contain.text', 'Sections & Passages');
-  });
-
-  it('should render menu items with correct ids', () => {
-    mountPlanTabSelect({ flat: false });
-
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    // Each menu item should have an id matching its text
-    cy.get('#import-export-menu', { timeout: 5000 }).within(() => {
-      cy.contains('Media').should('have.attr', 'id', 'Media');
-      cy.contains('Assignments').should('have.attr', 'id', 'Assignments');
-      cy.contains('Transcriptions').should('have.attr', 'id', 'Transcriptions');
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('body').click(0, 0);
+      cy.get('#import-export-menu').should('not.exist');
     });
   });
 
-  it('should handle closing menu when clicking outside', () => {
-    mountPlanTabSelect();
+  describe('with assignments tab (non-personal team, online)', () => {
+    it('should display all menu options including assignments', () => {
+      mountPlanTabSelect({ flat: false });
 
-    cy.wait(100);
-    // Click to open menu
-    cy.get('button[id="planTabSelect"]', { timeout: 5000 }).click();
-    cy.get('#import-export-menu', { timeout: 5000 }).should('be.visible');
-    // Click outside (on the body/document)
-    cy.get('body').click(0, 0);
-    // Menu should close
-    cy.get('#import-export-menu').should('not.exist');
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('#import-export-menu').within(() => {
+        cy.contains(sectionsPassagesLabel).should('be.visible');
+        cy.get(`#${CSS.escape(planTabsFixture.media)}`).should('be.visible');
+        cy.get(`#${CSS.escape(planTabsFixture.assignments)}`).should(
+          'be.visible'
+        );
+        cy.get(`#${CSS.escape(planTabsFixture.transcriptions)}`).should(
+          'be.visible'
+        );
+      });
+    });
+
+    it('should call setTab when Media menu item is clicked', () => {
+      mountPlanTabSelect({ flat: false, tab: 0 });
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get(`#${CSS.escape(planTabsFixture.media)}`).click();
+      cy.wrap(mockSetTab).should('have.been.calledWith', 1);
+    });
+
+    it('should call setTab with correct index for assignments and transcriptions', () => {
+      mountPlanTabSelect({ flat: false, tab: 0 });
+
+      cy.wait(100);
+      openPlanTabMenu();
+
+      cy.get(`#${CSS.escape(planTabsFixture.assignments)}`).click();
+      cy.wrap(mockSetTab).should('have.been.calledWith', 2);
+
+      cy.wait(300);
+      cy.get('#planTabSelect').click({ force: true });
+      cy.get(`#${CSS.escape(planTabsFixture.transcriptions)}`).click();
+      cy.wrap(mockSetTab).should('have.been.calledWith', 3);
+    });
+
+    it('should render menu items with stable ids from localized labels', () => {
+      mountPlanTabSelect({ flat: false });
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('#import-export-menu').within(() => {
+        cy.get(`#${CSS.escape(planTabsFixture.media)}`).should('exist');
+        cy.get(`#${CSS.escape(planTabsFixture.assignments)}`).should('exist');
+        cy.get(`#${CSS.escape(planTabsFixture.transcriptions)}`).should(
+          'exist'
+        );
+      });
+    });
+
+    it('should handle menu options with flat mode correctly', () => {
+      mountPlanTabSelect({ flat: true });
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('#import-export-menu')
+        .find('li[role="menuitem"]')
+        .first()
+        .should('contain.text', organizedByDefault)
+        .should('not.contain.text', sectionsPassagesLabel);
+    });
+  });
+
+  describe('without assignments tab (personal team or offline-only)', () => {
+    it('should not show Assignments for personal team (Personal Audio projects)', () => {
+      mountPlanTabSelect(
+        { flat: false },
+        { organization: 'org-1' },
+        personalTeamOrgs
+      );
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('#import-export-menu').within(() => {
+        cy.get(`#${CSS.escape(planTabsFixture.assignments)}`).should(
+          'not.exist'
+        );
+        cy.get(`#${CSS.escape(planTabsFixture.transcriptions)}`).should(
+          'be.visible'
+        );
+      });
+    });
+
+    it('should not show Assignments when offlineOnly', () => {
+      mountPlanTabSelect({ flat: false }, { offlineOnly: true });
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get('#import-export-menu').within(() => {
+        cy.get(`#${CSS.escape(planTabsFixture.assignments)}`).should(
+          'not.exist'
+        );
+      });
+    });
+
+    it('should call setTab(2) when Transcriptions is chosen on personal team', () => {
+      mountPlanTabSelect(
+        { flat: false, tab: 0 },
+        { organization: 'org-1' },
+        personalTeamOrgs
+      );
+
+      cy.wait(100);
+      openPlanTabMenu();
+      cy.get(`#${CSS.escape(planTabsFixture.transcriptions)}`).click();
+      cy.wrap(mockSetTab).should('have.been.calledWith', 2);
+    });
+
+    it('should show Transcriptions on button when tab is 2 on personal team', () => {
+      mountPlanTabSelect(
+        { flat: false, tab: 2 },
+        { organization: 'org-1' },
+        personalTeamOrgs
+      );
+
+      cy.wait(100);
+      cy.get('#planTabSelect').should(
+        'contain.text',
+        planTabsFixture.transcriptions
+      );
+    });
   });
 });

--- a/src/renderer/src/components/Sheet/PlanTabSelect.tsx
+++ b/src/renderer/src/components/Sheet/PlanTabSelect.tsx
@@ -1,12 +1,16 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
-import { IPlanTabsStrings } from '@model/index';
+import { IPlanTabsStrings, OrganizationD } from '@model/index';
 import { Menu, MenuItem } from '@mui/material';
 import DropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { AltButton } from '../../control/AltButton';
 import { planTabsSelector } from '../../selector';
 import { useOrganizedBy } from '../../crud/useOrganizedBy';
+import { isPersonalTeam } from '../../crud/isPersonalTeam';
 import { PlanContext } from '../../context/PlanContext';
+import { useGlobal } from '../../context/useGlobal';
+import { useOrbitData } from '../../hoc/useOrbitData';
+import { PlanTabEnum } from '../PlanTabsEnum';
 
 export const PlanTabSelect = () => {
   const [actionMenuItem, setActionMenuItem] = useState<null | HTMLElement>(
@@ -17,21 +21,39 @@ export const PlanTabSelect = () => {
   const organizedBy = getOrganizedBy(false);
   const ctx = useContext(PlanContext);
   const { flat, tab, setTab } = ctx.state;
+  const [team] = useGlobal('organization');
+  const [offlineOnly] = useGlobal('offlineOnly');
+  const teams = useOrbitData<OrganizationD[]>('organization');
+  const showAssign = useMemo(
+    () => !isPersonalTeam(team, teams) && !offlineOnly,
+    [team, teams, offlineOnly]
+  );
   const defaultItem = useMemo(
     () => (flat ? organizedBy : t.sectionsPassages.replace('{0}', organizedBy)),
     [flat, organizedBy, t]
   );
-  const [options, setOptions] = useState<string[]>([]);
+  const options = useMemo(() => {
+    const base = [defaultItem, t.media];
+    return showAssign
+      ? [...base, t.assignments, t.transcriptions]
+      : [...base, t.transcriptions];
+  }, [defaultItem, t.media, t.assignments, t.transcriptions, showAssign]);
   const handleMenu = (e: any) => setActionMenuItem(e.currentTarget);
   const handleClose = () => setActionMenuItem(null);
-  const handleChange = (i: number) => () => {
-    setTab(i);
+  const handleChange = (menuIndex: number) => () => {
+    const tabIndex =
+      showAssign || menuIndex < PlanTabEnum.assignment
+        ? menuIndex
+        : PlanTabEnum.assignment;
+    setTab(tabIndex);
     handleClose();
   };
 
-  useEffect(() => {
-    setOptions([defaultItem, t.media, t.assignments, t.transcriptions]);
-  }, [defaultItem, t.media, t.assignments, t.transcriptions]);
+  const resolvedTab = tab ?? 0;
+  const optionIndex =
+    !showAssign && resolvedTab === PlanTabEnum.transcription
+      ? PlanTabEnum.assignment
+      : resolvedTab;
 
   return (
     <>
@@ -41,7 +63,7 @@ export const PlanTabSelect = () => {
         aria-label={t.sectionsPassages}
         onClick={handleMenu}
       >
-        {options[tab]}
+        {options[optionIndex] ?? options[0]}
         <DropDownIcon sx={{ ml: 1 }} />
       </AltButton>
       <Menu


### PR DESCRIPTION
- Introduced a fixture for plan tab strings to streamline localization.
- Updated memory mock to align with DataProvider for better testing.
- Enhanced option handling in the dropdown to conditionally display items based on team type and offline status.
- Simplified state management and improved readability in the component's logic.
- Added tests to ensure correct rendering and functionality of the PlanTabSelect component.