### PR TITLE
TT-7222 no load while recording

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
@@ -66,6 +66,7 @@ export function PassageDetailRecord(props: IProps) {
     sharedResource,
     mediafileId,
     chooserSize,
+    recording,
     setRecording,
     currentstep,
   } = usePassageDetailContext();
@@ -270,6 +271,7 @@ export function PassageDetailRecord(props: IProps) {
               id="pdRecordLoadFile"
               onClick={handleUpload}
               title={ts.loadFromFile}
+              disabled={recording}
               startIcon={
                 <FolderOpenOutlinedIcon
                   sx={{ width: '14px', height: '14px' }}


### PR DESCRIPTION
Add recording state handling to PassageDetailRecord component

- Introduced a new 'recording' prop to manage the disabled state of the file upload button.
- Updated the button to be disabled when recording is active, enhancing user experience.