### PR TITLE
TT-7220 no load while unsaved recording present

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
@@ -66,6 +66,7 @@ export function PassageDetailRecord(props: IProps) {
     sharedResource,
     mediafileId,
     chooserSize,
+    recording,
     setRecording,
     currentstep,
   } = usePassageDetailContext();
@@ -269,6 +270,7 @@ export function PassageDetailRecord(props: IProps) {
             <AltButton
               id="pdRecordLoadFile"
               onClick={handleUpload}
+              disabled={canSave || recording}
               title={ts.loadFromFile}
               startIcon={
                 <FolderOpenOutlinedIcon


### PR DESCRIPTION
Add recording state management to PassageDetailRecord component

- Introduced a new `recording` prop to manage recording state.
- Disabled the upload button when a recording is in progress to prevent conflicts.