### PR TITLE
TT-7185 no offline mobile team settings

### DIFF
--- a/src/renderer/src/components/App/OrgHead.cy.tsx
+++ b/src/renderer/src/components/App/OrgHead.cy.tsx
@@ -886,19 +886,18 @@ describe('OrgHead', () => {
     });
   });
 
-  it('should not show first two menu items on mobile width', () => {
+  it('should show team settings menu on mobile width when online admin', () => {
     // Set mobile viewport (below 'sm' breakpoint which is 600px)
     cy.viewport(375, 667);
     const orgId = 'test-org-id';
     const orgName = 'Test Organization';
     const orgData = createMockOrganization(orgId, orgName);
-    // Create multiple projects to make showSort true
     const project1 = createMockProject('project-1', 'Project 1');
     const project2 = createMockProject('project-2', 'Project 2');
     const projectData = [project1, project2];
 
     mountOrgHead(
-      createInitialState({ offlineOnly: true }, orgData, projectData),
+      createInitialState({}, orgData, projectData),
       ['/team'],
       orgId,
       orgData,
@@ -907,20 +906,58 @@ describe('OrgHead', () => {
       projectData
     );
 
-    // Settings button should exist because showSort is true
     cy.get('button').first().click();
     cy.get('[role="menu"]').should('be.visible');
 
-    // First two menu items should NOT be visible on mobile
-    cy.contains('Team Settings').should('not.exist');
-    cy.contains('Edit Workflow').should('not.exist');
-
-    // Sort Projects (third item) should be visible since showSort is true
+    cy.contains('Team Settings').should('be.visible');
+    cy.contains('Edit Workflow').should('be.visible');
     cy.contains('Sort Projects').should('be.visible');
   });
 
-  it('should not show settings button on mobile width when showSort is false', () => {
+  it('should not show settings menu on mobile width when offline', () => {
+    cy.viewport(375, 667);
+    const orgId = 'test-org-id';
+    const orgName = 'Test Organization';
+    const orgData = createMockOrganization(orgId, orgName);
+    const project1 = createMockProject('project-1', 'Project 1');
+    const project2 = createMockProject('project-2', 'Project 2');
+    const projectData = [project1, project2];
+
+    mountOrgHead(
+      createInitialState({ offline: true, connected: false }, orgData, projectData),
+      ['/team'],
+      orgId,
+      orgData,
+      true,
+      undefined,
+      projectData
+    );
+
+    cy.get('button').should('have.length', 1);
+    cy.contains('Team Settings').should('not.exist');
+  });
+
+  it('should not show settings button on mobile width when offline (showSort false)', () => {
     // Set mobile viewport (below 'sm' breakpoint which is 600px)
+    cy.viewport(375, 667);
+    const orgId = 'test-org-id';
+    const orgName = 'Test Organization';
+    const orgData = createMockOrganization(orgId, orgName);
+
+    mountOrgHead(
+      createInitialState({ offline: true, connected: false }),
+      ['/team'],
+      orgId,
+      orgData,
+      true
+    );
+
+    // Team settings gear is hidden when offline (same as desktop TeamItem)
+    cy.get('button').should('have.length', 1); // Only members button should exist
+    cy.get('button svg').should('have.length', 1); // Only one icon (members)
+  });
+
+  it('should show settings button on mobile width when online admin even if showSort is false', () => {
     cy.viewport(375, 667);
     const orgId = 'test-org-id';
     const orgName = 'Test Organization';
@@ -928,10 +965,8 @@ describe('OrgHead', () => {
 
     mountOrgHead(createInitialState(), ['/team'], orgId, orgData, true);
 
-    // Settings button should NOT exist because isMobileWidth is true and showSort is false
-    // (no projects means hasMoreThanOneProject is false, so showSort is false)
-    cy.get('button').should('have.length', 1); // Only members button should exist
-    cy.get('button svg').should('have.length', 1); // Only one icon (members)
+    cy.get('button').should('have.length', 2); // Settings + members
+    cy.get('button svg').should('have.length', 2);
   });
 
   it('should show settings button on mobile width when showSort is true', () => {
@@ -955,7 +990,7 @@ describe('OrgHead', () => {
       projectData
     );
 
-    // Settings button should exist because showSort is true
+    // Settings button should exist because canModify is true (offlineOnly)
     cy.get('button').should('have.length.at.least', 2); // Settings and members buttons
     cy.get('button svg').should('have.length.at.least', 2); // At least two icons
 
@@ -963,11 +998,11 @@ describe('OrgHead', () => {
     cy.get('button').first().click();
     cy.get('[role="menu"]').should('be.visible');
 
-    // Sort Projects should be visible
+    cy.contains('Team Settings').should('be.visible');
     cy.contains('Sort Projects').should('be.visible');
   });
 
-  it('should not show Team Settings or Edit Workflow when mobile view is on at desktop width', () => {
+  it('should not show team settings menu when mobile view is on at desktop width but offline', () => {
     cy.viewport(1024, 768);
     cy.window().then((win) => {
       win.localStorage.setItem(
@@ -983,7 +1018,11 @@ describe('OrgHead', () => {
     const projectData = [project1, project2];
 
     mountOrgHead(
-      createInitialState({ mobileView: true, offlineOnly: true }, orgData, projectData),
+      createInitialState(
+        { mobileView: true, offline: true, connected: false },
+        orgData,
+        projectData
+      ),
       ['/team'],
       orgId,
       orgData,
@@ -992,10 +1031,7 @@ describe('OrgHead', () => {
       projectData
     );
 
-    cy.get('button').first().click();
-    cy.get('[role="menu"]').should('be.visible');
+    cy.get('button').should('have.length', 1);
     cy.contains('Team Settings').should('not.exist');
-    cy.contains('Edit Workflow').should('not.exist');
-    cy.contains('Sort Projects').should('be.visible');
   });
 });

--- a/src/renderer/src/components/App/OrgHead.tsx
+++ b/src/renderer/src/components/App/OrgHead.tsx
@@ -186,7 +186,7 @@ export const OrgHead = () => {
       </Typography>
       {isTeamScreen && (
         <>
-          {isAdmin && canModify && (
+          {canModify && (
             <>
               <IconButton
                 onClick={handleSettingsMenuOpen}

--- a/src/renderer/src/components/App/OrgHead.tsx
+++ b/src/renderer/src/components/App/OrgHead.tsx
@@ -186,7 +186,7 @@ export const OrgHead = () => {
       </Typography>
       {isTeamScreen && (
         <>
-          {isAdmin && (!isMobile || showSort) && (
+          {isAdmin && canModify && (
             <>
               <IconButton
                 onClick={handleSettingsMenuOpen}
@@ -199,17 +199,13 @@ export const OrgHead = () => {
                 open={Boolean(settingsMenuEl)}
                 onClose={handleSettingsMenuClose}
               >
-                {!isMobile && (
-                  <MenuItem onClick={handleSettings}>
-                    {cardStrings?.teamSettings || 'Team Settings'}
-                  </MenuItem>
-                )}
-                {!isMobile && canModify && (
-                  <MenuItem onClick={handleWorkflow}>
-                    {cardStrings?.editWorkflow?.replace('{0}', '') ||
-                      'Edit Workflow'}
-                  </MenuItem>
-                )}
+                <MenuItem onClick={handleSettings}>
+                  {cardStrings?.teamSettings || 'Team Settings'}
+                </MenuItem>
+                <MenuItem onClick={handleWorkflow}>
+                  {cardStrings?.editWorkflow?.replace('{0}', '') ||
+                    'Edit Workflow'}
+                </MenuItem>
                 {showSort && (
                   <MenuItem onClick={handleSort}>
                     {cardStrings?.sortProjects || 'Sort Projects'}

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -80,8 +80,9 @@ const TeamCard = ({ label, teamId, name, onOpenSettings }: ITeamCardProps) => {
   const [isOffline] = useGlobal('offline');
   const [offlineOnly] = useGlobal('offlineOnly');
   const [connected] = useGlobal('connected');
-  // For personal team, always show settings button (user owns it)
-  // For other teams, show settings button only if user is admin
+  // Personal teams are always eligible for settings; other teams require admin access.
+  // The button is only rendered when team settings can be modified in the current
+  // connectivity mode (online, or offlineOnly).
   const isPersonalTeam = teamId === personalTeam;
   const showSettings = isPersonalTeam || (teamRec && isAdmin(teamRec));
   const canModifyTeamSettings = (!isOffline && connected) || offlineOnly;

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -20,6 +20,7 @@ import AppHead from '../components/App/AppHead';
 import { useTheme, alpha } from '@mui/material/styles';
 import { TeamProvider } from '../context/TeamContext';
 import { TeamContext } from '../context/TeamContext';
+import { useGlobal } from '../context/useGlobal';
 import { useTeamActions } from '../components/Team/useTeamActions';
 import { SharedContentCreatorDialog } from '../components/Team/SharedContentCreatorDialog';
 
@@ -76,10 +77,16 @@ const TeamCard = ({ label, teamId, name, onOpenSettings }: ITeamCardProps) => {
   const { isAdmin, teams, personalTeam } = ctx.state;
   const teamRec = teams.find((t) => t.id === teamId);
   const { isMobile } = useMobile();
+  const [isOffline] = useGlobal('offline');
+  const [offlineOnly] = useGlobal('offlineOnly');
+  const [connected] = useGlobal('connected');
   // For personal team, always show settings button (user owns it)
   // For other teams, show settings button only if user is admin
   const isPersonalTeam = teamId === personalTeam;
   const showSettings = isPersonalTeam || (teamRec && isAdmin(teamRec));
+  const canModifyTeamSettings =
+    ((!isOffline && connected) || offlineOnly) &&
+    (isPersonalTeam || Boolean(teamRec && isAdmin(teamRec)));
 
   return (
     <Card
@@ -112,7 +119,7 @@ const TeamCard = ({ label, teamId, name, onOpenSettings }: ITeamCardProps) => {
         >
           {name}
         </Typography>
-        {showSettings && !isMobile && (
+        {showSettings && !isMobile && canModifyTeamSettings && (
           <SettingsButton label={label} onOpenSettings={onOpenSettings} />
         )}
       </Box>

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -84,9 +84,7 @@ const TeamCard = ({ label, teamId, name, onOpenSettings }: ITeamCardProps) => {
   // For other teams, show settings button only if user is admin
   const isPersonalTeam = teamId === personalTeam;
   const showSettings = isPersonalTeam || (teamRec && isAdmin(teamRec));
-  const canModifyTeamSettings =
-    ((!isOffline && connected) || offlineOnly) &&
-    (isPersonalTeam || Boolean(teamRec && isAdmin(teamRec)));
+  const canModifyTeamSettings = (!isOffline && connected) || offlineOnly;
 
   return (
     <Card


### PR DESCRIPTION
Refactor OrgHead component to improve mobile menu visibility logic. Updated tests to reflect changes in settings menu display based on online/offline status and admin permissions. Enhanced conditions for rendering menu items in mobile view.