### PR TITLE
TT-7227 Audio Tab fully visible

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,7 +8,7 @@ import { useSelector, shallowEqual } from 'react-redux';
 import { IState } from './model';
 import { getDataGridLocale } from './utils/dataGridLocale';
 import { useMemo } from 'react';
-export const HeadHeight = 64;
+export const HeadHeight = 56;
 
 function App(): React.JSX.Element {
   const lang = useSelector((state: IState) => state.strings.lang, shallowEqual);

--- a/src/renderer/src/components/AudioTab/AudioTable.tsx
+++ b/src/renderer/src/components/AudioTab/AudioTable.tsx
@@ -234,9 +234,8 @@ export const AudioTable = (props: IProps) => {
     <Box
       sx={{
         width: '100%',
-        minHeight: '20rem',
-        maxHeight: { xs: '20rem', sm: 'none' },
-        overflowY: 'auto',
+        // xs: let the list grow with the page so multiple cards are visible without a short inner scroll pane.
+        minHeight: { xs: 0, sm: '20rem' },
       }}
     >
       {sortedData.map((row) => {

--- a/src/renderer/src/components/PassageDetail/mobile/record/AudioVersionCard.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/record/AudioVersionCard.tsx
@@ -142,7 +142,7 @@ export const AudioVersionCard: React.FC<AudioVersionCardProps> = (props) => {
           sx={{
             width: '100%',
             minWidth: 0,
-            alignItems: 'stretch',
+            alignItems: 'flex-start',
           }}
         >
           <Stack
@@ -150,7 +150,7 @@ export const AudioVersionCard: React.FC<AudioVersionCardProps> = (props) => {
             alignItems="center"
             sx={{
               flexShrink: 0,
-              alignSelf: 'stretch',
+              alignSelf: 'flex-start',
             }}
           >
             {props.showAttachControl && props.onAttachToggle && (
@@ -324,9 +324,9 @@ export const AudioVersionCard: React.FC<AudioVersionCardProps> = (props) => {
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
-              justifyContent: 'flex-end',
+              justifyContent: 'flex-start',
               flexShrink: 0,
-              alignSelf: 'stretch',
+              alignSelf: 'flex-start',
             }}
           >
             <UserAvatar

--- a/src/renderer/src/components/PlanTabs.tsx
+++ b/src/renderer/src/components/PlanTabs.tsx
@@ -34,6 +34,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { planTabsSelector } from '../selector';
 import { PlanTabEnum } from './PlanTabsEnum';
 import { grey } from '@mui/material/colors';
+import { PlanTabSelect } from './Sheet/PlanTabSelect';
 
 interface IProps {
   checkSaved: (method: () => void) => void;
@@ -131,65 +132,73 @@ const ScrollableTabsButtonAuto = (props: IProps) => {
           width: '100%',
         }}
       >
-        <Tabs
-          value={tab ?? 0}
-          onChange={(e: any, v: number) => checkSaved(() => handleChange(e, v))}
-          indicatorColor="primary"
-          textColor="primary"
-          variant="scrollable"
-          scrollButtons="auto"
-        >
-          <Tab
-            id="secPass"
-            label={
-              flat
-                ? organizedBy
-                : t.sectionsPassages.replace('{0}', organizedBy)
+        {isMobile ? (
+          <Box>
+            <PlanTabSelect />
+          </Box>
+        ) : (
+          <Tabs
+            value={tab ?? 0}
+            onChange={(e: any, v: number) =>
+              checkSaved(() => handleChange(e, v))
             }
-          />
-          <Tab
-            id="audio"
-            label={
-              <Title
-                text={t.media}
-                status={statusMessage(
-                  t.mediaStatus,
-                  (attached ?? []).length,
-                  (planMedia ?? []).length
-                )}
-              />
-            }
-          />
-          {showAssign && (
+            indicatorColor="primary"
+            textColor="primary"
+            variant="scrollable"
+            scrollButtons="auto"
+          >
             <Tab
-              id="assignments"
+              id="secPass"
+              label={
+                flat
+                  ? organizedBy
+                  : t.sectionsPassages.replace('{0}', organizedBy)
+              }
+            />
+            <Tab
+              id="audio"
               label={
                 <Title
-                  text={t.assignments}
+                  text={t.media}
                   status={statusMessage(
-                    t.sectionStatus.replace('{0}', organizedBy),
-                    (assigned ?? []).length,
-                    (planSectionIds ?? []).length
+                    t.mediaStatus,
+                    (attached ?? []).length,
+                    (planMedia ?? []).length
                   )}
                 />
               }
-              disabled={isOffline}
             />
-          )}
-          <Tab
-            id="transcriptions"
-            label={
-              <Title
-                text={t.transcriptions}
-                status={statusMessage(
-                  t.passageStatus,
-                  (trans ?? []).length,
-                  (planPassages ?? []).length
-                )}
+            {showAssign && (
+              <Tab
+                id="assignments"
+                label={
+                  <Title
+                    text={t.assignments}
+                    status={statusMessage(
+                      t.sectionStatus.replace('{0}', organizedBy),
+                      (assigned ?? []).length,
+                      (planSectionIds ?? []).length
+                    )}
+                  />
+                }
+                disabled={isOffline}
               />
-            }
-          />
-        </Tabs>
+            )}
+            <Tab
+              id="transcriptions"
+              label={
+                <Title
+                  text={t.transcriptions}
+                  status={statusMessage(
+                    t.passageStatus,
+                    (trans ?? []).length,
+                    (planPassages ?? []).length
+                  )}
+                />
+              }
+            />
+          </Tabs>
+        )}
       </AppBar>
       <Box sx={{ pt: `${TabHeight}px` }}>
         {tab === PlanTabEnum.sectionPassage && (

--- a/src/renderer/src/components/Sheet/PlanTabSelect.tsx
+++ b/src/renderer/src/components/Sheet/PlanTabSelect.tsx
@@ -11,8 +11,10 @@ import { PlanContext } from '../../context/PlanContext';
 import { useGlobal } from '../../context/useGlobal';
 import { useOrbitData } from '../../hoc/useOrbitData';
 import { PlanTabEnum } from '../PlanTabsEnum';
+import { UnsavedContext } from '../../context/UnsavedContext';
 
 export const PlanTabSelect = () => {
+  const { checkSavedFn: checkSaved } = useContext(UnsavedContext).state;
   const [actionMenuItem, setActionMenuItem] = useState<null | HTMLElement>(
     null
   );
@@ -40,7 +42,7 @@ export const PlanTabSelect = () => {
   }, [defaultItem, t.media, t.assignments, t.transcriptions, showAssign]);
   const handleMenu = (e: any) => setActionMenuItem(e.currentTarget);
   const handleClose = () => setActionMenuItem(null);
-  const handleChange = (menuIndex: number) => () => {
+  const handleChange = (menuIndex: number) => {
     const tabIndex =
       showAssign || menuIndex < PlanTabEnum.assignment
         ? menuIndex
@@ -73,7 +75,11 @@ export const PlanTabSelect = () => {
         onClose={handleClose}
       >
         {options.map((v, i) => (
-          <MenuItem key={v} id={v} onClick={handleChange(i)}>
+          <MenuItem
+            key={v}
+            id={v}
+            onClick={() => checkSaved(() => handleChange(i))}
+          >
             {v}
           </MenuItem>
         ))}


### PR DESCRIPTION
- update HeadHeight to 56 - no space above secondary header
- integrate PlanTabSelect for mobile view so Audio shows up as a button
- refine alignment properties in AudioVersionCard to fill screen