### PR TITLE
TT-7221 handle multiple region delete

### DIFF
--- a/src/renderer/src/crud/useWavesurferRegions.tsx
+++ b/src/renderer/src/crud/useWavesurferRegions.tsx
@@ -347,17 +347,24 @@ export function useWaveSurferRegions(
           ra.attributes.nextRegion.attributes.prevRegion =
             ra.attributes?.prevRegion;
 
+        // Drop the selection immediately when this removal is the active region.
+        // Otherwise currentRegionRef can keep a dead Region reference across
+        // wsRegionDelete → loadDecoded while region-removed used waitForIt with a
+        // 1s poll interval, causing races and Delete Region to no-op.
+        if (currentRegionRef.current?.id === r.id) {
+          currentRegionOriginalColorRef.current = '';
+          loopingRegionRef.current = undefined;
+          currentRegionRef.current = undefined;
+          onCurrentRegion && onCurrentRegion(undefined);
+        }
+
         if (wsRef.current && !loadingRef.current && !destroyingRef.current) {
-          // wait for it to be removed from this list
-          waitForIt(
-            'region removed',
-            () => region(r.id) === undefined,
-            () => false,
-            200
-          ).then(() => {
-            if (destroyingRef.current) return;
+          queueMicrotask(() => {
+            if (destroyingRef.current || !wsRef.current) return;
             onRegion(numRegions(), true);
-            setCurrentRegion(findRegion(progress(), true));
+            if (!currentRegionRef.current) {
+              setCurrentRegion(findRegion(progress(), true));
+            }
           });
         }
       });


### PR DESCRIPTION
Here is what was going wrong and what we changed.

Cause
region-removed relied on waitForIt() so the plugin’s region list matched region(r.id) === undefined. That helper waits one second between attempts (waitForIt.ts), so updates to currentRegionRef could run much later than wsRegionDelete → await loadDecoded(...).

During that gap, currentRegionRef could still reference the Region you just removed while the waveform had already been reloaded. Combined with repeated deletes and new selections, that stale reference led to wsRegionDelete bailing out early (if (!currentRegion())) or behaving inconsistently on later deletes.

Fix
In 341:373:src/renderer/src/crud/useWavesurferRegions.tsx:

When the removed region is the current selection, clear currentRegionRef, loop state, color bookkeeping, and onCurrentRegion synchronously (without calling setOptions on a detached region).

Replace waitForIt with queueMicrotask for refreshing region count and only calling setCurrentRegion(findRegion(...)) if nothing else has become current (!currentRegionRef.current), so we don’t fight a newer click.