### PR TITLE
TT-7217 keep audio during discussion

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailMobileDetail.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailMobileDetail.tsx
@@ -48,7 +48,15 @@ export default function PassageDetailMobileDetail({
               spacing={1}
               sx={{ height: '100%', width: '100%', minWidth: 0 }}
             >
-              {recordContent}
+              <Box
+                sx={
+                  flushDiscussionLeft
+                    ? { display: 'none' }
+                    : { minWidth: 0, width: '100%' }
+                }
+              >
+                {recordContent}
+              </Box>
               <Box sx={{ width: '100%', minWidth: 0 }}>
                 <DiscussionPanel />
               </Box>

--- a/src/renderer/src/routes/PassageDetail.tsx
+++ b/src/renderer/src/routes/PassageDetail.tsx
@@ -72,7 +72,9 @@ const MobileDetail = () => {
       showNoAudioPlaceholder={showNoAudioPlaceholder}
       showSideBySide={showSideBySide}
       flushDiscussionLeft={flushDiscussionLeft}
-      recordContent={!discussOpen || showSideBySide ? <MobileStep /> : null}
+      // Always mount MobileStep on narrow mobile while discussion is open; unmounting
+      // drops PassageDetailRecord/MediaRecord state and clears an in-progress recording.
+      recordContent={<MobileStep />}
       noAudioText={ts.noAudio}
     />
   );


### PR DESCRIPTION
Refactor PassageDetailMobileDetail to always mount MobileStep on narrow mobile while discussion is open, preventing loss of state during unmounting. Wrap recordContent in a Box component to conditionally hide based on flushDiscussionLeft prop.