### PR TITLE
TT-7187 handle intellectual property media without passages

### DIFF
--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -28,9 +28,10 @@ jest.mock('../hoc/useOrbitData', () => ({
 }));
 
 jest.mock('../crud/useArtifactType', () => ({
-  useArtifactType: () => ({
+  useArtifactType: jest.fn(() => ({
     slugFromId: jest.fn(() => 'vernacular'),
-  }),
+    VernacularTag: null,
+  })),
   VernacularTag: null,
 }));
 
@@ -288,5 +289,87 @@ describe('useBurritoAudio', () => {
     expect(audioIngredient).toBeDefined();
     expect(audioIngredient![0].toLowerCase().endsWith('.mp3')).toBe(true);
     expect(audioIngredient![1].mimeType).toBe('audio/mpeg');
+  });
+
+  it('exports intellectual property media attached to a plan without a passage', async () => {
+    const ipc = makeIpc();
+    const { renderHook, act, useBurritoAudio } = loadAudioForApi(ipc);
+
+    /* eslint-disable @typescript-eslint/no-require-imports -- resetModules pattern */
+    const { useOrbitData } = require('../hoc/useOrbitData');
+    const { useArtifactType } = require('../crud/useArtifactType');
+    const { ArtifactTypeSlug } = require('../crud/artifactTypeSlug');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn((id: string | null | undefined) =>
+        id === 'at-ip' ? 'intellectualproperty' : 'vernacular'
+      ),
+      VernacularTag: null,
+    }));
+
+    const orbitMedia = [
+      {
+        id: 'ip-media-1',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-ip-1' },
+        attributes: {
+          audioUrl: 'https://example.test/ip-release.mp3',
+          originalFile: 'rights-statement.mp3',
+          contentType: 'audio/mpeg',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-ip' } },
+        },
+      },
+    ];
+
+    useOrbitData.mockImplementation((type: string) => {
+      if (type === 'mediafile') return orbitMedia;
+      if (type === 'passage') return [];
+      if (type === 'sectionresource') return [];
+      if (type === 'sharedresource') return [];
+      return [];
+    });
+
+    const metadata = burritoFixture();
+    const { result } = renderHook(() => useBurritoAudio(teamId));
+
+    await act(async () => {
+      await result.current({
+        metadata,
+        bible: bibleFixture,
+        book: 'GEN',
+        bookPath: '/burrito/GEN',
+        preLen: 0,
+        sections: [
+          {
+            id: 's1',
+            type: 'section',
+            relationships: {
+              plan: { data: { type: 'plan', id: 'plan1' } },
+            },
+          } as SectionD,
+        ],
+        artifactTypeFilter: [ArtifactTypeSlug.IntellectualProperty],
+      });
+    });
+
+    expect(ipc.copyFile).toHaveBeenCalled();
+    const ipIngredient = Object.entries(metadata.ingredients).find(
+      ([, ing]) => ing?.properties?.apmId === 'remote-ip-1'
+    );
+    expect(ipIngredient).toBeDefined();
+    expect(ipIngredient![0]).toContain('rights-statement');
+    expect(ipIngredient![1].mimeType).toBe('audio/mpeg');
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'vernacular'),
+      VernacularTag: null,
+    }));
   });
 });

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -231,6 +231,7 @@ export const useBurritoAudio = (teamId: string) => {
 
     let chapter = 0;
     let chapterPath = '';
+    let plan: string | undefined;
 
     for (const section of sections) {
       const refCount = new Map<string, number>();
@@ -240,9 +241,8 @@ export const useBurritoAudio = (teamId: string) => {
       };
 
       // get the passage files for the plan sorted by sequence number
-      const planMedia = mediafiles.filter(
-        (m) => related(section, 'plan') === related(m, 'plan')
-      );
+      plan = related(section, 'plan') as string;
+      const planMedia = mediafiles.filter((m) => plan === related(m, 'plan'));
       const passageRecs = passages
         .filter((p) => related(p, 'section') === section.id)
         .sort((a, b) => a.attributes.sequencenum - b.attributes.sequencenum);
@@ -359,6 +359,18 @@ export const useBurritoAudio = (teamId: string) => {
           );
         }
       }
+    }
+    // filters by plan set in the section records
+    const planMedia = mediafiles
+      .filter(
+        (m) => related(m, 'plan') === plan && related(m, 'passage') === null
+      )
+      .filter(makeArtifactFilter());
+    for (const m of planMedia) {
+      const { name } = path.parse(m.attributes.originalFile);
+      const destName = `${bibleId}-${book}-${cleanFileName(name)}.${getMediaExt(m)}`;
+      const destPath = path.join(bookPath, destName);
+      await processMediaFile(m, destPath, '', '', false);
     }
     const alignment = new AlignmentBuilder()
       .withGroups(alignmentGroups)


### PR DESCRIPTION
- Updated useBurritoAudio to filter media files by plan and handle cases where passages are null.
- Added a new test case to verify the export of intellectual property media attached to a plan without a passage.
- Mocked dependencies to support the new test scenario.

Co-authored-by: Greg Trihus <gtryus@gmail.com>
Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>