### PR TITLE
TT-7246 Each USFM begins with \\id

### DIFF
--- a/src/renderer/src/burrito/useBurritoText.test.ts
+++ b/src/renderer/src/burrito/useBurritoText.test.ts
@@ -229,6 +229,45 @@ describe('useBurritoText', () => {
     );
   });
 
+  it('writes each USFM file beginning with a \\id line', async () => {
+    const ipc = makeIpc();
+    const { renderHook, act, useBurritoText } = loadTextForApi(ipc as never, {
+      passages: [passageFixture()],
+      mediafiles: [
+        mediaFixture({ versionNumber: 2, transcription: 'Second version' }),
+        mediaFixture({ versionNumber: 1, transcription: 'First version' }),
+      ],
+      getOrgDefaultImpl: (key: string) => {
+        if (key === 'burritoVersions') return '2';
+        if (key === 'burritoFormat') return { textOutputFormat: 'usfm' };
+        return undefined;
+      },
+    });
+
+    const { result } = renderHook(() => useBurritoText(teamId));
+    const metadata = burritoFixture();
+
+    await act(async () => {
+      await result.current({
+        metadata,
+        book: 'GEN',
+        bookPath,
+        preLen,
+        sections: [sectionFixture()],
+      });
+    });
+
+    const usfmWrites = ipc.write.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('.usfm')
+    );
+    expect(usfmWrites).toHaveLength(2);
+
+    for (const writeCall of usfmWrites) {
+      const written = writeCall[1] as string;
+      expect(written.split('\n')[0]).toBe('\\id GEN');
+    }
+  });
+
   it('does not throw when window.api is missing', async () => {
     const { renderHook, act, useBurritoText } = loadTextForApi(undefined, {
       passages: [passageFixture()],

--- a/src/renderer/src/burrito/useBurritoText.ts
+++ b/src/renderer/src/burrito/useBurritoText.ts
@@ -55,6 +55,7 @@ export const useBurritoText = (teamId: string) => {
     let chapter = 0;
     let sectionId = '';
     let initialText = new Array<string>();
+    initialText.push(`\\id ${book}`);
     const versions = parseInt(
       (getOrgDefault('burritoVersions', teamId) || '1') as string
     );
@@ -86,7 +87,6 @@ export const useBurritoText = (teamId: string) => {
         parseRef(p);
         const { startChapter, startVerse, endChapter, endVerse } = p.attributes;
         if (startChapter && startChapter !== chapter) {
-          if (startChapter === 1) initialText.push(`\\id ${book}`);
           chapter = startChapter;
           initialText.push(`\\c ${chapter.toString()}`);
           chapters.add(chapter.toString());


### PR DESCRIPTION
Implement USFM file writing with \\id line in useBurritoText

- Added functionality to write USFM files starting with a \\id line for the specified book.
- Updated the initial text array to include the \\id line when the book is set.
- Introduced a new test case to verify that each USFM file begins with the correct \\id line.

Co-authored-by: Greg Trihus <gtryus@gmail.com>