### PR TITLE
TT-7250 scroll step bar

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -16,7 +16,7 @@ import { useSnackBar } from '../../../hoc/SnackBar';
 import { sharedSelector, workflowStepsSelector } from '../../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useWfLabel } from '../../../utils/useWfLabel';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
 
@@ -63,14 +63,32 @@ export default function MobileWorkflowSteps() {
       : '';
   }, [currentLabel, t]);
 
+  const didMountRef = useRef(false);
+  const stepRefs = useRef(new Map<string, HTMLElement>());
+
+  useEffect(() => {
+    const el = stepRefs.current.get(currentstep);
+    if (!el) {
+      return;
+    }
+    el.scrollIntoView({
+      behavior: didMountRef.current ? 'smooth' : 'auto',
+      block: 'nearest',
+      inline: 'center',
+    });
+    didMountRef.current = true;
+  }, [currentstep, workflow.length]);
+
   return (
     <Box sx={{ px: 1.5, py: 0.5 }} data-cy="workflow-steps">
       <Box
         sx={{
           display: 'flex',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
           gap: 0.75,
-          overflowX: 'hidden',
+          overflowX: 'auto',
+          overflowY: 'hidden',
+          WebkitOverflowScrolling: 'touch',
           pb: 0.25,
         }}
       >
@@ -83,6 +101,13 @@ export default function MobileWorkflowSteps() {
               role="button"
               onClick={handleSelect(step.id)}
               tabIndex={0}
+              ref={(el) => {
+                if (el) {
+                  stepRefs.current.set(step.id, el);
+                } else {
+                  stepRefs.current.delete(step.id);
+                }
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();

--- a/src/renderer/src/routes/PassageDetail.tsx
+++ b/src/renderer/src/routes/PassageDetail.tsx
@@ -44,9 +44,8 @@ const MobileStep = () => {
 
 const MobileDetail = () => {
   const { isMobileWidth } = useMobile();
-  const { discussOpen, rowData, currentstep } = useContext(
-    PassageDetailContext
-  )?.state ?? {
+  const { discussOpen, rowData, currentstep } = useContext(PassageDetailContext)
+    ?.state ?? {
     discussOpen: false,
     rowData: [],
     currentstep: '',
@@ -55,8 +54,7 @@ const MobileDetail = () => {
   const currentVersion = useMemo(() => rowData[0]?.version ?? 0, [rowData]);
   /** Policy lives here (with step tool); the layout component only branches on the result. */
   const showNoAudioPlaceholder = useMemo(
-    () =>
-      currentVersion === 0 && !toolAllowsEmptyVernacularAudio(tool),
+    () => currentVersion === 0 && !toolAllowsEmptyVernacularAudio(tool),
     [currentVersion, tool]
   );
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);


### PR DESCRIPTION
- Horizontal scrolling enabled: the steps container now uses overflowX: 'auto' (instead of hidden), so it scrolls when steps exceed screen width.
- Current step auto-visible: when the component mounts (and whenever currentstep changes), it scrolls the highlighted step into view (centered).