### PR TITLE
TT-7262  Convert usj and usx to usfm for import

### DIFF
--- a/src/renderer/src/burrito/normalizeTextToUsfm.test.ts
+++ b/src/renderer/src/burrito/normalizeTextToUsfm.test.ts
@@ -1,0 +1,63 @@
+jest.mock('usfm-grammar-web/tree-sitter-usfm.wasm?url', () => 'grammar.wasm', {
+  virtual: true,
+});
+jest.mock('usfm-grammar-web/tree-sitter.wasm?url', () => 'parser.wasm', {
+  virtual: true,
+});
+
+describe('normalizeTextToUsfm', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  async function loadWithParser() {
+    // Match production: `new USFMParser(null, usj)` / `new USFMParser(null, null, usxDoc)`
+    const USFMParser = class {
+      static init = jest.fn().mockResolvedValue(undefined);
+      usfm: string;
+      constructor(_usfm: string | null, usj?: unknown, usx?: unknown) {
+        if (usj != null) {
+          this.usfm = '\\id GEN\n\\c 1\n\\v 1 from-usj';
+        } else if (usx != null) {
+          this.usfm = '\\id GEN\n\\c 1\n\\v 1 from-usx';
+        } else if (typeof _usfm === 'string') {
+          this.usfm = _usfm;
+        } else {
+          this.usfm = '';
+        }
+      }
+    };
+
+    jest.doMock('usfm-grammar-web/dist/bundle.mjs', () => ({ USFMParser }), {
+      virtual: true,
+    });
+
+    const mod = await import('./normalizeTextToUsfm');
+    return { normalizeTextToUsfm: mod.normalizeTextToUsfm, USFMParser };
+  }
+
+  it('returns input for usfm', async () => {
+    const { normalizeTextToUsfm } = await loadWithParser();
+    const input = '\\id GEN\r\n\\c 1\r\n\\v 1 Hello';
+    await expect(normalizeTextToUsfm(input, 'usfm')).resolves.toBe(
+      '\\id GEN\n\\c 1\n\\v 1 Hello'
+    );
+  });
+
+  it('converts usj to usfm via USFMParser', async () => {
+    const { normalizeTextToUsfm } = await loadWithParser();
+    const usj = JSON.stringify({ type: 'USJ', version: '0.3.0', content: [] });
+    const out = await normalizeTextToUsfm(usj, 'usj');
+    expect(out).toContain('\\c 1');
+    expect(out).toContain('from-usj');
+  });
+
+  it('converts usx to usfm via USFMParser', async () => {
+    const { normalizeTextToUsfm } = await loadWithParser();
+    const usx =
+      '<usx><chapter number="1"/><para style="p"><verse number="1"/>x</para></usx>';
+    const out = await normalizeTextToUsfm(usx, 'usx');
+    expect(out).toContain('\\c 1');
+    expect(out).toContain('from-usx');
+  });
+});

--- a/src/renderer/src/burrito/normalizeTextToUsfm.ts
+++ b/src/renderer/src/burrito/normalizeTextToUsfm.ts
@@ -1,0 +1,71 @@
+import { DOMParser } from '@xmldom/xmldom';
+import grammarWasmUrl from 'usfm-grammar-web/tree-sitter-usfm.wasm?url';
+import parserWasmUrl from 'usfm-grammar-web/tree-sitter.wasm?url';
+
+export type BurritoTextInputFormat = 'usfm' | 'usj' | 'usx';
+
+interface USFMParserCtor {
+  init(grammarPath?: string, parserPath?: string): Promise<void>;
+  // The published d.ts only declares `constructor(usfm: string)`, but we also
+  // support `{ from_usj }` / `{ from_usx }` in runtime builds. Use `any`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (usfm: string | null, usj?: any, usx?: Document | null): any;
+}
+
+let parserCtorPromise: Promise<USFMParserCtor> | null = null;
+let parserInitPromise: Promise<void> | null = null;
+
+async function getUSFMParserCtor(): Promise<USFMParserCtor> {
+  if (parserCtorPromise == null) {
+    parserCtorPromise = (async () => {
+      const mod = (await import('usfm-grammar-web/dist/bundle.mjs')) as {
+        USFMParser: USFMParserCtor;
+      };
+      return mod.USFMParser;
+    })();
+  }
+  return await parserCtorPromise;
+}
+
+async function ensureUSFMParserInitialized(USFMParser: USFMParserCtor) {
+  if (parserInitPromise == null) {
+    parserInitPromise = USFMParser.init(grammarWasmUrl, parserWasmUrl).catch(
+      (err: unknown) => {
+        // Allow subsequent calls to retry if initialization fails.
+        parserInitPromise = null;
+        throw err;
+      }
+    );
+  }
+  await parserInitPromise;
+}
+
+function normalizeNewlines(s: string): string {
+  return String(s ?? '').replace(/\r\n?/g, '\n');
+}
+
+export async function normalizeTextToUsfm(
+  input: string,
+  format: BurritoTextInputFormat
+): Promise<string> {
+  const raw = normalizeNewlines(input);
+  if (format === 'usfm') {
+    return raw;
+  }
+
+  const USFMParser = await getUSFMParserCtor();
+  await ensureUSFMParserInitialized(USFMParser);
+
+  if (format === 'usj') {
+    const usj = JSON.parse(raw);
+    const parser = new USFMParser(null, usj);
+    const usfm = String(parser?.usfm ?? '');
+    return normalizeNewlines(usfm);
+  }
+
+  const usxDoc = new DOMParser().parseFromString(raw, 'application/xml');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parser = new USFMParser(null, null, usxDoc);
+  const usfm = String(parser?.usfm ?? '');
+  return normalizeNewlines(usfm);
+}

--- a/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.test.ts
+++ b/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.test.ts
@@ -74,4 +74,68 @@ describe('preprocessTextTranslationBurritoToUsfm', () => {
     // and metadata should have been rewritten
     expect(writes.some((w) => w.path === metaPath)).toBe(true);
   });
+
+  it('skips burritos and ingredients that resolve outside the wrapper directory', async () => {
+    const readPaths: string[] = [];
+    const writePaths: string[] = [];
+    const wrapperDir = '/wrapper';
+
+    const ipc = {
+      exists: async () => true,
+      read: async (p: string) => {
+        readPaths.push(p);
+        if (p.endsWith('wrapper.json')) {
+          return JSON.stringify({
+            format: 'scripture burrito wrapper',
+            contents: {
+              burritos: [
+                { path: 'text' },
+                { path: '../outside' },
+                { path: 'evilmeta' },
+              ],
+            },
+          });
+        }
+        if (p.includes('/text/') && p.endsWith('metadata.json')) {
+          return JSON.stringify({
+            type: { flavorType: { flavor: { name: 'textTranslation' } } },
+            ingredients: {
+              'ingredients/GEN.usj': {
+                mimeType: 'application/usj+json',
+                scope: { GEN: ['1'] },
+              },
+              '../../escape/GEN.usj': {
+                mimeType: 'application/usj+json',
+                scope: { GEN: ['1'] },
+              },
+            },
+          });
+        }
+        if (p.includes('/evilmeta/')) {
+          return JSON.stringify({
+            type: { flavorType: { flavor: { name: 'textTranslation' } } },
+            ingredients: {},
+          });
+        }
+        return '';
+      },
+      write: async (p: string) => {
+        writePaths.push(p);
+      },
+      md5File: async () => 'md5',
+    };
+
+    const files = new Map<string, string>([
+      [`${wrapperDir}/text/ingredients/GEN.usj`, '{}'],
+    ]);
+    (ipc as any).exists = async (p: string) =>
+      p.startsWith(`${wrapperDir}/`) && (files.has(p) || p.endsWith('metadata.json') || p.endsWith('wrapper.json'));
+
+    await preprocessTextTranslationBurritoToUsfm(wrapperDir, ipc as any);
+
+    expect(readPaths.some((p) => p.includes('outside'))).toBe(false);
+    expect(readPaths.every((p) => p.startsWith(`${wrapperDir}/`))).toBe(true);
+    expect(writePaths.every((p) => p.startsWith(`${wrapperDir}/`))).toBe(true);
+    expect(writePaths.some((p) => p.includes('escape'))).toBe(false);
+  });
 });

--- a/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.test.ts
+++ b/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.test.ts
@@ -1,0 +1,77 @@
+import { preprocessTextTranslationBurritoToUsfm } from './preprocessTextTranslationBurritoToUsfm';
+
+jest.mock('./normalizeTextToUsfm', () => ({
+  normalizeTextToUsfm: jest.fn(async (_input: string, format: string) => {
+    return `\\id GEN\n\\c 1\n\\v 1 from-${format}`;
+  }),
+}));
+
+describe('preprocessTextTranslationBurritoToUsfm', () => {
+  it('adds text/usfm ingredient derived from usj/usx and writes metadata first', async () => {
+    const files = new Map<string, string>();
+    const writes: Array<{ path: string; data: unknown }> = [];
+
+    // `preprocessTextTranslationBurritoToUsfm` uses `path-browserify` which
+    // emits POSIX separators, so keep fixture paths POSIX-like.
+    const wrapperDir = '/wrapper';
+    files.set(
+      `${wrapperDir}/wrapper.json`,
+      JSON.stringify({
+        format: 'scripture burrito wrapper',
+        meta: { name: { en: 'X' } },
+        contents: { burritos: [{ path: 'text' }] },
+      })
+    );
+    files.set(
+      `${wrapperDir}/text/metadata.json`,
+      JSON.stringify({
+        type: { flavorType: { flavor: { name: 'textTranslation' } } },
+        ingredients: {
+          'ingredients/GEN.usj': {
+            mimeType: 'application/usj+json',
+            scope: { GEN: ['1'] },
+          },
+        },
+      })
+    );
+    files.set(
+      `${wrapperDir}/text/ingredients/GEN.usj`,
+      JSON.stringify({ type: 'USJ', version: '0.3.0', content: [] })
+    );
+
+    const ipc = {
+      exists: async (p: string) => files.has(p),
+      read: async (p: string) => files.get(p) ?? '',
+      write: async (p: string, data: unknown) => {
+        writes.push({ path: p, data });
+        files.set(p, String(data));
+        return undefined as any;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      md5File: async (_p: string) => 'md5',
+    };
+
+    await preprocessTextTranslationBurritoToUsfm(wrapperDir, ipc as any);
+
+    const metaPath = `${wrapperDir}/text/metadata.json`;
+    const updated = JSON.parse(files.get(metaPath) ?? '{}');
+    const keys = Object.keys(updated.ingredients ?? {});
+
+    // generated usfm should be present and appear first
+    expect(keys[0]).toBe('ingredients/GEN.usfm');
+    expect(updated.ingredients['ingredients/GEN.usfm'].mimeType).toBe(
+      'text/usfm'
+    );
+    expect(updated.ingredients['ingredients/GEN.usfm'].scope).toEqual({
+      GEN: ['1'],
+    });
+
+    // file write for new usfm should exist
+    expect(files.get(`${wrapperDir}/text/ingredients/GEN.usfm`)).toContain(
+      '\\v 1 from-usj'
+    );
+
+    // and metadata should have been rewritten
+    expect(writes.some((w) => w.path === metaPath)).toBe(true);
+  });
+});

--- a/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.ts
+++ b/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.ts
@@ -1,5 +1,6 @@
 import path from 'path-browserify';
 import { MainAPI } from '@model/main-api';
+import { resolvePathUnderRoot } from '../utils/resolvePathUnderRoot';
 import { normalizeTextToUsfm } from './normalizeTextToUsfm';
 
 type BurritoTextFormat = 'usfm' | 'usj' | 'usx';
@@ -52,8 +53,8 @@ export async function preprocessTextTranslationBurritoToUsfm(
   const ipc = (ipcOverride ?? (window?.api as MainAPI)) as MinimalIpc;
   if (!ipc) return;
 
-  const wrapperPath = path.join(wrapperDir, 'wrapper.json');
-  if (!(await ipc.exists(wrapperPath))) return;
+  const wrapperPath = resolvePathUnderRoot(wrapperDir, 'wrapper.json');
+  if (!wrapperPath || !(await ipc.exists(wrapperPath))) return;
 
   const wrapperRaw = (await ipc.read(wrapperPath, { encoding: 'utf-8' })) as
     | string
@@ -65,8 +66,12 @@ export async function preprocessTextTranslationBurritoToUsfm(
     const burritoPath = String(burrito?.path ?? '');
     if (!burritoPath || burritoPath === 'apmdata') continue;
 
-    const metaPath = path.join(wrapperDir, burritoPath, 'metadata.json');
-    if (!(await ipc.exists(metaPath))) continue;
+    const metaPath = resolvePathUnderRoot(
+      wrapperDir,
+      burritoPath,
+      'metadata.json'
+    );
+    if (!metaPath || !(await ipc.exists(metaPath))) continue;
     const metaRaw = (await ipc.read(metaPath, { encoding: 'utf-8' })) as
       | string
       | Uint8Array;
@@ -82,8 +87,8 @@ export async function preprocessTextTranslationBurritoToUsfm(
       const format = detectBurritoTextFormat(relPath, (ing as any)?.mimeType);
       if (format !== 'usj' && format !== 'usx') continue;
 
-      const absPath = path.join(wrapperDir, burritoPath, relPath);
-      if (!(await ipc.exists(absPath))) continue;
+      const absPath = resolvePathUnderRoot(wrapperDir, burritoPath, relPath);
+      if (!absPath || !(await ipc.exists(absPath))) continue;
 
       const raw = (await ipc.read(absPath, { encoding: 'utf-8' })) as
         | string
@@ -92,7 +97,8 @@ export async function preprocessTextTranslationBurritoToUsfm(
       if (!usfm.trim()) continue;
 
       const usfmRel = toUsfmIngredientPath(relPath);
-      const usfmAbs = path.join(wrapperDir, burritoPath, usfmRel);
+      const usfmAbs = resolvePathUnderRoot(wrapperDir, burritoPath, usfmRel);
+      if (!usfmAbs) continue;
       await ipc.write(usfmAbs, usfm);
 
       generated[usfmRel] = {

--- a/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.ts
+++ b/src/renderer/src/burrito/preprocessTextTranslationBurritoToUsfm.ts
@@ -1,0 +1,121 @@
+import path from 'path-browserify';
+import { MainAPI } from '@model/main-api';
+import { normalizeTextToUsfm } from './normalizeTextToUsfm';
+
+type BurritoTextFormat = 'usfm' | 'usj' | 'usx';
+
+function detectBurritoTextFormat(
+  ingredientPath: string,
+  mimeType: unknown
+): BurritoTextFormat | null {
+  const mt = String(mimeType ?? '')
+    .trim()
+    .toLowerCase();
+  const ext = path.extname(String(ingredientPath ?? '')).toLowerCase();
+  if (mt === 'text/usfm' || mt.startsWith('text/usfm') || ext === '.usfm') {
+    return 'usfm';
+  }
+  if (
+    mt === 'application/usx+xml' ||
+    mt === 'application/xml' ||
+    ext === '.usx' ||
+    ext === '.xml'
+  ) {
+    return 'usx';
+  }
+  if (
+    mt === 'application/usj+json' ||
+    mt === 'application/json' ||
+    ext === '.usj' ||
+    ext === '.json'
+  ) {
+    return 'usj';
+  }
+  return null;
+}
+
+function toUsfmIngredientPath(inputPath: string): string {
+  return inputPath.replace(/\.(usj|json|usx|xml)$/i, '.usfm');
+}
+
+type MinimalIpc = Pick<MainAPI, 'exists' | 'read' | 'write' | 'md5File'>;
+
+/**
+ * Renderer-only preprocessing step. Ensures the `textTranslation` burrito has
+ * `text/usfm` ingredients even when exported as USJ/USX, so the Node migration
+ * script can populate `mediafile.transcription`.
+ */
+export async function preprocessTextTranslationBurritoToUsfm(
+  wrapperDir: string,
+  ipcOverride?: MinimalIpc
+): Promise<void> {
+  const ipc = (ipcOverride ?? (window?.api as MainAPI)) as MinimalIpc;
+  if (!ipc) return;
+
+  const wrapperPath = path.join(wrapperDir, 'wrapper.json');
+  if (!(await ipc.exists(wrapperPath))) return;
+
+  const wrapperRaw = (await ipc.read(wrapperPath, { encoding: 'utf-8' })) as
+    | string
+    | Uint8Array;
+  const wrapper = JSON.parse(String(wrapperRaw)) as any;
+  const burritos: any[] = wrapper?.contents?.burritos ?? [];
+
+  for (const burrito of burritos) {
+    const burritoPath = String(burrito?.path ?? '');
+    if (!burritoPath || burritoPath === 'apmdata') continue;
+
+    const metaPath = path.join(wrapperDir, burritoPath, 'metadata.json');
+    if (!(await ipc.exists(metaPath))) continue;
+    const metaRaw = (await ipc.read(metaPath, { encoding: 'utf-8' })) as
+      | string
+      | Uint8Array;
+    const meta = JSON.parse(String(metaRaw)) as any;
+
+    const flavorName = meta?.type?.flavorType?.flavor?.name ?? null;
+    if (flavorName !== 'textTranslation') continue;
+
+    const ingredients: Record<string, any> = meta.ingredients ?? {};
+    const generated: Record<string, any> = {};
+
+    for (const [relPath, ing] of Object.entries(ingredients)) {
+      const format = detectBurritoTextFormat(relPath, (ing as any)?.mimeType);
+      if (format !== 'usj' && format !== 'usx') continue;
+
+      const absPath = path.join(wrapperDir, burritoPath, relPath);
+      if (!(await ipc.exists(absPath))) continue;
+
+      const raw = (await ipc.read(absPath, { encoding: 'utf-8' })) as
+        | string
+        | Uint8Array;
+      const usfm = await normalizeTextToUsfm(String(raw), format);
+      if (!usfm.trim()) continue;
+
+      const usfmRel = toUsfmIngredientPath(relPath);
+      const usfmAbs = path.join(wrapperDir, burritoPath, usfmRel);
+      await ipc.write(usfmAbs, usfm);
+
+      generated[usfmRel] = {
+        ...(ing as any),
+        checksum: { md5: await ipc.md5File(usfmAbs) },
+        mimeType: 'text/usfm',
+        size: usfm.length,
+        scope: (ing as any)?.scope,
+      };
+    }
+
+    const generatedKeys = Object.keys(generated);
+    if (generatedKeys.length === 0) continue;
+
+    // Ensure the migration script (which picks the first `text/usfm` ingredient
+    // per book scope) sees these generated USFM ingredients first.
+    const reordered: Record<string, any> = {};
+    for (const k of generatedKeys) reordered[k] = generated[k];
+    for (const [k, v] of Object.entries(ingredients)) {
+      if (!(k in reordered)) reordered[k] = v;
+    }
+    meta.ingredients = reordered;
+
+    await ipc.write(metaPath, JSON.stringify(meta, null, 2));
+  }
+}

--- a/src/renderer/src/components/ImportTab.tsx
+++ b/src/renderer/src/components/ImportTab.tsx
@@ -96,6 +96,7 @@ import {
 } from '../utils/parseBurritoMetadata';
 import { convertWrapperToPTFs } from '../utils/burritoConversion';
 import FilterContent from './FilterContent';
+import { preprocessTextTranslationBurritoToUsfm } from '../burrito/preprocessTextTranslationBurritoToUsfm';
 
 const ipc = window?.api as MainAPI;
 
@@ -526,6 +527,11 @@ export function ImportTab(props: IProps) {
             if (books.length === 0) {
               return [];
             }
+
+            // Renderer-only: ensure `textTranslation` contains `text/usfm` so the
+            // Node migration script can populate `mediafile.transcription`.
+            await preprocessTextTranslationBurritoToUsfm(dir);
+
             flushSync(() => {
               setBurritoPrepareProgress({
                 phase: 'convert',

--- a/src/renderer/src/utils/__tests__/parseBurritoMetadata.test.ts
+++ b/src/renderer/src/utils/__tests__/parseBurritoMetadata.test.ts
@@ -1,15 +1,14 @@
 type LocalizedString = Record<string, string>;
 
-jest.mock('path-browserify', () => ({
-  __esModule: true,
-  default: {
-    join: (...args: string[]) => args.join('/'),
-    extname: (p: string) => {
-      const idx = p.lastIndexOf('.');
-      return idx >= 0 ? p.slice(idx) : '';
-    },
-  },
-}));
+jest.mock('path-browserify', () => {
+  const actual = jest.requireActual('path-browserify') as {
+    default?: typeof import('path-browserify');
+  };
+  return {
+    __esModule: true,
+    default: actual.default ?? (actual as unknown as typeof import('path-browserify')),
+  };
+});
 
 describe('parseBurritoMetadata', () => {
   beforeEach(() => {
@@ -176,6 +175,68 @@ describe('parseBurritoMetadata', () => {
 
       await expect(buildStructure(wrapperRoot, 'en')).rejects.toThrow(
         /Invalid Scripture Burrito for import:/
+      );
+    });
+
+    it('does not read files outside the wrapper when burrito or ingredient paths are malicious', async () => {
+      jest.resetModules();
+
+      const wrapperRoot = '/test/path';
+      const readPaths: string[] = [];
+      (window as any).api = {
+        exists: jest.fn(
+          async (p: string) =>
+            p === `${wrapperRoot}/wrapper.json` ||
+            p === `${wrapperRoot}/audio/metadata.json` ||
+            p === `${wrapperRoot}/audio/ingredients/MAT.usfm`
+        ),
+        read: jest.fn(async (p: string) => {
+          readPaths.push(p);
+          if (p === `${wrapperRoot}/wrapper.json`) {
+            return JSON.stringify({
+              meta: { name: { en: 'Wrapper' } },
+              contents: {
+                burritos: [
+                  { path: 'apmdata' },
+                  { path: '../outside' },
+                  { path: 'audio' },
+                ],
+              },
+            });
+          }
+          if (p === `${wrapperRoot}/audio/metadata.json`) {
+            return JSON.stringify({
+              type: { flavorType: { flavor: { name: 'audioTranslation' } } },
+              localizedNames: { 'book-mat': { long: { en: 'Matthew' } } },
+              ingredients: {
+                'ingredients/MAT.usfm': {
+                  mimeType: 'text/usfm',
+                  scope: { MAT: ['1'] },
+                },
+                '../../../etc/passwd': {
+                  mimeType: 'text/usfm',
+                  scope: { MAT: ['1'] },
+                },
+              },
+            });
+          }
+          if (p === `${wrapperRoot}/audio/ingredients/MAT.usfm`) {
+            return '\\id MAT\n\\c 1\n';
+          }
+          throw new Error(`unexpected read: ${p}`);
+        }),
+      };
+
+      const { buildStructure, BURRITO_CHAPTER_FILTER_OTHER } =
+        await import('../parseBurritoMetadata');
+
+      const result = await buildStructure(wrapperRoot, 'en');
+      expect(readPaths.every((rp) => rp.startsWith(`${wrapperRoot}/`))).toBe(
+        true
+      );
+      expect(result.books).toHaveLength(1);
+      expect(result.books[0].chapters).toEqual(
+        expect.arrayContaining(['1', BURRITO_CHAPTER_FILTER_OTHER])
       );
     });
   });

--- a/src/renderer/src/utils/parseBurritoMetadata.ts
+++ b/src/renderer/src/utils/parseBurritoMetadata.ts
@@ -7,6 +7,7 @@ import {
   LocalizedString,
 } from '../burrito/data/types';
 import path from 'path-browserify';
+import { resolvePathUnderRoot } from './resolvePathUnderRoot';
 import { sortChapters } from './sort';
 
 const ipc = window?.api as MainAPI;
@@ -113,7 +114,8 @@ function extractChapterNumbersFromScripture(raw: string): string[] {
 }
 
 async function chaptersFromScriptureFilesForBook(
-  burritoRoot: string,
+  wrapperPath: string,
+  burritoRelFolder: string,
   metadata: Burrito,
   bookId: string
 ): Promise<string[]> {
@@ -127,8 +129,8 @@ async function chaptersFromScriptureFilesForBook(
     if (!isScriptureTextIngredient(relPath, ing)) {
       continue;
     }
-    const absPath = path.join(burritoRoot, relPath);
-    if (!(await ipc.exists(absPath))) {
+    const absPath = resolvePathUnderRoot(wrapperPath, burritoRelFolder, relPath);
+    if (!absPath || !(await ipc.exists(absPath))) {
       continue;
     }
     try {
@@ -177,24 +179,29 @@ export async function buildStructure(
   lang: string
 ): Promise<WrapperStructure> {
   try {
-    const wrapper = await readJson<BurritoWrapper>(
-      path.join(burritoWrapperPath, 'wrapper.json')
+    const wrapperJsonPath = resolvePathUnderRoot(
+      burritoWrapperPath,
+      'wrapper.json'
     );
+    if (!wrapperJsonPath) {
+      throw new Error('Invalid wrapper path');
+    }
+    const wrapper = await readJson<BurritoWrapper>(wrapperJsonPath);
 
     const flavorNames = new Set<string>();
-    let audioBurritoPath: string | null = null;
-    let textBurritoPath: string | null = null;
+    let audioBurritoRel: string | null = null;
+    let textBurritoRel: string | null = null;
 
     for (const burrito of wrapper.contents?.burritos ?? []) {
       if (burrito.path === 'apmdata') {
         continue;
       }
-      const metaPath = path.join(
+      const metaPath = resolvePathUnderRoot(
         burritoWrapperPath,
         burrito.path,
         'metadata.json'
       );
-      if (!(await ipc.exists(metaPath))) {
+      if (!metaPath || !(await ipc.exists(metaPath))) {
         continue;
       }
       const meta = await readJson<Burrito>(metaPath);
@@ -203,25 +210,35 @@ export async function buildStructure(
         flavorNames.add(fn);
       }
       if (fn === 'audioTranslation') {
-        audioBurritoPath = path.join(burritoWrapperPath, burrito.path);
+        audioBurritoRel = burrito.path;
       }
       if (fn === 'textTranslation') {
-        textBurritoPath = path.join(burritoWrapperPath, burrito.path);
+        textBurritoRel = burrito.path;
       }
     }
 
-    if (!audioBurritoPath) {
-      audioBurritoPath = path.join(burritoWrapperPath, 'audio');
+    if (!audioBurritoRel) {
+      audioBurritoRel = 'audio';
     }
 
-    const audio = await readJson<Burrito>(
-      path.join(audioBurritoPath, 'metadata.json')
+    const audioMetaPath = resolvePathUnderRoot(
+      burritoWrapperPath,
+      audioBurritoRel,
+      'metadata.json'
     );
+    if (!audioMetaPath) {
+      throw new Error('Invalid audio burrito path');
+    }
+    const audio = await readJson<Burrito>(audioMetaPath);
 
     let text: Burrito | null = null;
-    if (textBurritoPath) {
-      const textMetaPath = path.join(textBurritoPath, 'metadata.json');
-      if (await ipc.exists(textMetaPath)) {
+    if (textBurritoRel) {
+      const textMetaPath = resolvePathUnderRoot(
+        burritoWrapperPath,
+        textBurritoRel,
+        'metadata.json'
+      );
+      if (textMetaPath && (await ipc.exists(textMetaPath))) {
         try {
           text = await readJson<Burrito>(textMetaPath);
         } catch {
@@ -270,14 +287,16 @@ export async function buildStructure(
         ? chaptersFromScopesForBook(text.ingredients, bookId)
         : [];
       const chaptersFromAudioFiles = await chaptersFromScriptureFilesForBook(
-        audioBurritoPath,
+        burritoWrapperPath,
+        audioBurritoRel,
         audio,
         bookId
       );
       const chaptersFromTextFiles =
-        text && textBurritoPath
+        text && textBurritoRel
           ? await chaptersFromScriptureFilesForBook(
-              textBurritoPath,
+              burritoWrapperPath,
+              textBurritoRel,
               text,
               bookId
             )

--- a/src/renderer/src/utils/resolvePathUnderRoot.test.ts
+++ b/src/renderer/src/utils/resolvePathUnderRoot.test.ts
@@ -1,0 +1,57 @@
+import path from 'path-browserify';
+import { resolvePathUnderRoot } from './resolvePathUnderRoot';
+
+describe('resolvePathUnderRoot', () => {
+  const root = '/safe/wrapper';
+
+  it('returns resolved path for normal nested segments', () => {
+    expect(resolvePathUnderRoot(root, 'text', 'metadata.json')).toBe(
+      path.resolve(root, 'text', 'metadata.json')
+    );
+    expect(resolvePathUnderRoot(root, 'audio', 'ingredients', 'MAT.usfm')).toBe(
+      path.resolve(root, 'audio', 'ingredients', 'MAT.usfm')
+    );
+  });
+
+  it('returns path for wrapper.json under root', () => {
+    expect(resolvePathUnderRoot(root, 'wrapper.json')).toBe(
+      path.resolve(root, 'wrapper.json')
+    );
+  });
+
+  it('returns null when a segment is absolute', () => {
+    expect(resolvePathUnderRoot(root, '/etc', 'passwd')).toBeNull();
+    expect(resolvePathUnderRoot(root, 'text', '/tmp/x')).toBeNull();
+  });
+
+  it('returns null when traversal escapes root', () => {
+    expect(resolvePathUnderRoot(root, '..', 'outside')).toBeNull();
+    expect(resolvePathUnderRoot(root, 'text', '..', '..', 'etc')).toBeNull();
+    expect(resolvePathUnderRoot(root, 'a', 'b', '..', '..', '..', 'escape')).toBeNull();
+  });
+
+  it('returns null for empty root', () => {
+    expect(resolvePathUnderRoot('', 'a')).toBeNull();
+  });
+
+  it('returns null when a segment contains a null byte', () => {
+    expect(resolvePathUnderRoot(root, 'a\0b')).toBeNull();
+  });
+
+  it('allows single dot segments that stay inside', () => {
+    const r = resolvePathUnderRoot(root, 'text', '.', 'file.usfm');
+    expect(r).toBe(path.resolve(root, 'text', 'file.usfm'));
+  });
+
+  it('normalizes redundant separators inside safe paths', () => {
+    const r = resolvePathUnderRoot(root, 'text/sub', '../sub/file.usfm');
+    expect(r).toBe(path.normalize(path.join(root, 'text/sub/file.usfm')));
+  });
+
+  it('works with Windows-style root (no process.cwd)', () => {
+    const winRoot = 'D:\\burritos\\import';
+    const r = resolvePathUnderRoot(winRoot, 'audio', 'metadata.json');
+    expect(r).not.toBeNull();
+    expect(r).toBe(path.normalize(path.join(winRoot, 'audio', 'metadata.json')));
+  });
+});

--- a/src/renderer/src/utils/resolvePathUnderRoot.ts
+++ b/src/renderer/src/utils/resolvePathUnderRoot.ts
@@ -1,0 +1,57 @@
+import path from 'path-browserify';
+
+/** Windows drive path (e.g. C:\ or D:/foo) — not POSIX-absolute in path-browserify. */
+function segmentLooksAbsolute(seg: string): boolean {
+  if (path.isAbsolute(seg)) {
+    return true;
+  }
+  if (/^[a-zA-Z]:/.test(seg)) {
+    return true;
+  }
+  if (seg.startsWith('\\\\')) {
+    return true;
+  }
+  return false;
+}
+
+/** Normalize for prefix comparison only (forward slashes, collapse duplicate slashes). */
+function comparablePath(p: string): string {
+  const unified = p.replace(/\\/g, '/');
+  const normalized = path.normalize(unified);
+  return normalized.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+}
+
+/**
+ * Resolves `rootDir` + `segments` to an absolute path only if the result stays
+ * inside `rootDir` (no `..` escape, no absolute segments, no null bytes).
+ *
+ * Uses `path.join` + `path.normalize` only — never `path.resolve` / `path.relative`,
+ * because path-browserify calls `process.cwd()` when paths are not POSIX-absolute,
+ * which breaks Windows roots like `C:\...` in the Electron renderer.
+ */
+export function resolvePathUnderRoot(
+  rootDir: string,
+  ...segments: string[]
+): string | null {
+  if (!rootDir) {
+    return null;
+  }
+  for (const seg of segments) {
+    if (seg == null || seg.includes('\0')) {
+      return null;
+    }
+    if (segmentLooksAbsolute(seg)) {
+      return null;
+    }
+  }
+  const filtered = segments.filter((s) => s !== '');
+  const resolved = path.normalize(path.join(rootDir, ...filtered));
+
+  const baseComp = comparablePath(rootDir);
+  const fullComp = comparablePath(resolved);
+  const prefix = baseComp.endsWith('/') ? baseComp : `${baseComp}/`;
+  if (fullComp !== baseComp && !fullComp.startsWith(prefix)) {
+    return null;
+  }
+  return resolved;
+}


### PR DESCRIPTION
- Implemented `normalizeTextToUsfm` function to handle conversion from USJ and USX formats to USFM.
- Created tests for `normalizeTextToUsfm` to ensure correct functionality for various input formats.
- Developed `preprocessTextTranslationBurritoToUsfm` to ensure `textTranslation` burritos contain `text/usfm` ingredients, facilitating migration scripts.
- Integrated preprocessing step in `ImportTab` to automatically generate USFM ingredients during import.

Author-by: cursor
Co-authored-by: Greg Trihus <gtryus@gmail.com>
Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>