### PR TITLE
TT-6962 No Switch Teams for work alone offline

### DIFF
--- a/src/renderer/src/context/TeamContext.tsx
+++ b/src/renderer/src/context/TeamContext.tsx
@@ -107,6 +107,8 @@ const initState = {
   planTypes: Array<PlanType>(),
   isDeleting: false,
   teams: Array<OrganizationD>(),
+  /** True once orbit has returned org or membership rows (teams list is not just pre-load empty). */
+  teamDirectoryReady: false,
   personalTeam: '',
   personalProjects: Array<VProjectD>(),
   teamProjects: (teamId: string) => Array<VProjectD>(),
@@ -666,9 +668,20 @@ const TeamProvider = (props: IProps) => {
       });
     }
     const teams = getTeams();
-    if (JSON.stringify(teams) !== JSON.stringify(state.teams)) {
-      setState((state) => ({ ...state, teams }));
-    }
+    const teamsChanged = JSON.stringify(teams) !== JSON.stringify(state.teams);
+    const directoryNowReady =
+      organizations.length > 0 || orgMembers.length > 0;
+    setState((state) => {
+      const nextReady = state.teamDirectoryReady || directoryNowReady;
+      if (!teamsChanged && nextReady === state.teamDirectoryReady) {
+        return state;
+      }
+      return {
+        ...state,
+        ...(teamsChanged ? { teams } : {}),
+        teamDirectoryReady: nextReady,
+      };
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizations, orgMembers, user, isOffline]);
 

--- a/src/renderer/src/routes/ProjectsScreen.cy.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.cy.tsx
@@ -191,6 +191,7 @@ describe('ProjectsScreen', () => {
         planTypes: [],
         isDeleting: false,
         teams: teams,
+        teamDirectoryReady: true,
         personalTeam: personalTeam,
         personalProjects: [],
         teamProjects: () => [],
@@ -444,27 +445,16 @@ describe('ProjectsScreen', () => {
     cy.get('#ProjectsScreen').should('exist');
   });
 
-  it('should navigate to /switch-teams when teamId is undefined', () => {
+  it('should navigate to switch-teams when teamId is undefined (picker decides PAP redirect)', () => {
     mountWithoutTeam({ planId: 'test-plan-id' });
 
-    // Wait for the navigation effect to occur
-    // The component calls handleSwitchTeams() in useEffect when teamId is undefined,
-    // which removes the plan from localStorage and navigates to /switch-teams
     cy.wait(200).then(() => {
-      // Verify that navigation occurred by checking side effects of handleSwitchTeams
-      // handleSwitchTeams removes LocalKey.plan before navigating to /switch-teams
       cy.window().then((win) => {
-        // The plan should be removed (side effect of handleSwitchTeams, proving it was called)
-        // This confirms that navigation to /switch-teams was triggered
+        expect(win.localStorage.getItem(localUserKey(LocalKey.team))).to.be.null;
         expect(win.localStorage.getItem(LocalKey.plan)).to.be.null;
-        // Verify teamId is still undefined
-        expect(win.localStorage.getItem(localUserKey(LocalKey.team))).to.be
-          .null;
       });
     });
 
-    // The component should not render its content when teamId is missing
-    // (it returns null early)
     cy.get('#ProjectsScreen').should('not.exist');
   });
 
@@ -477,7 +467,7 @@ describe('ProjectsScreen', () => {
     const mockTeam = createTestTeam(teamId);
 
     // Mount with teamId defined - this should NOT trigger navigation
-    // The component has: if (!teamId) handleSwitchTeams();
+    // The component navigates to /switch-teams when teamId is missing (after personalTeam is set).
     // Since teamId is defined, handleSwitchTeams should not be called
     mountProjectsScreen(createInitialState(), ['/projects'], {
       isAdmin: () => false,

--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -37,7 +37,12 @@ const ProjectsBox = styled(Box)<ProjectBoxProps>(({ theme, isMobile }) => ({
 
 export const ProjectsScreenInner: React.FC = () => {
   const navigate = useMyNavigate();
-  const teamId = localStorage.getItem(localUserKey(LocalKey.team));
+  const [bootstrappedTeamId, setBootstrappedTeamId] = React.useState<
+    string | null
+  >(null);
+  const teamId =
+    bootstrappedTeamId ??
+    localStorage.getItem(localUserKey(LocalKey.team));
   const ctx = React.useContext(TeamContext);
   const {
     teamProjects,
@@ -65,13 +70,21 @@ export const ProjectsScreenInner: React.FC = () => {
     navigate('/switch-teams');
   }, [navigate]);
 
-  // Handle missing teamId with useEffect to prevent infinite render loops
+  // Handle missing teamId: PAP-like users (only personal team) stay on /team; others pick a team
   React.useEffect(() => {
-    if (!teamId) {
-      handleSwitchTeams();
+    const currentId =
+      bootstrappedTeamId ??
+      localStorage.getItem(localUserKey(LocalKey.team));
+    if (currentId) return;
+    if (!personalTeam) return;
+    if (teams.length === 0) {
+      localStorage.setItem(localUserKey(LocalKey.team), personalTeam);
+      setBootstrappedTeamId(personalTeam);
+      return;
     }
+    handleSwitchTeams();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleSwitchTeams]);
+  }, [bootstrappedTeamId, personalTeam, teams, handleSwitchTeams]);
 
   React.useEffect(() => {
     startClear();
@@ -81,6 +94,8 @@ export const ProjectsScreenInner: React.FC = () => {
   }, []);
 
   const isPersonal = teamId === personalTeam;
+  const isPapLike =
+    Boolean(personalTeam) && isPersonal && teams.length === 0;
   const projects = React.useMemo(
     () => (isPersonal ? personalProjects : teamId ? teamProjects(teamId) : []),
     [isPersonal, personalProjects, teamId, teamProjects]
@@ -270,17 +285,19 @@ export const ProjectsScreenInner: React.FC = () => {
               {t.addNewProject || 'Add New Project...'}
             </Button>
           )}
-          <Button
-            id="ProjectActSwitch"
-            variant="outlined"
-            onClick={handleSwitchTeams}
-            sx={(theme) => ({
-              minWidth: 120,
-              bgcolor: theme.palette.common.white,
-            })}
-          >
-            {t.switchTeams || 'Switch Teams'}
-          </Button>
+          {!isPapLike && (
+            <Button
+              id="ProjectActSwitch"
+              variant="outlined"
+              onClick={handleSwitchTeams}
+              sx={(theme) => ({
+                minWidth: 120,
+                bgcolor: theme.palette.common.white,
+              })}
+            >
+              {t.switchTeams || 'Switch Teams'}
+            </Button>
+          )}
         </Stack>
       </Box>
       <BigDialog

--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -37,12 +37,7 @@ const ProjectsBox = styled(Box)<ProjectBoxProps>(({ theme, isMobile }) => ({
 
 export const ProjectsScreenInner: React.FC = () => {
   const navigate = useMyNavigate();
-  const [bootstrappedTeamId, setBootstrappedTeamId] = React.useState<
-    string | null
-  >(null);
-  const teamId =
-    bootstrappedTeamId ??
-    localStorage.getItem(localUserKey(LocalKey.team));
+  const teamId = localStorage.getItem(localUserKey(LocalKey.team));
   const ctx = React.useContext(TeamContext);
   const {
     teamProjects,
@@ -50,6 +45,7 @@ export const ProjectsScreenInner: React.FC = () => {
     personalTeam,
     cardStrings,
     teams,
+    teamDirectoryReady,
     isAdmin,
   } = ctx.state;
   const t = cardStrings;
@@ -70,21 +66,13 @@ export const ProjectsScreenInner: React.FC = () => {
     navigate('/switch-teams');
   }, [navigate]);
 
-  // Handle missing teamId: PAP-like users (only personal team) stay on /team; others pick a team
+  // Missing teamId: always open picker; SwitchTeamsGuard redirects true PAP-like users back to /team
   React.useEffect(() => {
-    const currentId =
-      bootstrappedTeamId ??
-      localStorage.getItem(localUserKey(LocalKey.team));
+    const currentId = localStorage.getItem(localUserKey(LocalKey.team));
     if (currentId) return;
     if (!personalTeam) return;
-    if (teams.length === 0) {
-      localStorage.setItem(localUserKey(LocalKey.team), personalTeam);
-      setBootstrappedTeamId(personalTeam);
-      return;
-    }
     handleSwitchTeams();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bootstrappedTeamId, personalTeam, teams, handleSwitchTeams]);
+  }, [personalTeam, handleSwitchTeams]);
 
   React.useEffect(() => {
     startClear();
@@ -95,7 +83,10 @@ export const ProjectsScreenInner: React.FC = () => {
 
   const isPersonal = teamId === personalTeam;
   const isPapLike =
-    Boolean(personalTeam) && isPersonal && teams.length === 0;
+    Boolean(personalTeam) &&
+    isPersonal &&
+    teams.length === 0 &&
+    teamDirectoryReady;
   const projects = React.useMemo(
     () => (isPersonal ? personalProjects : teamId ? teamProjects(teamId) : []),
     [isPersonal, personalProjects, teamId, teamProjects]

--- a/src/renderer/src/routes/SwitchTeams.cy.tsx
+++ b/src/renderer/src/routes/SwitchTeams.cy.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import SwitchTeams from './SwitchTeams';
+import { SwitchTeamsGuard, SwitchTeamsUnguarded } from './SwitchTeams';
+import { TeamContext } from '../context/TeamContext';
 import { GlobalProvider } from '../context/GlobalContext';
 import { Provider } from 'react-redux';
 import {
@@ -190,7 +191,7 @@ describe('SwitchTeams', () => {
             <DataProvider dataStore={memory}>
               <UnsavedProvider>
                 <TokenContext.Provider value={mockTokenContextValue as any}>
-                  <SwitchTeams />
+                  <SwitchTeamsUnguarded />
                 </TokenContext.Provider>
               </UnsavedProvider>
             </DataProvider>
@@ -456,5 +457,95 @@ describe('SwitchTeams', () => {
     // Settings button should not be visible on mobile
     cy.get('[data-testid="personal-settings"]').should('not.exist');
     cy.get('[data-testid^="team-settings"]').should('not.exist');
+  });
+});
+
+describe('SwitchTeamsGuard', () => {
+  const papLikeTeamState = {
+    teams: [],
+    personalTeam: 'personal-team-id',
+    teamDirectoryReady: true,
+  };
+
+  const mountGuard = (
+    globalOverrides: Record<string, unknown>,
+    teamState: typeof papLikeTeamState
+  ) => {
+    const mockTeamCtx = {
+      state: { ...papLikeTeamState, ...teamState } as any,
+      setState: cy.stub(),
+    };
+    cy.mount(
+      <MemoryRouter initialEntries={['/switch-teams']}>
+        <Provider store={mockStore}>
+          <GlobalProvider
+            init={{
+              coordinator: mockCoordinator,
+              errorReporter: bugsnagClient,
+              fingerprint: 'test-fingerprint',
+              memory: createMockMemory(),
+              lang: 'en',
+              latestVersion: '',
+              loadComplete: false,
+              offlineOnly: false,
+              organization: '',
+              releaseDate: '',
+              user: 'test-user-id',
+              alertOpen: false,
+              autoOpenAddMedia: false,
+              changed: false,
+              connected: true,
+              dataChangeCount: 0,
+              developer: false,
+              enableOffsite: false,
+              home: false,
+              importexportBusy: false,
+              orbitRetries: 0,
+              orgRole: undefined,
+              plan: '',
+              playingMediaId: '',
+              progress: 0,
+              project: '',
+              projectsLoaded: [],
+              projType: '',
+              remoteBusy: false,
+              saveResult: undefined,
+              snackAlert: undefined,
+              snackMessage: (<></>) as React.JSX.Element,
+              offline: false,
+              mobileView: false,
+              ...globalOverrides,
+            }}
+          >
+            <TeamContext.Provider value={mockTeamCtx as any}>
+              <SwitchTeamsGuard>
+                <div id="TeamsScreen">picker</div>
+              </SwitchTeamsGuard>
+            </TeamContext.Provider>
+          </GlobalProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+  };
+
+  it('shows picker when offline and not offlineOnly (empty teams is not reliable PAP)', () => {
+    mountGuard(
+      { offline: true, offlineOnly: false },
+      papLikeTeamState
+    );
+    cy.get('#TeamsScreen').should('exist');
+  });
+
+  it('redirects when online and PAP-like', () => {
+    mountGuard({ offline: false, offlineOnly: false }, papLikeTeamState);
+    cy.get('#TeamsScreen').should('not.exist');
+  });
+
+  it('redirects when offlineOnly and PAP-like', () => {
+    mountGuard(
+      { offline: true, offlineOnly: true },
+      papLikeTeamState
+    );
+    cy.get('#TeamsScreen').should('not.exist');
   });
 });

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -23,6 +23,7 @@ import { TeamContext } from '../context/TeamContext';
 import { useGlobal } from '../context/useGlobal';
 import { useTeamActions } from '../components/Team/useTeamActions';
 import { SharedContentCreatorDialog } from '../components/Team/SharedContentCreatorDialog';
+import StickyRedirect from '../components/StickyRedirect';
 
 interface ISettingsButtonProps {
   label: string;
@@ -384,6 +385,28 @@ const useSettingsHandlers = () => {
   return ctx;
 };
 
+/** Work Alone / PAP-like: only personal team exists — redirect to team home instead of picker */
+const SwitchTeamsGuard: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const ctx = React.useContext(TeamContext);
+  const { teams, personalTeam } = ctx.state;
+
+  if (!personalTeam) {
+    return null;
+  }
+
+  if (teams.length === 0) {
+    const key = localUserKey(LocalKey.team);
+    if (localStorage.getItem(key) !== personalTeam) {
+      localStorage.setItem(key, personalTeam);
+    }
+    return <StickyRedirect to="/team" />;
+  }
+
+  return <>{children}</>;
+};
+
 const MainTeamsLayout: React.FC = () => {
   const { openSettingsForTeam, openSettingsForPersonal } =
     useSettingsHandlers();
@@ -416,9 +439,11 @@ export const SwitchTeams: React.FC = () => {
       <TeamProvider>
         <>
           <AppHead />
-          <SettingsProvider>
-            <MainTeamsLayout />
-          </SettingsProvider>
+          <SwitchTeamsGuard>
+            <SettingsProvider>
+              <MainTeamsLayout />
+            </SettingsProvider>
+          </SwitchTeamsGuard>
         </>
       </TeamProvider>
     </Box>

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -386,21 +386,34 @@ const useSettingsHandlers = () => {
 };
 
 /** Work Alone / PAP-like: only personal team exists — redirect to team home instead of picker */
-const SwitchTeamsGuard: React.FC<{ children: React.ReactNode }> = ({
+export const SwitchTeamsGuard: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const ctx = React.useContext(TeamContext);
-  const { teams, personalTeam } = ctx.state;
+  const { teams, personalTeam, teamDirectoryReady } = ctx.state;
+  const [isOffline] = useGlobal('offline');
+  const [offlineOnly] = useGlobal('offlineOnly');
+  // When offline && !offlineOnly, getTeams() may be empty because shared teams
+  // without local projects are filtered out — not the same as true PAP-only.
+  const isPapLike =
+    Boolean(personalTeam) &&
+    teams.length === 0 &&
+    teamDirectoryReady &&
+    (!isOffline || offlineOnly);
+
+  React.useEffect(() => {
+    if (!isPapLike || !personalTeam) return;
+    const key = localUserKey(LocalKey.team);
+    if (localStorage.getItem(key) !== personalTeam) {
+      localStorage.setItem(key, personalTeam);
+    }
+  }, [isPapLike, personalTeam]);
 
   if (!personalTeam) {
     return null;
   }
 
-  if (teams.length === 0) {
-    const key = localUserKey(LocalKey.team);
-    if (localStorage.getItem(key) !== personalTeam) {
-      localStorage.setItem(key, personalTeam);
-    }
+  if (isPapLike) {
     return <StickyRedirect to="/team" />;
   }
 
@@ -444,6 +457,22 @@ export const SwitchTeams: React.FC = () => {
               <MainTeamsLayout />
             </SettingsProvider>
           </SwitchTeamsGuard>
+        </>
+      </TeamProvider>
+    </Box>
+  );
+};
+
+/** Same UI as the route without the PAP-like redirect; CT uses empty orbit data so `teams` stays []. */
+export const SwitchTeamsUnguarded: React.FC = () => {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <TeamProvider>
+        <>
+          <AppHead />
+          <SettingsProvider>
+            <MainTeamsLayout />
+          </SettingsProvider>
         </>
       </TeamProvider>
     </Box>


### PR DESCRIPTION
- Introduced state management for bootstrapped team ID in ProjectsScreen to handle team selection more effectively.
- Updated useEffect hooks to prevent infinite render loops and ensure proper team switching logic for PAP-like users.
- Added SwitchTeamsGuard component to redirect users with only a personal team to the team home, enhancing user experience.
- Conditional rendering of the "Switch Teams" button based on user type to streamline the interface.