### PR TITLE
TT-7179 Refactor PassageDetailRecord to optimize media performer retrieval

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
@@ -147,17 +147,19 @@ export function PassageDetailRecord(props: IProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mediafileId, passage]);
 
-  useEffect(() => {
+  const performedByFromMedia = useMemo(() => {
     const mediaRec = findRecord(memory, 'mediafile', mediafileId) as
       | MediaFileD
       | undefined;
-    const performer = mediaRec?.attributes?.performedBy;
-    if (performer) {
-      setSpeaker(performer);
+    return mediaRec?.attributes?.performedBy;
+  }, [memory, mediafileId, mediafiles]);
+
+  useEffect(() => {
+    if (performedByFromMedia) {
+      setSpeaker(performedByFromMedia);
       setHasRight(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mediafileId, mediafiles]);
+  }, [mediafileId, performedByFromMedia]);
 
   useEffect(() => {
     recordPreloadInitiatedRef.current = null;


### PR DESCRIPTION
- Introduced useMemo to compute the performer from media records, improving performance by reducing unnecessary calculations.
- Updated useEffect dependencies to ensure correct state updates for speaker and rights management based on mediafileId and performer data.