### PR TITLE
TT-7124 Enhance useBurritoAudio fore resource burrito creation

### DIFF
--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -372,4 +372,410 @@ describe('useBurritoAudio', () => {
       VernacularTag: null,
     }));
   });
+
+  it('section resources with same version and extension use distinct paths per sequenceNum', async () => {
+    const ipc = makeIpc();
+    const { renderHook, act, useBurritoAudio } = loadAudioForApi(ipc);
+
+    /* eslint-disable @typescript-eslint/no-require-imports -- resetModules pattern */
+    const { useOrbitData } = require('../hoc/useOrbitData');
+    const { useArtifactType } = require('../crud/useArtifactType');
+    const { ArtifactTypeSlug } = require('../crud/artifactTypeSlug');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'resource'),
+      VernacularTag: null,
+    }));
+
+    const orbitMedia = [
+      {
+        id: 'm-a',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-a' },
+        attributes: {
+          audioUrl: 'https://example.test/a.mp3',
+          originalFile: 'a.mp3',
+          contentType: 'audio/mpeg',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-r' } },
+        },
+      },
+      {
+        id: 'm-b',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-b' },
+        attributes: {
+          audioUrl: 'https://example.test/b.mp3',
+          originalFile: 'b.mp3',
+          contentType: 'audio/mpeg',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-r' } },
+        },
+      },
+    ];
+
+    const orbitSectionResources = [
+      {
+        id: 'sr-2',
+        type: 'sectionresource',
+        attributes: {
+          sequenceNum: 2,
+          description: '',
+          dateCreated: '',
+          dateUpdated: '',
+          lastModifiedBy: 0,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          mediafile: { data: { type: 'mediafile', id: 'm-b' } },
+        },
+      },
+      {
+        id: 'sr-1',
+        type: 'sectionresource',
+        attributes: {
+          sequenceNum: 1,
+          description: '',
+          dateCreated: '',
+          dateUpdated: '',
+          lastModifiedBy: 0,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          mediafile: { data: { type: 'mediafile', id: 'm-a' } },
+        },
+      },
+    ];
+
+    const orbitPassages = [
+      {
+        id: 'p1',
+        type: 'passage',
+        attributes: {
+          book: 'GEN',
+          reference: 'GEN 1:1',
+          startChapter: 1,
+          sequencenum: 1,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          sharedResource: { data: null },
+        },
+      },
+    ];
+
+    useOrbitData.mockImplementation((type: string) => {
+      if (type === 'mediafile') return orbitMedia;
+      if (type === 'passage') return orbitPassages;
+      if (type === 'sectionresource') return orbitSectionResources;
+      if (type === 'sharedresource') return [];
+      return [];
+    });
+
+    const metadata = burritoFixture();
+    const { result } = renderHook(() => useBurritoAudio(teamId));
+
+    await act(async () => {
+      await result.current({
+        metadata,
+        bible: bibleFixture,
+        book: 'GEN',
+        bookPath: '/burrito/GEN',
+        preLen: 0,
+        sections: [
+          {
+            id: 's1',
+            type: 'section',
+            relationships: {
+              plan: { data: { type: 'plan', id: 'plan1' } },
+            },
+          } as SectionD,
+        ],
+        passageTypeFilter: null,
+        flavorTypeName: 'x-resources',
+        artifactTypeFilter: [ArtifactTypeSlug.Resource],
+      });
+    });
+
+    const destPaths = (ipc.copyFile as jest.Mock).mock.calls.map(
+      (c: unknown[]) => c[1] as string
+    );
+    const sectionDestPaths = destPaths.filter((p) => p.includes('-section-'));
+    expect(sectionDestPaths).toHaveLength(2);
+    expect(sectionDestPaths.some((p) => p.includes('r1v1.'))).toBe(true);
+    expect(sectionDestPaths.some((p) => p.includes('r2v1.'))).toBe(true);
+    expect(sectionDestPaths[0]).not.toBe(sectionDestPaths[1]);
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'vernacular'),
+      VernacularTag: null,
+    }));
+  });
+
+  it('skips plan-root copy for media already exported as section resources', async () => {
+    const ipc = makeIpc();
+    const { renderHook, act, useBurritoAudio } = loadAudioForApi(ipc);
+
+    /* eslint-disable @typescript-eslint/no-require-imports -- resetModules pattern */
+    const { useOrbitData } = require('../hoc/useOrbitData');
+    const { useArtifactType } = require('../crud/useArtifactType');
+    const { ArtifactTypeSlug } = require('../crud/artifactTypeSlug');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'resource'),
+      VernacularTag: null,
+    }));
+
+    const orbitMedia = [
+      {
+        id: 'm-section',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-s' },
+        attributes: {
+          audioUrl: 'https://example.test/section.mp3',
+          originalFile: 'section.mp3',
+          contentType: 'audio/mpeg',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-r' } },
+        },
+      },
+      {
+        id: 'm-plan-only',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-p' },
+        attributes: {
+          audioUrl: 'https://example.test/plan-only.mp3',
+          originalFile: 'plan-only.mp3',
+          contentType: 'audio/mpeg',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-r' } },
+        },
+      },
+    ];
+
+    const orbitSectionResources = [
+      {
+        id: 'sr-1',
+        type: 'sectionresource',
+        attributes: {
+          sequenceNum: 1,
+          description: '',
+          dateCreated: '',
+          dateUpdated: '',
+          lastModifiedBy: 0,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          mediafile: { data: { type: 'mediafile', id: 'm-section' } },
+        },
+      },
+    ];
+
+    const orbitPassages = [
+      {
+        id: 'p1',
+        type: 'passage',
+        attributes: {
+          book: 'GEN',
+          reference: 'GEN 1:1',
+          startChapter: 1,
+          sequencenum: 1,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          sharedResource: { data: null },
+        },
+      },
+    ];
+
+    useOrbitData.mockImplementation((type: string) => {
+      if (type === 'mediafile') return orbitMedia;
+      if (type === 'passage') return orbitPassages;
+      if (type === 'sectionresource') return orbitSectionResources;
+      if (type === 'sharedresource') return [];
+      return [];
+    });
+
+    const metadata = burritoFixture();
+    const { result } = renderHook(() => useBurritoAudio(teamId));
+
+    await act(async () => {
+      await result.current({
+        metadata,
+        bible: bibleFixture,
+        book: 'GEN',
+        bookPath: '/burrito/GEN',
+        preLen: 0,
+        sections: [
+          {
+            id: 's1',
+            type: 'section',
+            relationships: {
+              plan: { data: { type: 'plan', id: 'plan1' } },
+            },
+          } as SectionD,
+        ],
+        passageTypeFilter: null,
+        flavorTypeName: 'x-resources',
+        artifactTypeFilter: [ArtifactTypeSlug.Resource],
+      });
+    });
+
+    const copyDests = (ipc.copyFile as jest.Mock).mock.calls.map(
+      (c: unknown[]) => c[1] as string
+    );
+    const sectionCopies = copyDests.filter((p) => p.includes('-section-'));
+    const planRootCopies = copyDests.filter(
+      (p) => p.includes('/burrito/GEN/') && !p.includes('/001/')
+    );
+    expect(sectionCopies).toHaveLength(1);
+    expect(sectionCopies[0]).toMatch(/-section-/);
+    expect(planRootCopies).toHaveLength(1);
+    expect(planRootCopies[0]).toContain('plan-only');
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'vernacular'),
+      VernacularTag: null,
+    }));
+  });
+
+  it('writes inline text/plain to burrito without audioUrl', async () => {
+    const ipc = makeIpc();
+    const { renderHook, act, useBurritoAudio } = loadAudioForApi(ipc);
+
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const { useOrbitData } = require('../hoc/useOrbitData');
+    const { useArtifactType } = require('../crud/useArtifactType');
+    const { ArtifactTypeSlug } = require('../crud/artifactTypeSlug');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'resource'),
+      VernacularTag: null,
+    }));
+
+    const longBody = `${'x'.repeat(500)}`;
+    const orbitMedia = [
+      {
+        id: 'm-text',
+        type: 'mediafile',
+        keys: { remoteId: 'remote-t' },
+        attributes: {
+          audioUrl: '',
+          originalFile: longBody,
+          contentType: 'text/plain',
+          versionNumber: 1,
+          segments: '{}',
+        },
+        relationships: {
+          plan: { data: { type: 'plan', id: 'plan1' } },
+          passage: { data: null },
+          artifactType: { data: { type: 'artifacttype', id: 'at-r' } },
+        },
+      },
+    ];
+
+    const orbitSectionResources = [
+      {
+        id: 'sr-t',
+        type: 'sectionresource',
+        attributes: {
+          sequenceNum: 1,
+          description: '',
+          dateCreated: '',
+          dateUpdated: '',
+          lastModifiedBy: 0,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          mediafile: { data: { type: 'mediafile', id: 'm-text' } },
+        },
+      },
+    ];
+
+    const orbitPassages = [
+      {
+        id: 'p1',
+        type: 'passage',
+        attributes: {
+          book: 'GEN',
+          reference: 'GEN 1:1',
+          startChapter: 1,
+          sequencenum: 1,
+        },
+        relationships: {
+          section: { data: { type: 'section', id: 's1' } },
+          sharedResource: { data: null },
+        },
+      },
+    ];
+
+    useOrbitData.mockImplementation((type: string) => {
+      if (type === 'mediafile') return orbitMedia;
+      if (type === 'passage') return orbitPassages;
+      if (type === 'sectionresource') return orbitSectionResources;
+      if (type === 'sharedresource') return [];
+      return [];
+    });
+
+    const metadata = burritoFixture();
+    const { result } = renderHook(() => useBurritoAudio(teamId));
+
+    await act(async () => {
+      await result.current({
+        metadata,
+        bible: bibleFixture,
+        book: 'GEN',
+        bookPath: '/burrito/GEN',
+        preLen: 0,
+        sections: [
+          {
+            id: 's1',
+            type: 'section',
+            relationships: {
+              plan: { data: { type: 'plan', id: 'plan1' } },
+            },
+          } as SectionD,
+        ],
+        passageTypeFilter: null,
+        flavorTypeName: 'x-resources',
+        artifactTypeFilter: [ArtifactTypeSlug.Resource],
+      });
+    });
+
+    expect(ipc.copyFile).not.toHaveBeenCalled();
+    expect(ipc.write).toHaveBeenCalled();
+    const textWrite = (ipc.write as jest.Mock).mock.calls.find(
+      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string) === longBody
+    );
+    expect(textWrite).toBeDefined();
+    expect((textWrite![0] as string).endsWith('.txt')).toBe(true);
+
+    useArtifactType.mockImplementation(() => ({
+      slugFromId: jest.fn(() => 'vernacular'),
+      VernacularTag: null,
+    }));
+  });
 });

--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -768,7 +768,8 @@ describe('useBurritoAudio', () => {
     expect(ipc.copyFile).not.toHaveBeenCalled();
     expect(ipc.write).toHaveBeenCalled();
     const textWrite = (ipc.write as jest.Mock).mock.calls.find(
-      (c: unknown[]) => typeof c[1] === 'string' && (c[1] as string) === longBody
+      (c: unknown[]) =>
+        typeof c[1] === 'string' && (c[1] as string) === longBody
     );
     expect(textWrite).toBeDefined();
     expect((textWrite![0] as string).endsWith('.txt')).toBe(true);

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -34,11 +34,31 @@ import { useComputeRef } from '../components/PassageDetail/Internalization/useCo
 import { MainAPI } from '@model/main-api';
 import { Stats } from 'fs';
 import getMediaExt from '../utils/getMediaExt';
+import getBurritoMediaExportStem from '../utils/burritoMediaFileStem';
 import {
   BURRITO_AUDIO_FILE_EXTENSIONS,
   inferAudioContentType,
 } from '../utils/mimeTypes';
 const ipc = window?.api as MainAPI;
+
+const truncateForMessage = (s: string, maxLen = 120): string => {
+  const t = (s ?? '').trim();
+  if (t.length <= maxLen) return t;
+  return `${t.slice(0, maxLen - 1)}…`;
+};
+
+const primaryContentType = (m: MediaFileD): string =>
+  (m.attributes.contentType || '').split(';')[0]?.trim().toLowerCase() ?? '';
+
+const looksLikeHttpUrl = (s: string): boolean =>
+  /^https?:\/\//i.test((s || '').trim());
+
+const inlineTextExtension = (contentType: string): string => {
+  const sub = contentType.split('/')[1]?.trim() || '';
+  if (sub === 'html' || sub === 'xhtml+xml') return '.html';
+  if (sub === 'markdown') return '.md';
+  return '.txt';
+};
 
 interface Props {
   metadata: Burrito;
@@ -120,6 +140,17 @@ export const useBurritoAudio = (teamId: string) => {
             : () => true
         );
 
+    const stripTrailingExtension = (filePath: string): string => {
+      const ext = path.extname(filePath);
+      return ext ? filePath.slice(0, -ext.length) : filePath;
+    };
+
+    const ensureParentDir = async (filePath: string) => {
+      const dir = path.dirname(filePath);
+      if (!dir || dir === '.' || dir === '/') return;
+      await ipc?.createFolder(dir);
+    };
+
     const processMediaFile = async (
       m: MediaFileD,
       destPath: string,
@@ -131,7 +162,9 @@ export const useBurritoAudio = (teamId: string) => {
       // const ext = getExtention(m);
       // compressions.add(ext ?? '');
       if (!attr.audioUrl) {
-        showMessage(`No media URL for ${contextLabel} (${attr.originalFile})`);
+        showMessage(
+          `No media URL for ${truncateForMessage(contextLabel)} (${truncateForMessage(attr.originalFile)})`
+        );
         return;
       }
       const local = { localname: '' };
@@ -141,10 +174,11 @@ export const useBurritoAudio = (teamId: string) => {
         const id = m.keys?.remoteId || m.id;
         await fetchUrl({ id, cancelled: () => false });
         if (!(await ipc?.exists(mediaName))) {
-          showMessage(`Failed to download ${attr.audioUrl}`);
+          showMessage(`Failed to download ${truncateForMessage(attr.audioUrl)}`);
           return;
         }
       }
+      await ensureParentDir(destPath);
       await ipc?.copyFile(mediaName, destPath);
       let finalPath = destPath;
       if (convertToMp3) {
@@ -155,7 +189,9 @@ export const useBurritoAudio = (teamId: string) => {
             : `${destPath}.mp3`;
           const convResult = await ipc?.convertToMp3(destPath, mp3Path);
           if (typeof convResult === 'string') {
-            showMessage(`Failed to convert ${contextLabel} to mp3`);
+            showMessage(
+              `Failed to convert ${truncateForMessage(contextLabel)} to mp3`
+            );
             return;
           }
           await ipc?.delete(destPath);
@@ -215,11 +251,14 @@ export const useBurritoAudio = (teamId: string) => {
       scopeRef: string
     ) => {
       const attr = m.attributes;
-      destPath += '.md';
-      ipc?.write(destPath, attr.originalFile);
-      const docid = destPath.substring(preLen);
+      const finalPath = destPath.toLowerCase().endsWith('.md')
+        ? destPath
+        : `${stripTrailingExtension(destPath)}.md`;
+      await ensureParentDir(finalPath);
+      await ipc?.write(finalPath, attr.originalFile);
+      const docid = finalPath.substring(preLen);
       ingredients[docid] = {
-        checksum: { md5: await ipc?.md5File(destPath) },
+        checksum: { md5: await ipc?.md5File(finalPath) },
         mimeType: attr.contentType,
         size: attr.originalFile.length,
         scope: { [book]: [scopeRef] },
@@ -229,9 +268,87 @@ export const useBurritoAudio = (teamId: string) => {
       };
     };
 
+    const processInlineTextFile = async (
+      m: MediaFileD,
+      destPath: string,
+      scopeRef: string
+    ) => {
+      const attr = m.attributes;
+      const ct = primaryContentType(m);
+      const ext = inlineTextExtension(ct);
+      const base = stripTrailingExtension(destPath);
+      const finalPath = `${base}${ext}`;
+      await ensureParentDir(finalPath);
+      await ipc?.write(finalPath, attr.originalFile);
+      const docid = finalPath.substring(preLen);
+      ingredients[docid] = {
+        checksum: { md5: await ipc?.md5File(finalPath) },
+        mimeType: attr.contentType || 'text/plain',
+        size: attr.originalFile.length,
+        scope: { [book]: [scopeRef] },
+        properties: {
+          apmId: m.keys?.remoteId || m.id,
+        },
+      };
+    };
+
+    const processLinkUrlFile = async (
+      m: MediaFileD,
+      destPath: string,
+      scopeRef: string
+    ) => {
+      const url = m.attributes.originalFile.trim();
+      const base = stripTrailingExtension(destPath);
+      const finalPath = `${base}.link.txt`;
+      await ensureParentDir(finalPath);
+      await ipc?.write(finalPath, `${url}\n`);
+      const docid = finalPath.substring(preLen);
+      ingredients[docid] = {
+        checksum: { md5: await ipc?.md5File(finalPath) },
+        mimeType: 'text/plain',
+        size: url.length + 1,
+        scope: { [book]: [scopeRef] },
+        properties: {
+          apmId: m.keys?.remoteId || m.id,
+        },
+      };
+    };
+
+    const processExportableMedia = async (
+      m: MediaFileD,
+      destPath: string,
+      scopeRef: string,
+      contextLabel: string,
+      buildAlignment: boolean
+    ) => {
+      const attr = m.attributes;
+      const ct = primaryContentType(m);
+      if (ct === 'text/markdown') {
+        await processMarkdownFile(m, destPath, scopeRef);
+        return;
+      }
+      if (ct.startsWith('text/')) {
+        await processInlineTextFile(m, destPath, scopeRef);
+        return;
+      }
+      if (!attr.audioUrl && looksLikeHttpUrl(attr.originalFile || '')) {
+        await processLinkUrlFile(m, destPath, scopeRef);
+        return;
+      }
+      await processMediaFile(
+        m,
+        destPath,
+        scopeRef,
+        contextLabel,
+        buildAlignment
+      );
+    };
+
     let chapter = 0;
     let chapterPath = '';
     let plan: string | undefined;
+    /** Avoid duplicating section-level resources into the book folder (plan-attached, passage-null loop below). */
+    const mediaIdsExportedAsSectionResources = new Set<string>();
 
     for (const section of sections) {
       const refCount = new Map<string, number>();
@@ -267,41 +384,37 @@ export const useBurritoAudio = (teamId: string) => {
 
       // when using artifactTypeFilter (e.g. Resources), include section-level resources (one copy each)
       if (artifactTypeFilter) {
-        const sectionLevelSecRes = sectionResources.filter(
-          (sr) =>
-            related(sr, 'section') === section.id && !related(sr, 'passage')
-        );
-        const seenMediaIds = new Set<string>();
-        const sectionResourceMedia = sectionLevelSecRes
-          .map((sr) => planMedia.find((m) => m.id === related(sr, 'mediafile')))
+        const sectionLevelSecRes = sectionResources
           .filter(
-            (m): m is MediaFileD =>
-              m != null &&
-              !seenMediaIds.has(m.id) &&
-              (seenMediaIds.add(m.id), true)
+            (sr) =>
+              related(sr, 'section') === section.id && !related(sr, 'passage')
+          )
+          .sort(
+            (a, b) =>
+              (a.attributes.sequenceNum ?? 0) - (b.attributes.sequenceNum ?? 0)
           );
-        const sectionFilteredMedia = filterAndSortMedia(
-          sectionResourceMedia,
-          true
-        );
-        if (sectionFilteredMedia.length > 0) {
-          const sectionRefCount = nextRef(sectionRef);
-          for (const m of sectionFilteredMedia) {
-            const attr = m.attributes;
-            const destName = `${bibleId}-${book}-section-${cleanFileName(sectionRef) + `${nType}${sectionRefCount}`}v${attr.versionNumber}.${getMediaExt(m)}`;
-            const destPath = path.join(sectionChapterPath, destName);
-            if (attr.contentType === 'text/markdown') {
-              await processMarkdownFile(m, destPath, sectionRef);
-            } else {
-              await processMediaFile(
-                m,
-                destPath,
-                sectionRef,
-                'section resource',
-                false
-              );
-            }
+        const exportedSectionMediaIds = new Set<string>();
+        let sectionRefCount: string | null = null;
+        for (const sr of sectionLevelSecRes) {
+          const m = planMedia.find((x) => x.id === related(sr, 'mediafile'));
+          if (!m || !makeArtifactFilter()(m)) continue;
+          if (exportedSectionMediaIds.has(m.id)) continue;
+          exportedSectionMediaIds.add(m.id);
+          mediaIdsExportedAsSectionResources.add(m.id);
+          if (sectionRefCount === null) {
+            sectionRefCount = nextRef(sectionRef);
           }
+          const seq = sr.attributes.sequenceNum ?? 0;
+          const attr = m.attributes;
+          const destName = `${bibleId}-${book}-section-${cleanFileName(sectionRef) + `${nType}${sectionRefCount}`}r${seq}v${attr.versionNumber}.${getMediaExt(m)}`;
+          const destPath = path.join(sectionChapterPath, destName);
+          await processExportableMedia(
+            m,
+            destPath,
+            sectionRef,
+            'section resource',
+            false
+          );
         }
       }
 
@@ -350,7 +463,7 @@ export const useBurritoAudio = (teamId: string) => {
           const destName = `${bibleId}-${book}-${cleanFileName(lastReference + lastReferenceCount + sharedResourceTitle)}v${m.attributes.versionNumber}.${getMediaExt(m)}`;
           const destPath = path.join(chapterPath, destName);
           const contextLabel = `${p.attributes.book} ${lastReference}`;
-          await processMediaFile(
+          await processExportableMedia(
             m,
             destPath,
             lastReference,
@@ -367,10 +480,11 @@ export const useBurritoAudio = (teamId: string) => {
       )
       .filter(makeArtifactFilter());
     for (const m of planMedia) {
-      const { name } = path.parse(m.attributes.originalFile);
-      const destName = `${bibleId}-${book}-${cleanFileName(name)}.${getMediaExt(m)}`;
+      if (mediaIdsExportedAsSectionResources.has(m.id)) continue;
+      const stem = getBurritoMediaExportStem(m);
+      const destName = `${bibleId}-${book}-${stem}.${getMediaExt(m)}`;
       const destPath = path.join(bookPath, destName);
-      await processMediaFile(m, destPath, '', '', false);
+      await processExportableMedia(m, destPath, '', '', false);
     }
     const alignment = new AlignmentBuilder()
       .withGroups(alignmentGroups)

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -174,7 +174,9 @@ export const useBurritoAudio = (teamId: string) => {
         const id = m.keys?.remoteId || m.id;
         await fetchUrl({ id, cancelled: () => false });
         if (!(await ipc?.exists(mediaName))) {
-          showMessage(`Failed to download ${truncateForMessage(attr.audioUrl)}`);
+          showMessage(
+            `Failed to download ${truncateForMessage(attr.audioUrl)}`
+          );
           return;
         }
       }

--- a/src/renderer/src/burrito/useCreateBurrito.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.ts
@@ -557,7 +557,15 @@ export const useCreateBurrito = (teamId: string) => {
       mediafiles,
       versions: isNaN(versions) ? 1 : versions,
     });
-  }, [books, getOrgDefault, getSections, mediafiles, passages, sections, teamId]);
+  }, [
+    books,
+    getOrgDefault,
+    getSections,
+    mediafiles,
+    passages,
+    sections,
+    teamId,
+  ]);
 
   return {
     createBurrito,

--- a/src/renderer/src/burrito/useCreateBurrito.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.ts
@@ -390,6 +390,7 @@ export const useCreateBurrito = (teamId: string) => {
               ArtifactTypeSlug.Resource,
               ArtifactTypeSlug.SharedResource,
               ArtifactTypeSlug.ProjectResource,
+              ArtifactTypeSlug.AIResource,
             ],
             convertToMp3,
           });

--- a/src/renderer/src/utils/burritoMediaFileStem.test.ts
+++ b/src/renderer/src/utils/burritoMediaFileStem.test.ts
@@ -1,0 +1,42 @@
+import type { MediaFileD } from '@model/mediafile';
+import { getBurritoMediaExportStem } from './burritoMediaFileStem';
+
+describe('getBurritoMediaExportStem', () => {
+  it('uses id-based stem for long text/* body (formatted text) content', () => {
+    const body = '# Title\n\n'.repeat(30);
+    const media = {
+      type: 'mediafile',
+      id: 'abc-123-uuid',
+      keys: { remoteId: 'remote-xyz' },
+      attributes: {
+        originalFile: body,
+        contentType: 'text/html',
+      },
+    } as unknown as MediaFileD;
+    expect(getBurritoMediaExportStem(media)).toBe('text-remote-xyz');
+  });
+
+  it('keeps a real short filename from originalFile', () => {
+    const media = {
+      type: 'mediafile',
+      id: 'm1',
+      attributes: {
+        originalFile: 'C:\\docs\\MyNotes.md',
+        contentType: 'text/markdown',
+      },
+    } as unknown as MediaFileD;
+    expect(getBurritoMediaExportStem(media)).toBe('MyNotes');
+  });
+
+  it('derives stem from URL path when originalFile is http(s)', () => {
+    const media = {
+      type: 'mediafile',
+      id: 'm1',
+      attributes: {
+        originalFile: 'https://example.org/static/guide.pdf',
+        contentType: 'application/pdf',
+      },
+    } as unknown as MediaFileD;
+    expect(getBurritoMediaExportStem(media)).toBe('guide');
+  });
+});

--- a/src/renderer/src/utils/burritoMediaFileStem.ts
+++ b/src/renderer/src/utils/burritoMediaFileStem.ts
@@ -1,0 +1,88 @@
+import path from 'path-browserify';
+import { MediaFileD } from '@model/mediafile';
+import { removeExtension } from './removeExtension';
+import cleanFileName from './cleanFileName';
+
+const MAX_STEM_LEN = 100;
+
+const safeBasename = (originalFile: string): string => {
+  const noQuery = (originalFile || '').split('?')[0] ?? '';
+  return path.basename(noQuery.replace(/\\/g, '/'));
+};
+
+const looksLikeHttpUrl = (s: string): boolean =>
+  /^https?:\/\//i.test((s || '').trim());
+
+const idStem = (m: MediaFileD): string => {
+  const id = m.keys?.remoteId || m.id;
+  const safe = String(id).replace(/[^a-zA-Z0-9-]/g, '');
+  return cleanFileName(`text-${safe.slice(0, 48)}`);
+};
+
+/**
+ * When `originalFile` holds inline document body (formatted text, markdown content, etc.)
+ * rather than a real file path, using `path.parse(originalFile).name` produces unusable paths.
+ */
+const inlineTextShouldUseIdStem = (m: MediaFileD): boolean => {
+  const ct = (m.attributes.contentType || '').split(';')[0].trim().toLowerCase();
+  if (!ct.startsWith('text/')) return false;
+  const raw = m.attributes.originalFile || '';
+  if (raw.length > MAX_STEM_LEN) return true;
+  if (/[\r\n]/.test(raw)) return true;
+  const base = safeBasename(raw);
+  // Reasonable uploaded filename: short basename with a normal extension
+  if (
+    base.length <= MAX_STEM_LEN &&
+    !/[\r\n]/.test(base) &&
+    /\.[a-z0-9]{1,10}$/i.test(base)
+  ) {
+    return false;
+  }
+  // Long single-line body without a file-like extension
+  if (raw.length > 48 && !/\.[a-z0-9]{1,10}$/i.test(base.trim())) return true;
+  return false;
+};
+
+/**
+ * Stable, filesystem-safe stem for burrito output names (no extension).
+ * Callers append `.${getMediaExt(m)}` or rely on processExportableMedia to set the final extension.
+ */
+export const getBurritoMediaExportStem = (m: MediaFileD): string => {
+  const raw = m.attributes.originalFile || '';
+
+  if (looksLikeHttpUrl(raw)) {
+    try {
+      const u = new URL(raw.trim());
+      const fromPath = safeBasename(u.pathname);
+      if (
+        fromPath &&
+        fromPath !== '/' &&
+        fromPath.length <= MAX_STEM_LEN &&
+        !/[\r\n]/.test(fromPath)
+      ) {
+        const { name } = removeExtension(fromPath);
+        if (name) return cleanFileName(name);
+      }
+      const host = (u.hostname || 'link').replace(/:/g, '_');
+      return cleanFileName(host);
+    } catch {
+      /* fall through */
+    }
+  }
+
+  if (inlineTextShouldUseIdStem(m)) {
+    return idStem(m);
+  }
+
+  const base = safeBasename(raw);
+  const { name } = removeExtension(base);
+  let stem = name || 'media';
+
+  if (stem.length > MAX_STEM_LEN) {
+    return idStem(m);
+  }
+
+  return cleanFileName(stem);
+};
+
+export default getBurritoMediaExportStem;

--- a/src/renderer/src/utils/burritoMediaFileStem.ts
+++ b/src/renderer/src/utils/burritoMediaFileStem.ts
@@ -24,7 +24,10 @@ const idStem = (m: MediaFileD): string => {
  * rather than a real file path, using `path.parse(originalFile).name` produces unusable paths.
  */
 const inlineTextShouldUseIdStem = (m: MediaFileD): boolean => {
-  const ct = (m.attributes.contentType || '').split(';')[0].trim().toLowerCase();
+  const ct = (m.attributes.contentType || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
   if (!ct.startsWith('text/')) return false;
   const raw = m.attributes.originalFile || '';
   if (raw.length > MAX_STEM_LEN) return true;
@@ -76,7 +79,7 @@ export const getBurritoMediaExportStem = (m: MediaFileD): string => {
 
   const base = safeBasename(raw);
   const { name } = removeExtension(base);
-  let stem = name || 'media';
+  const stem = name || 'media';
 
   if (stem.length > MAX_STEM_LEN) {
     return idStem(m);

--- a/src/renderer/src/utils/getMediaExt.test.ts
+++ b/src/renderer/src/utils/getMediaExt.test.ts
@@ -1,0 +1,24 @@
+import type { MediaFileD } from '@model/mediafile';
+import getMediaExt from './getMediaExt';
+
+describe('getMediaExt', () => {
+  it('uses basename only so path-like suffixes are not treated as extension', () => {
+    const media = {
+      attributes: {
+        originalFile: 'prefix.is\\bible\\engesv\\luk\\1',
+        contentType: 'text/plain',
+      },
+    } as MediaFileD;
+    expect(getMediaExt(media)).toBe('txt');
+  });
+
+  it('returns real extension from basename', () => {
+    const media = {
+      attributes: {
+        originalFile: 'https://example.com/foo/bar.mp3',
+        contentType: 'audio/mpeg',
+      },
+    } as MediaFileD;
+    expect(getMediaExt(media)).toBe('mp3');
+  });
+});

--- a/src/renderer/src/utils/getMediaExt.test.ts
+++ b/src/renderer/src/utils/getMediaExt.test.ts
@@ -21,4 +21,24 @@ describe('getMediaExt', () => {
     } as MediaFileD;
     expect(getMediaExt(media)).toBe('mp3');
   });
+
+  it('uses contentType for webm when basename has no valid extension', () => {
+    const media = {
+      attributes: {
+        originalFile: 'inline-recording',
+        contentType: 'audio/webm;codecs=opus',
+      },
+    } as MediaFileD;
+    expect(getMediaExt(media)).toBe('webm');
+  });
+
+  it('uses opus extension for audio/opus, not ogg', () => {
+    const media = {
+      attributes: {
+        originalFile: 'clip',
+        contentType: 'audio/opus',
+      },
+    } as MediaFileD;
+    expect(getMediaExt(media)).toBe('opus');
+  });
 });

--- a/src/renderer/src/utils/getMediaExt.ts
+++ b/src/renderer/src/utils/getMediaExt.ts
@@ -1,12 +1,41 @@
+import path from 'path-browserify';
 import { MediaFileD } from '@model/mediafile';
 import { removeExtension } from './removeExtension';
 
+/** Last path segment only, so URL/path strings do not produce bogus "extensions" with separators. */
+const safeFileBasename = (originalFile: string): string => {
+  const noQuery = (originalFile || '').split('?')[0] ?? '';
+  const unified = noQuery.replace(/\\/g, '/');
+  return path.basename(unified);
+};
+
+const isSafeExtensionSegment = (ext: string): boolean =>
+  /^[a-z0-9]{1,10}$/i.test(ext);
+
+const extFromContentType = (m: MediaFileD): string => {
+  const ct = (m.attributes.contentType || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+  if (ct === 'audio/mpeg') return 'mp3';
+  if (ct === 'audio/mp4' || ct === 'audio/x-m4a' || ct === 'audio/m4a')
+    return 'm4a';
+  if (ct === 'audio/wav' || ct === 'audio/x-wav') return 'wav';
+  if (ct === 'audio/ogg' || ct === 'audio/opus') return 'ogg';
+  if (ct === 'text/markdown') return 'md';
+  if (ct.startsWith('text/')) return 'txt';
+  if (ct.startsWith('audio/')) return 'mp3';
+  return 'dat';
+};
+
 const getMediaExt = (media: MediaFileD) => {
-  return (
-    removeExtension(media.attributes.originalFile)
-      .ext?.split('?')[0]
-      ?.toLowerCase() ?? ''
-  );
+  const base = safeFileBasename(media.attributes.originalFile || '');
+  let ext =
+    removeExtension(base).ext?.split('?')[0]?.trim().toLowerCase() ?? '';
+  if (!isSafeExtensionSegment(ext)) {
+    ext = extFromContentType(media);
+  }
+  return ext;
 };
 
 export default getMediaExt;

--- a/src/renderer/src/utils/getMediaExt.ts
+++ b/src/renderer/src/utils/getMediaExt.ts
@@ -1,5 +1,6 @@
 import path from 'path-browserify';
 import { MediaFileD } from '@model/mediafile';
+import { extensionFromAudioContentType } from './mimeTypes';
 import { removeExtension } from './removeExtension';
 
 /** Last path segment only, so URL/path strings do not produce bogus "extensions" with separators. */
@@ -17,14 +18,13 @@ const extFromContentType = (m: MediaFileD): string => {
     .split(';')[0]
     .trim()
     .toLowerCase();
-  if (ct === 'audio/mpeg') return 'mp3';
-  if (ct === 'audio/mp4' || ct === 'audio/x-m4a' || ct === 'audio/m4a')
-    return 'm4a';
-  if (ct === 'audio/wav' || ct === 'audio/x-wav') return 'wav';
-  if (ct === 'audio/ogg' || ct === 'audio/opus') return 'ogg';
+  const audioExt = extensionFromAudioContentType(
+    m.attributes.contentType || ''
+  );
+  if (audioExt) return audioExt;
   if (ct === 'text/markdown') return 'md';
   if (ct.startsWith('text/')) return 'txt';
-  if (ct.startsWith('audio/')) return 'mp3';
+  if (ct.startsWith('audio/')) return 'dat';
   return 'dat';
 };
 

--- a/src/renderer/src/utils/mimeTypes.ts
+++ b/src/renderer/src/utils/mimeTypes.ts
@@ -12,6 +12,27 @@ export const BURRITO_AUDIO_FILE_EXTENSIONS = new Set([
   '.flac',
 ]);
 
+/** Primary audio MIME (no parameters) → filename extension when the basename has no safe extension. */
+export const AUDIO_CONTENT_TYPE_TO_EXTENSION: Record<string, string> = {
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/m4a': 'm4a',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/ogg': 'ogg',
+  'audio/opus': 'opus',
+  'audio/webm': 'webm',
+  'audio/aac': 'aac',
+  'audio/flac': 'flac',
+};
+
+/** Maps `audio/…` MIME (strips `;codecs=` etc.) to a burrito file extension, or undefined if unknown. */
+export function extensionFromAudioContentType(mime: string): string | undefined {
+  const base = (mime ?? '').split(';')[0].trim().toLowerCase();
+  return AUDIO_CONTENT_TYPE_TO_EXTENSION[base];
+}
+
 export function inferAudioContentType(
   ingredientPath: string,
   declaredMime: string


### PR DESCRIPTION
- Introduced new utility functions for handling media file paths and extensions, improving file management.
- Updated the useBurritoAudio hook to ensure proper directory creation and error handling for media downloads.
- Added logic to prevent duplication of section-level resources during media export.
- Implemented new tests for getBurritoMediaExportStem and getMediaExt to validate media file handling.
- Refactored existing code for better readability and maintainability.