### PR TITLE
TT-7184 Enhance UserActionCell and ProfileDialog for offline handling

### DIFF
--- a/src/renderer/src/components/ProfileDialog.tsx
+++ b/src/renderer/src/components/ProfileDialog.tsx
@@ -790,7 +790,21 @@ export function ProfileDialog(props: ProfileDialogProps) {
 
   useEffect(() => setReadOnly(mode === 'viewMyAccount'), [mode]);
 
+  useEffect(() => {
+    if (mode !== 'editMember' || !editId || /Add/i.test(editId)) return;
+    if (isOffline || offlineOnly) setReadOnly(true);
+    else setReadOnly(false);
+  }, [mode, editId, isOffline, offlineOnly, open]);
+
   const onEditClicked = () => {
+    if (
+      mode === 'editMember' &&
+      editId &&
+      !/Add/i.test(editId) &&
+      (isOffline || offlineOnly)
+    ) {
+      return;
+    }
     setReadOnly(false);
   };
 

--- a/src/renderer/src/components/ProfileDialog.tsx
+++ b/src/renderer/src/components/ProfileDialog.tsx
@@ -792,19 +792,19 @@ export function ProfileDialog(props: ProfileDialogProps) {
 
   useEffect(() => {
     if (mode !== 'editMember' || !editId || /Add/i.test(editId)) return;
-    if (isOffline || offlineOnly) setReadOnly(true);
+    if (isOffline && !offlineOnly) setReadOnly(true);
     else setReadOnly(false);
   }, [mode, editId, isOffline, offlineOnly, open]);
 
+  const memberEditOfflineBlocked =
+    mode === 'editMember' &&
+    !!editId &&
+    !/Add/i.test(editId) &&
+    isOffline &&
+    !offlineOnly;
+
   const onEditClicked = () => {
-    if (
-      mode === 'editMember' &&
-      editId &&
-      !/Add/i.test(editId) &&
-      (isOffline || offlineOnly)
-    ) {
-      return;
-    }
+    if (memberEditOfflineBlocked) return;
     setReadOnly(false);
   };
 
@@ -863,7 +863,7 @@ export function ProfileDialog(props: ProfileDialogProps) {
             <Caption sx={profileEmailProps}>{email || ''}</Caption>
             {((editId && /Add/i.test(editId)) || !userNotComplete()) && (
               <Button
-                disabled={!readOnly}
+                disabled={!readOnly || memberEditOfflineBlocked}
                 variant="contained"
                 onClick={onEditClicked}
                 sx={editProfileProps}

--- a/src/renderer/src/components/UserActionCell.test.tsx
+++ b/src/renderer/src/components/UserActionCell.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import UserActionCell from './UserActionCell';
+import type { GridRenderCellParams } from '@mui/x-data-grid';
+import type { IRow } from './UserTable';
+
+jest.mock('../context/useGlobal', () => ({
+  useGlobal: (key: string) =>
+    key === 'user' ? ['admin-id', jest.fn()] : [null, jest.fn()],
+}));
+
+jest.mock('../crud/useRole', () => ({
+  useRole: () => ({ userIsAdmin: true }),
+}));
+
+const baseParams = {
+  id: 'other-user',
+  field: 'action',
+  value: 'other-user',
+  row: { id: 'other-user' } as IRow,
+  colDef: { field: 'action' },
+  api: {} as GridRenderCellParams<IRow>['api'],
+  hasFocus: false,
+  tabIndex: 0,
+} as GridRenderCellParams<IRow>;
+
+describe('UserActionCell', () => {
+  it('disables edit and delete when memberActionsEnabled is false (offline / offline-only)', () => {
+    render(
+      <UserActionCell
+        {...baseParams}
+        handleEdit={() => () => {}}
+        handleDelete={() => () => {}}
+        admins={[{ id: 'other-user', role: 'Admin' } as IRow]}
+        memberActionsEnabled={false}
+      />
+    );
+    expect(screen.getByLabelText('edit-other-user')).toBeDisabled();
+    expect(screen.getByLabelText('del-other-user')).toBeDisabled();
+  });
+
+  it('allows edit and delete for another user when admin and memberActionsEnabled', () => {
+    render(
+      <UserActionCell
+        {...baseParams}
+        handleEdit={() => () => {}}
+        handleDelete={() => () => {}}
+        admins={[
+          { id: 'admin-id', role: 'Admin' } as IRow,
+          { id: 'other-user', role: 'Admin' } as IRow,
+        ]}
+        memberActionsEnabled
+      />
+    );
+    expect(screen.getByLabelText('edit-other-user')).not.toBeDisabled();
+    expect(screen.getByLabelText('del-other-user')).not.toBeDisabled();
+  });
+});

--- a/src/renderer/src/components/UserActionCell.tsx
+++ b/src/renderer/src/components/UserActionCell.tsx
@@ -10,11 +10,19 @@ interface IProps {
   handleEdit: (userId: string) => () => void;
   handleDelete: (value: string) => () => void;
   admins: IRow[];
+  /** When false (offline or desktop offline-only), member row actions must stay disabled — local changes are not synced. */
+  memberActionsEnabled?: boolean;
 }
 
 export default function PlayCell(params: GridRenderCellParams<IRow> & IProps) {
   const [user] = useGlobal('user');
-  const { value, handleEdit, handleDelete, admins } = params;
+  const {
+    value,
+    handleEdit,
+    handleDelete,
+    admins,
+    memberActionsEnabled = true,
+  } = params;
   const { userIsAdmin } = useRole();
 
   const isCurrentUser = (userId: string) => userId === user;
@@ -27,7 +35,7 @@ export default function PlayCell(params: GridRenderCellParams<IRow> & IProps) {
         aria-label={'edit-' + value}
         color="default"
         onClick={handleEdit(value)}
-        disabled={isCurrentUser(value)}
+        disabled={!memberActionsEnabled || isCurrentUser(value)}
       >
         <EditIcon />
       </IconButton>
@@ -38,9 +46,10 @@ export default function PlayCell(params: GridRenderCellParams<IRow> & IProps) {
         color="default"
         onClick={handleDelete(value)}
         disabled={
-          userIsAdmin
+          !memberActionsEnabled ||
+          (userIsAdmin
             ? admins.length === 1 && isCurrentUser(value)
-            : !isCurrentUser(value)
+            : !isCurrentUser(value))
         }
       >
         <DeleteIcon />

--- a/src/renderer/src/components/UserTable.tsx
+++ b/src/renderer/src/components/UserTable.tsx
@@ -185,9 +185,14 @@ export function UserTable() {
     () => data.filter((d) => d.role === RoleNames.Admin),
     [data]
   );
+  /** Team membership changes (invite, add, edit, remove) only apply locally when offline; they are not synced to the server. */
+  const memberActionsEnabled = useMemo(
+    () => !offline && !offlineOnly,
+    [offline, offlineOnly]
+  );
   const canEdit = useMemo(
-    () => userIsAdmin && (!offline || offlineOnly),
-    [userIsAdmin, offline, offlineOnly]
+    () => userIsAdmin && memberActionsEnabled,
+    [userIsAdmin, memberActionsEnabled]
   );
 
   const columns: GridColDef<IRow>[] = [
@@ -198,7 +203,8 @@ export function UserTable() {
     { field: 'role', headerName: ts.teamrole, width: 100 },
     {
       field: 'action',
-      headerName: userIsAdmin ? t.action : '\u00A0',
+      headerName:
+        userIsAdmin && memberActionsEnabled ? t.action : '\u00A0',
       width: 150,
       sortable: false,
       filterable: false,
@@ -208,6 +214,7 @@ export function UserTable() {
           handleEdit={handleEdit}
           handleDelete={handleDelete}
           admins={admins}
+          memberActionsEnabled={memberActionsEnabled}
         />
       ),
     },

--- a/src/renderer/src/components/UserTable.tsx
+++ b/src/renderer/src/components/UserTable.tsx
@@ -182,12 +182,21 @@ export function UserTable() {
   }, [organization, users, roles, organizationMemberships]);
 
   const admins = useMemo(
-    () => data.filter((d) => d.role === RoleNames.Admin),
-    [data]
+    () =>
+      data.filter((d) => {
+        const rec = organizationMemberships.find(
+          (om) =>
+            related(om, 'user') === d.id &&
+            related(om, 'organization') === organization
+        );
+        const role = roles.find((r) => r.id === related(rec, 'role'));
+        return role && role.attributes.roleName === RoleNames.Admin;
+      }),
+    [data, organizationMemberships, roles, organization]
   );
-  /** Team membership changes (invite, add, edit, remove) only apply locally when offline; they are not synced to the server. */
+  /** Team membership changes are allowed when online, or when running as an offline-only desktop (local-first). They are blocked only when an online session has lost connectivity, since changes could not be synced. */
   const memberActionsEnabled = useMemo(
-    () => !offline && !offlineOnly,
+    () => !offline || offlineOnly,
     [offline, offlineOnly]
   );
   const canEdit = useMemo(
@@ -203,8 +212,7 @@ export function UserTable() {
     { field: 'role', headerName: ts.teamrole, width: 100 },
     {
       field: 'action',
-      headerName:
-        userIsAdmin && memberActionsEnabled ? t.action : '\u00A0',
+      headerName: userIsAdmin && memberActionsEnabled ? t.action : '\u00A0',
       width: 150,
       sortable: false,
       filterable: false,


### PR DESCRIPTION
- Added memberActionsEnabled prop to UserActionCell to control edit/delete button states based on offline status.
- Updated ProfileDialog to set read-only mode when offline or in specific edit scenarios.
- Introduced tests for UserActionCell to verify button states under different conditions.