### PR TITLE
TT-7335 Improve aesthetics of racetrack UI

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { legacy_createStore as createStore, combineReducers } from 'redux';
 import LocalizedStrings from 'react-localization';
@@ -11,23 +12,95 @@ import {
   PassageDetailContext,
   ICtxState,
 } from '../../../context/PassageDetailContext';
+import { UnsavedContext } from '../../../context/UnsavedContext';
 import MobileWorkflowSteps from './MobileWorkflowSteps';
 
-const createMockMemory = (): Memory =>
-  ({
+// Mock memory that resolves findRecord calls by a "type:id" lookup map
+const createMockMemory = (records: Record<string, any> = {}): Memory => {
+  const qb = {
+    findRecord: ({ type, id }: { type: string; id: string }) => ({ type, id }),
+  };
+  return {
     cache: {
-      query: () => [],
+      query: (fn: any) => {
+        if (typeof fn !== 'function') return undefined;
+        const spec = fn(qb);
+        return spec?.type && spec?.id
+          ? records[`${spec.type}:${spec.id}`]
+          : undefined;
+      },
       liveQuery: () => ({
         subscribe: () => () => {},
         query: () => [],
       }),
     },
     update: () => {},
-  }) as unknown as Memory;
+  } as unknown as Memory;
+};
 
 const mockCoordinator = {
   getSource: () => createMockMemory(),
 } as unknown as Coordinator;
+
+const stepProgressionOrgRecord = {
+  type: 'organization',
+  id: 'test-org',
+  attributes: {
+    defaultParams: JSON.stringify({ WorkflowProgression: 'step' }),
+  },
+};
+
+// Two passage records used in passage progression mode tests
+const mockSectionPassageRecords = {
+  'passage:p-1': {
+    id: 'p-1',
+    attributes: { sequencenum: 1, reference: '1:1', book: 'GEN' },
+  },
+  'passage:p-2': {
+    id: 'p-2',
+    attributes: { sequencenum: 2, reference: '1:2', book: 'GEN' },
+  },
+};
+
+// Extended set with an earlier passage (sequencenum 0) to cover the "complete" colour state
+const mockSectionPassageRecordsWithPrior = {
+  'passage:p-0': {
+    id: 'p-0',
+    attributes: { sequencenum: 0, reference: '1:0', book: 'GEN' },
+  },
+  ...mockSectionPassageRecords,
+};
+
+const mockSectionWithThreePassages = {
+  id: 'section-1',
+  relationships: {
+    passages: {
+      data: [
+        { type: 'passage', id: 'p-0' },
+        { type: 'passage', id: 'p-1' },
+        { type: 'passage', id: 'p-2' },
+      ],
+    },
+  },
+} as any;
+
+// Section whose passages relationship points to the records above
+const mockSection = {
+  id: 'section-1',
+  relationships: {
+    passages: {
+      data: [
+        { type: 'passage', id: 'p-1' },
+        { type: 'passage', id: 'p-2' },
+      ],
+    },
+  },
+} as any;
+
+const mockCurrentPassage = {
+  id: 'p-1',
+  attributes: { sequencenum: 1, reference: '1:1', book: 'GEN' },
+} as any;
 
 const createInitialState = (
   overrides: Partial<GlobalState> = {}
@@ -97,6 +170,24 @@ const mockStore = createStore(
   })
 );
 
+const mockUnsavedState = {
+  checkSavedFn: (method: () => void) => method(),
+  t: {} as any,
+  handleSaveConfirmed: () => {},
+  handleSaveRefused: () => {},
+  toolChanged: () => {},
+  startSave: () => {},
+  startClear: () => {},
+  saveCompleted: () => {},
+  clearCompleted: () => {},
+  waitForSave: async () => {},
+  anySaving: () => false as const,
+  saveRequested: () => false as const,
+  clearRequested: () => false as const,
+  isChanged: () => false as const,
+  toolsChanged: {},
+};
+
 const createPassageDetailState = (
   overrides: Partial<ICtxState> = {}
 ): ICtxState =>
@@ -110,6 +201,9 @@ const createPassageDetailState = (
     commentRecording: false,
     stepComplete: () => false,
     setCurrentStep: cy.stub(),
+    passage: mockCurrentPassage,
+    section: {} as any,
+    prjId: 'proj-1',
     ...overrides,
   }) as ICtxState;
 
@@ -120,6 +214,10 @@ const mountMobileWorkflowSteps = ({
   remoteBusy = false,
   recording = false,
   commentRecording = false,
+  isStepProgression = false,
+  section,
+  passage,
+  extraMemoryRecords = {},
 }: {
   currentstep?: string;
   workflow?: ICtxState['workflow'];
@@ -127,6 +225,10 @@ const mountMobileWorkflowSteps = ({
   remoteBusy?: boolean;
   recording?: boolean;
   commentRecording?: boolean;
+  isStepProgression?: boolean;
+  section?: any;
+  passage?: any;
+  extraMemoryRecords?: Record<string, any>;
 } = {}) => {
   const setCurrentStep = cy.stub().as('setCurrentStep');
   const ctxOverrides: Partial<ICtxState> = {
@@ -135,106 +237,290 @@ const mountMobileWorkflowSteps = ({
     commentRecording,
     setCurrentStep,
     stepComplete: (id: string) => completedStepIds.includes(id),
+    ...(section !== undefined ? { section } : {}),
+    ...(passage !== undefined ? { passage } : {}),
   };
-  if (workflow) {
-    ctxOverrides.workflow = workflow;
-  }
+  if (workflow) ctxOverrides.workflow = workflow;
   const ctxState = createPassageDetailState(ctxOverrides);
-  const initialState = createInitialState({ remoteBusy });
+
+  const mem = createMockMemory({
+    ...(isStepProgression
+      ? { 'organization:test-org': stepProgressionOrgRecord }
+      : {}),
+    ...extraMemoryRecords,
+  });
+  const initialState = createInitialState({ remoteBusy, memory: mem });
 
   cy.mount(
-    <Provider store={mockStore}>
-      <GlobalProvider init={initialState}>
-        <SnackBarProvider>
-          <PassageDetailContext.Provider
-            value={{ state: ctxState, setState: cy.stub() }}
-          >
-            <MobileWorkflowSteps />
-          </PassageDetailContext.Provider>
-        </SnackBarProvider>
-      </GlobalProvider>
-    </Provider>
+    <MemoryRouter>
+      <Provider store={mockStore}>
+        <GlobalProvider init={initialState}>
+          <SnackBarProvider>
+            <UnsavedContext.Provider
+              value={{ state: mockUnsavedState, setState: cy.stub() }}
+            >
+              <PassageDetailContext.Provider
+                value={{ state: ctxState, setState: cy.stub() }}
+              >
+                <MobileWorkflowSteps />
+              </PassageDetailContext.Provider>
+            </UnsavedContext.Provider>
+          </SnackBarProvider>
+        </GlobalProvider>
+      </Provider>
+    </MemoryRouter>
   );
 };
 
 describe('MobileWorkflowSteps', () => {
-  it('renders workflow steps and current label', () => {
-    mountMobileWorkflowSteps();
+  describe('step progression mode', () => {
+    it('renders workflow step parallelograms and current step label', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true });
 
-    cy.get('[data-cy="workflow-step"]').should('have.length', 2);
-    cy.get('[data-cy="workflow-step-label"]').should('contain.text', 'Record');
-  });
-
-  it('shows current, complete, and incomplete step colors', () => {
-    mountMobileWorkflowSteps({
-      workflow: [
-        { id: 'step-1', label: 'Record' },
-        { id: 'step-2', label: 'Review' },
-        { id: 'step-3', label: 'Publish' },
-      ],
-      completedStepIds: ['step-2'],
+      cy.get('[data-cy="workflow-step"]').should('have.length', 2);
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'Record'
+      );
     });
 
-    cy.get('[data-cy="workflow-step"]')
-      .eq(0)
-      .should('have.css', 'background-color', 'rgb(97, 97, 97)');
-    cy.get('[data-cy="workflow-step"]')
-      .eq(1)
-      .should('have.css', 'background-color', 'rgb(189, 189, 189)');
-    cy.get('[data-cy="workflow-step"]')
-      .eq(2)
-      .should('have.css', 'background-color', 'rgb(238, 238, 238)');
+    it('shows current, complete, and incomplete step colors', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        workflow: [
+          { id: 'step-1', label: 'Record' },
+          { id: 'step-2', label: 'Review' },
+          { id: 'step-3', label: 'Publish' },
+        ],
+        completedStepIds: ['step-2'],
+      });
+
+      cy.get('[data-cy="workflow-step"]')
+        .eq(0)
+        .should('have.css', 'background-color', 'rgb(97, 97, 97)');
+      cy.get('[data-cy="workflow-step"]')
+        .eq(1)
+        .should('have.css', 'background-color', 'rgb(189, 189, 189)');
+      cy.get('[data-cy="workflow-step"]')
+        .eq(2)
+        .should('have.css', 'background-color', 'rgb(238, 238, 238)');
+    });
+
+    it('shows a tip button in the step label area that opens a dialog', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true });
+
+      cy.get(
+        '[data-cy="workflow-step-label"] [data-cy="workflow-step-tip"]'
+      ).click();
+
+      cy.get('[role="dialog"]').should('be.visible');
+      cy.contains('Record tip').should('be.visible');
+      cy.contains('Close').click();
+      cy.get('[role="dialog"]').should('not.exist');
+    });
+
+    it('selects a different step when a parallelogram is clicked', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true });
+
+      cy.get('[data-cy="workflow-step"]').eq(1).click();
+
+      cy.get('@setCurrentStep').should('have.been.calledWith', 'step-2');
+    });
+
+    it('does not re-select the current step', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true });
+
+      cy.get('[data-cy="workflow-step"]').eq(0).click();
+
+      cy.get('@setCurrentStep').should('not.have.been.called');
+    });
+
+    it('blocks step selection and shows wait message when remote is busy', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true, remoteBusy: true });
+
+      cy.get('[data-cy="workflow-step"]').eq(1).click();
+
+      cy.get('@setCurrentStep').should('not.have.been.called');
+      cy.contains('Please wait').should('be.visible');
+    });
+
+    it('blocks step selection while recording', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true, recording: true });
+
+      cy.get('[data-cy="workflow-step"]').eq(1).click();
+
+      cy.get('@setCurrentStep').should('not.have.been.called');
+    });
+
+    it('blocks step selection while comment recording', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        commentRecording: true,
+      });
+
+      cy.get('[data-cy="workflow-step"]').eq(1).click();
+
+      cy.get('@setCurrentStep').should('not.have.been.called');
+    });
+
+    it('blocks passage dropdown while recording', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true, recording: true });
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('not.exist');
+    });
+
+    it('blocks passage dropdown and shows wait message when remote is busy', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true, remoteBusy: true });
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('not.exist');
+      cy.contains('Please wait').should('be.visible');
+    });
+
+    it('dropdown shows current passage book and reference', () => {
+      mountMobileWorkflowSteps({ isStepProgression: true });
+
+      cy.get('[data-cy="passage-dropdown"]').should('contain.text', 'GEN 1:1');
+    });
+
+    it('dropdown opens section passages as menu items', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('be.visible');
+      cy.get('[role="menuitem"]').should('have.length', 2);
+      cy.get('[role="menuitem"]').eq(0).should('contain.text', 'GEN 1:1');
+    });
+
+    it('renders the step label as plain text when the current step has no tip', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        currentstep: 'step-2',
+      });
+
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'Review'
+      );
+      cy.get('[data-cy="workflow-step-tip"]').should('not.exist');
+    });
   });
 
-  it('shows a tip dialog for the current step', () => {
-    mountMobileWorkflowSteps();
+  describe('passage progression mode', () => {
+    it('renders passage parallelograms for each section passage', () => {
+      mountMobileWorkflowSteps({
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
 
-    cy.get('[data-cy="workflow-step-tip"]').click();
+      cy.get('[data-cy="passage-step"]').should('have.length', 2);
+    });
 
-    cy.get('[role="dialog"]').should('be.visible');
-    cy.contains('Record tip').should('be.visible');
-    cy.contains('Close').click();
-    cy.get('[role="dialog"]').should('not.exist');
-  });
+    it('shows a tip button left of the dropdown that opens a dialog', () => {
+      mountMobileWorkflowSteps();
 
-  it('selects a different step when clicked', () => {
-    mountMobileWorkflowSteps();
+      cy.get('[data-cy="workflow-step-tip"]').click();
 
-    cy.get('[data-cy="workflow-step"]').eq(1).click();
+      cy.get('[role="dialog"]').should('be.visible');
+      cy.contains('Record tip').should('be.visible');
+      cy.contains('Close').click();
+      cy.get('[role="dialog"]').should('not.exist');
+    });
 
-    cy.get('@setCurrentStep').should('have.been.calledWith', 'step-2');
-  });
+    it('dropdown shows the current workflow step label', () => {
+      mountMobileWorkflowSteps();
 
-  it('does not re-select the current step', () => {
-    mountMobileWorkflowSteps();
+      cy.get('[data-cy="passage-dropdown"]').should('contain.text', 'Record');
+    });
 
-    cy.get('[data-cy="workflow-step"]').eq(0).click();
+    it('dropdown opens a menu with workflow step options', () => {
+      mountMobileWorkflowSteps();
 
-    cy.get('@setCurrentStep').should('not.have.been.called');
-  });
+      cy.get('[data-cy="passage-dropdown"]').click();
 
-  it('blocks selection and shows wait message when remote busy', () => {
-    mountMobileWorkflowSteps({ remoteBusy: true });
+      cy.get('[role="menu"]').should('be.visible');
+      cy.get('[role="menuitem"]').should('have.length', 2);
+    });
 
-    cy.get('[data-cy="workflow-step"]').eq(1).click();
+    it('blocks passage click while recording', () => {
+      mountMobileWorkflowSteps({
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+        recording: true,
+      });
 
-    cy.get('@setCurrentStep').should('not.have.been.called');
-    cy.contains('Please wait').should('be.visible');
-  });
+      cy.get('[data-cy="passage-step"]').eq(1).click();
 
-  it('blocks selection while recording', () => {
-    mountMobileWorkflowSteps({ recording: true });
+      cy.get('@setCurrentStep').should('not.have.been.called');
+    });
 
-    cy.get('[data-cy="workflow-step"]').eq(1).click();
+    it('blocks passage click and shows wait message when remote is busy', () => {
+      mountMobileWorkflowSteps({
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+        remoteBusy: true,
+      });
 
-    cy.get('@setCurrentStep').should('not.have.been.called');
-  });
+      cy.get('[data-cy="passage-step"]').eq(1).click();
 
-  it('blocks selection while comment recording', () => {
-    mountMobileWorkflowSteps({ commentRecording: true });
+      cy.contains('Please wait').should('be.visible');
+    });
 
-    cy.get('[data-cy="workflow-step"]').eq(1).click();
+    it('shows current, complete, and incomplete passage step colors', () => {
+      mountMobileWorkflowSteps({
+        section: mockSectionWithThreePassages,
+        extraMemoryRecords: mockSectionPassageRecordsWithPrior,
+      });
 
-    cy.get('@setCurrentStep').should('not.have.been.called');
+      // p-0 sequencenum 0 < current sequencenum 1 → complete
+      cy.get('[data-cy="passage-step"]')
+        .eq(0)
+        .should('have.css', 'background-color', 'rgb(189, 189, 189)');
+      // p-1 is current passage
+      cy.get('[data-cy="passage-step"]')
+        .eq(1)
+        .should('have.css', 'background-color', 'rgb(97, 97, 97)');
+      // p-2 sequencenum 2 > current sequencenum 1 → incomplete
+      cy.get('[data-cy="passage-step"]')
+        .eq(2)
+        .should('have.css', 'background-color', 'rgb(238, 238, 238)');
+    });
+
+    it('step label shows current passage book and reference', () => {
+      mountMobileWorkflowSteps();
+
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'GEN 1:1'
+      );
+    });
+
+    it('blocks dropdown while comment recording', () => {
+      mountMobileWorkflowSteps({ commentRecording: true });
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('not.exist');
+    });
+
+    it('blocks passage click while comment recording', () => {
+      mountMobileWorkflowSteps({
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+        commentRecording: true,
+      });
+
+      cy.get('[data-cy="passage-step"]').eq(1).click();
+
+      cy.get('@setCurrentStep').should('not.have.been.called');
+    });
   });
 });

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -19,7 +19,7 @@ import { useSnackBar } from '../../../hoc/SnackBar';
 import { sharedSelector, workflowStepsSelector } from '../../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useWfLabel } from '../../../utils/useWfLabel';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
 
@@ -80,6 +80,22 @@ export default function MobileWorkflowSteps() {
       : '';
   }, [currentLabel, t]);
 
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownWidth, setDropdownWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = dropdownRef.current;
+    if (!el) return;
+    const update = () => {
+      const style = window.getComputedStyle(el);
+      setDropdownWidth(el.offsetWidth + parseFloat(style.marginRight));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const didMountRef = useRef(false);
   const stepRefs = useRef(new Map<string, HTMLElement>());
 
@@ -105,7 +121,7 @@ export default function MobileWorkflowSteps() {
           width: '100%',
         }}
       >
-        <Box sx={{ flexShrink: 0, mr: 1 }}>
+        <Box ref={dropdownRef} sx={{ flexShrink: 0, mr: 1 }}>
           <Button
             size="small"
             endIcon={<ArrowDropDownIcon />}
@@ -138,50 +154,51 @@ export default function MobileWorkflowSteps() {
           sx={{
             flex: 1,
             display: 'flex',
-            justifyContent: 'flex-start',
             overflowX: 'auto',
             overflowY: 'hidden',
             WebkitOverflowScrolling: 'touch',
-            pb: 0.25,
           }}
         >
-          {workflow.map((step) => {
-            const isCurrent = step.id === currentstep;
-            return (
-              <ButtonBase
-                key={step.id}
-                data-cy="workflow-step"
-                role="button"
-                onClick={handleSelect(step.id)}
-                tabIndex={0}
-                ref={(el) => {
-                  if (el) {
-                    stepRefs.current.set(step.id, el);
-                  } else {
-                    stepRefs.current.delete(step.id);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                  }
-                }}
-                sx={{
-                  flex: '0 0 80px',
-                  height: 30,
-                  mr: -0.25,
-                  backgroundColor: isCurrent
-                    ? theme.palette.grey[700]
-                    : stepComplete(step.id)
-                      ? theme.palette.grey[400]
-                      : theme.palette.grey[200],
-                  clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                  cursor:
-                    recording || commentRecording ? 'not-allowed' : 'pointer',
-                }}
-              />
-            );
-          })}
+          <Box sx={{ display: 'flex', mx: 'auto', pb: 0.25 }}>
+            {workflow.map((step) => {
+              const isCurrent = step.id === currentstep;
+              return (
+                <ButtonBase
+                  key={step.id}
+                  data-cy="workflow-step"
+                  role="button"
+                  onClick={handleSelect(step.id)}
+                  tabIndex={0}
+                  ref={(el) => {
+                    if (el) {
+                      stepRefs.current.set(step.id, el);
+                    } else {
+                      stepRefs.current.delete(step.id);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                    }
+                  }}
+                  sx={{
+                    flex: '0 0 80px',
+                    height: 30,
+                    mr: -0.25,
+                    backgroundColor: isCurrent
+                      ? theme.palette.grey[700]
+                      : stepComplete(step.id)
+                        ? theme.palette.grey[400]
+                        : theme.palette.grey[200],
+                    clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                    cursor:
+                      recording || commentRecording ? 'not-allowed' : 'pointer',
+                  }}
+                />
+              );
+            })}
+            <Box sx={{ flexShrink: 0, width: dropdownWidth }} />
+          </Box>
         </Box>
       </Box>
       {currentLabel && (

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -130,7 +130,14 @@ export default function MobileWorkflowSteps() {
             size="small"
             endIcon={<ArrowDropDownIcon />}
             sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
-            onClick={(e) => setPassageMenuAnchor(e.currentTarget)}
+            onClick={(e) => {
+              if (recording || commentRecording) return;
+              if (getGlobal('remoteBusy')) {
+                showMessage(ts.wait);
+                return;
+              }
+              setPassageMenuAnchor(e.currentTarget);
+            }}
             data-cy="passage-dropdown"
           >
             {[passage?.attributes?.book, passage?.attributes?.reference]

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -67,13 +67,12 @@ export default function MobileWorkflowSteps() {
     }
   };
 
-  const currentLabel = useMemo(() => {
-    return workflow.find((w) => w.id === currentstep)?.label ?? '';
-  }, [currentstep, workflow]);
+  const currentLabel = useMemo(
+    () => workflow.find((w) => w.id === currentstep)?.label ?? '',
+    [currentstep, workflow]
+  );
   const currentTip = useMemo(() => {
-    if (!currentLabel) {
-      return '';
-    }
+    if (!currentLabel) return '';
     const tipKey = toCamel(currentLabel + 'Tip');
     return Object.prototype.hasOwnProperty.call(t, tipKey)
       ? t.getString(tipKey)
@@ -86,10 +85,10 @@ export default function MobileWorkflowSteps() {
   useLayoutEffect(() => {
     const el = dropdownRef.current;
     if (!el) return;
-    const update = () => {
-      const style = window.getComputedStyle(el);
-      setDropdownWidth(el.offsetWidth + parseFloat(style.marginRight));
-    };
+    const update = () =>
+      setDropdownWidth(
+        el.offsetWidth + parseFloat(window.getComputedStyle(el).marginRight)
+      );
     update();
     const ro = new ResizeObserver(update);
     ro.observe(el);
@@ -101,9 +100,7 @@ export default function MobileWorkflowSteps() {
 
   useEffect(() => {
     const el = stepRefs.current.get(currentstep);
-    if (!el) {
-      return;
-    }
+    if (!el) return;
     el.scrollIntoView({
       behavior: didMountRef.current ? 'smooth' : 'auto',
       block: 'nearest',
@@ -170,11 +167,8 @@ export default function MobileWorkflowSteps() {
                   onClick={handleSelect(step.id)}
                   tabIndex={0}
                   ref={(el) => {
-                    if (el) {
-                      stepRefs.current.set(step.id, el);
-                    } else {
-                      stepRefs.current.delete(step.id);
-                    }
+                    if (el) stepRefs.current.set(step.id, el);
+                    else stepRefs.current.delete(step.id);
                   }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -218,7 +212,7 @@ export default function MobileWorkflowSteps() {
               aria-label={currentTip}
             >
               {getWfLabel(currentLabel) + '\u00A0'}
-              <InfoIcon color={'info'} fontSize="small" />
+              <InfoIcon color="info" fontSize="small" />
             </ButtonBase>
           ) : (
             getWfLabel(currentLabel)

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -6,6 +6,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
   Menu,
   MenuItem,
   Typography,
@@ -142,7 +143,21 @@ export default function MobileWorkflowSteps() {
         }}
       >
         {/* Passage dropdown */}
-        <Box ref={dropdownRef} sx={{ flexShrink: 0, mr: 1 }}>
+        <Box
+          ref={dropdownRef}
+          sx={{ flexShrink: 0, mr: 1, display: 'flex', alignItems: 'center' }}
+        >
+          {!isStepProgression && currentTip && (
+            <IconButton
+              size="small"
+              onClick={() => setTipOpen(true)}
+              data-cy="workflow-step-tip"
+              aria-label={currentTip}
+              color="info"
+            >
+              <InfoIcon fontSize="small" />
+            </IconButton>
+          )}
           <Button
             size="small"
             endIcon={<ArrowDropDownIcon />}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -23,6 +23,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
 
+// TODO: Hook this up with real passages
 const mockPassages = [
   'Passage 1',
   'Passage 2',
@@ -118,6 +119,7 @@ export default function MobileWorkflowSteps() {
           width: '100%',
         }}
       >
+        {/* Passage dropdown */}
         <Box ref={dropdownRef} sx={{ flexShrink: 0, mr: 1 }}>
           <Button
             size="small"
@@ -133,6 +135,7 @@ export default function MobileWorkflowSteps() {
             open={Boolean(passageMenuAnchor)}
             onClose={() => setPassageMenuAnchor(null)}
           >
+            {/* TODO: Hook this up with real passages */}
             {mockPassages.map((p) => (
               <MenuItem
                 key={p}
@@ -147,6 +150,7 @@ export default function MobileWorkflowSteps() {
             ))}
           </Menu>
         </Box>
+        {/* Workflow step parallelograms */}
         <Box
           sx={{
             flex: 1,
@@ -178,7 +182,7 @@ export default function MobileWorkflowSteps() {
                   sx={{
                     flex: '0 0 80px',
                     height: 30,
-                    mr: -0.25,
+                    mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
                     backgroundColor: isCurrent
                       ? theme.palette.grey[700]
                       : stepComplete(step.id)
@@ -191,6 +195,7 @@ export default function MobileWorkflowSteps() {
                 />
               );
             })}
+            {/* Spacer to mirror the dropdown width so mx:auto centers the parallelograms */}
             <Box sx={{ flexShrink: 0, width: dropdownWidth }} />
           </Box>
         </Box>

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -26,6 +26,7 @@ import { related } from '../../../crud/related';
 import { findRecord } from '../../../crud/tryFindRecord';
 import { rememberCurrentPassage } from '../../../utils';
 import { usePassageNavigate } from '../usePassageNavigate';
+import { isPublishingTitle } from '../../../control/passageTypeFromRef';
 
 export default function MobileWorkflowSteps() {
   const {
@@ -55,7 +56,9 @@ export default function MobileWorkflowSteps() {
     if (!Array.isArray(passRecIds)) return [];
     return passRecIds
       .map((p) => findRecord(memory, 'passage', p.id) as PassageD)
-      .filter(Boolean)
+      .filter(
+        (p) => Boolean(p) && !isPublishingTitle(p?.attributes?.reference, false)
+      )
       .sort((a, b) => a.attributes.sequencenum - b.attributes.sequencenum);
   }, [section, memory]);
 

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -6,10 +6,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Menu,
+  MenuItem,
   Typography,
   useTheme,
 } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import usePassageDetailContext from '../../../context/usePassageDetailContext';
 import { useGetGlobal } from '../../../context/useGlobal';
 import { useSnackBar } from '../../../hoc/SnackBar';
@@ -19,6 +22,17 @@ import { useWfLabel } from '../../../utils/useWfLabel';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
+
+const mockPassages = [
+  'Passage 1',
+  'Passage 2',
+  'Passage 3',
+  'Passage 4',
+  'Passage 5',
+  'Passage 6',
+  'Passage 7',
+  'Passage 8',
+];
 
 export default function MobileWorkflowSteps() {
   const {
@@ -39,6 +53,9 @@ export default function MobileWorkflowSteps() {
     shallowEqual
   );
   const [tipOpen, setTipOpen] = useState(false);
+  const [passageMenuAnchor, setPassageMenuAnchor] =
+    useState<HTMLElement | null>(null);
+  const [passageRef, setPassageRef] = useState(mockPassages[0]);
 
   const handleSelect = (id: string) => () => {
     if (getGlobal('remoteBusy')) {
@@ -84,50 +101,88 @@ export default function MobileWorkflowSteps() {
       <Box
         sx={{
           display: 'flex',
-          justifyContent: 'flex-start',
-          overflowX: 'auto',
-          overflowY: 'hidden',
-          WebkitOverflowScrolling: 'touch',
-          pb: 0.25,
+          alignItems: 'flex-start',
+          width: '100%',
         }}
       >
-        {workflow.map((step) => {
-          const isCurrent = step.id === currentstep;
-          return (
-            <ButtonBase
-              key={step.id}
-              data-cy="workflow-step"
-              role="button"
-              onClick={handleSelect(step.id)}
-              tabIndex={0}
-              ref={(el) => {
-                if (el) {
-                  stepRefs.current.set(step.id, el);
-                } else {
-                  stepRefs.current.delete(step.id);
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                }
-              }}
-              sx={{
-                flex: '0 0 80px',
-                height: 30,
-                mr: -0.25,
-                backgroundColor: isCurrent
-                  ? theme.palette.grey[700]
-                  : stepComplete(step.id)
-                    ? theme.palette.grey[400]
-                    : theme.palette.grey[200],
-                clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                cursor:
-                  recording || commentRecording ? 'not-allowed' : 'pointer',
-              }}
-            />
-          );
-        })}
+        <Box sx={{ flexShrink: 0, mr: 1 }}>
+          <Button
+            size="small"
+            endIcon={<ArrowDropDownIcon />}
+            sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+            onClick={(e) => setPassageMenuAnchor(e.currentTarget)}
+            data-cy="passage-dropdown"
+          >
+            {passageRef}
+          </Button>
+          <Menu
+            anchorEl={passageMenuAnchor}
+            open={Boolean(passageMenuAnchor)}
+            onClose={() => setPassageMenuAnchor(null)}
+          >
+            {mockPassages.map((p) => (
+              <MenuItem
+                key={p}
+                selected={p === passageRef}
+                onClick={() => {
+                  setPassageRef(p);
+                  setPassageMenuAnchor(null);
+                }}
+              >
+                {p}
+              </MenuItem>
+            ))}
+          </Menu>
+        </Box>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'flex-start',
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            WebkitOverflowScrolling: 'touch',
+            pb: 0.25,
+          }}
+        >
+          {workflow.map((step) => {
+            const isCurrent = step.id === currentstep;
+            return (
+              <ButtonBase
+                key={step.id}
+                data-cy="workflow-step"
+                role="button"
+                onClick={handleSelect(step.id)}
+                tabIndex={0}
+                ref={(el) => {
+                  if (el) {
+                    stepRefs.current.set(step.id, el);
+                  } else {
+                    stepRefs.current.delete(step.id);
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                  }
+                }}
+                sx={{
+                  flex: '0 0 80px',
+                  height: 30,
+                  mr: -0.25,
+                  backgroundColor: isCurrent
+                    ? theme.palette.grey[700]
+                    : stepComplete(step.id)
+                      ? theme.palette.grey[400]
+                      : theme.palette.grey[200],
+                  clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                  cursor:
+                    recording || commentRecording ? 'not-allowed' : 'pointer',
+                }}
+              />
+            );
+          })}
+        </Box>
       </Box>
       {currentLabel && (
         <Typography

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -14,26 +14,18 @@ import {
 import InfoIcon from '@mui/icons-material/Info';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import usePassageDetailContext from '../../../context/usePassageDetailContext';
-import { useGetGlobal } from '../../../context/useGlobal';
+import { useGetGlobal, useGlobal } from '../../../context/useGlobal';
 import { useSnackBar } from '../../../hoc/SnackBar';
 import { sharedSelector, workflowStepsSelector } from '../../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useWfLabel } from '../../../utils/useWfLabel';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { IWorkflowStepsStrings } from '../../../model';
+import { IWorkflowStepsStrings, PassageD } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
-
-// TODO: Hook this up with real passages
-const mockPassages = [
-  'Passage 1',
-  'Passage 2',
-  'Passage 3',
-  'Passage 4',
-  'Passage 5',
-  'Passage 6',
-  'Passage 7',
-  'Passage 8',
-];
+import { related } from '../../../crud/related';
+import { findRecord } from '../../../crud/tryFindRecord';
+import { rememberCurrentPassage } from '../../../utils';
+import { usePassageNavigate } from '../usePassageNavigate';
 
 export default function MobileWorkflowSteps() {
   const {
@@ -43,7 +35,12 @@ export default function MobileWorkflowSteps() {
     recording,
     commentRecording,
     stepComplete,
+    passage,
+    section,
+    prjId,
   } = usePassageDetailContext();
+  const [memory] = useGlobal('memory');
+  const passageNavigate = usePassageNavigate(() => {}, setCurrentStep);
   const getGlobal = useGetGlobal();
   const { showMessage } = useSnackBar();
   const ts = useSelector(sharedSelector, shallowEqual);
@@ -53,10 +50,18 @@ export default function MobileWorkflowSteps() {
     workflowStepsSelector,
     shallowEqual
   );
+  const sectionPassages = useMemo<PassageD[]>(() => {
+    const passRecIds = related(section, 'passages');
+    if (!Array.isArray(passRecIds)) return [];
+    return passRecIds
+      .map((p) => findRecord(memory, 'passage', p.id) as PassageD)
+      .filter(Boolean)
+      .sort((a, b) => a.attributes.sequencenum - b.attributes.sequencenum);
+  }, [section, memory]);
+
   const [tipOpen, setTipOpen] = useState(false);
   const [passageMenuAnchor, setPassageMenuAnchor] =
     useState<HTMLElement | null>(null);
-  const [passageRef, setPassageRef] = useState(mockPassages[0]);
 
   const handleSelect = (id: string) => () => {
     if (getGlobal('remoteBusy')) {
@@ -128,24 +133,29 @@ export default function MobileWorkflowSteps() {
             onClick={(e) => setPassageMenuAnchor(e.currentTarget)}
             data-cy="passage-dropdown"
           >
-            {passageRef}
+            {[passage?.attributes?.book, passage?.attributes?.reference]
+              .filter(Boolean)
+              .join(' ') || ''}
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}
             open={Boolean(passageMenuAnchor)}
             onClose={() => setPassageMenuAnchor(null)}
           >
-            {/* TODO: Hook this up with real passages */}
-            {mockPassages.map((p) => (
+            {sectionPassages.map((p) => (
               <MenuItem
-                key={p}
-                selected={p === passageRef}
+                key={p.id}
+                selected={p.id === passage?.id}
                 onClick={() => {
-                  setPassageRef(p);
+                  const remId = p.keys?.remoteId ?? p.id;
+                  rememberCurrentPassage(memory, remId);
+                  passageNavigate(`/detail/${prjId}/${remId}`);
                   setPassageMenuAnchor(null);
                 }}
               >
-                {p}
+                {[p.attributes.book, p.attributes.reference]
+                  .filter(Boolean)
+                  .join(' ')}
               </MenuItem>
             ))}
           </Menu>

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -85,7 +85,6 @@ export default function MobileWorkflowSteps() {
         sx={{
           display: 'flex',
           justifyContent: 'flex-start',
-          gap: 0.75,
           overflowX: 'auto',
           overflowY: 'hidden',
           WebkitOverflowScrolling: 'touch',
@@ -114,18 +113,17 @@ export default function MobileWorkflowSteps() {
                 }
               }}
               sx={{
-                width: 36,
-                height: 14,
+                flex: '0 0 80px',
+                height: 30,
+                mr: -0.25,
                 backgroundColor: isCurrent
                   ? theme.palette.grey[700]
                   : stepComplete(step.id)
                     ? theme.palette.grey[400]
                     : theme.palette.grey[200],
-                transform: 'skewX(-20deg)',
-                borderRadius: '2px',
+                clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
                 cursor:
                   recording || commentRecording ? 'not-allowed' : 'pointer',
-                flexShrink: 0,
               }}
             />
           );

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -131,15 +131,18 @@ export default function MobileWorkflowSteps() {
       </Box>
       {currentLabel && (
         <Typography
-          variant="caption"
-          sx={{ display: 'block', textAlign: 'center' }}
+          sx={{ mt: 1, textAlign: 'center' }}
           data-cy="workflow-step-label"
         >
           {currentTip ? (
             <ButtonBase
               onClick={() => setTipOpen(true)}
               data-cy="workflow-step-tip"
-              sx={{ borderRadius: 1 }}
+              sx={{
+                borderRadius: 1,
+                fontWeight: 'inherit',
+                fontSize: 'inherit',
+              }}
               aria-label={currentTip}
             >
               {getWfLabel(currentLabel) + '\u00A0'}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -27,6 +27,10 @@ import { findRecord } from '../../../crud/tryFindRecord';
 import { rememberCurrentPassage } from '../../../utils';
 import { usePassageNavigate } from '../usePassageNavigate';
 import { isPublishingTitle } from '../../../control/passageTypeFromRef';
+import {
+  orgDefaultWorkflowProgression,
+  useOrgDefaults,
+} from '../../../crud/useOrgDefaults';
 
 export default function MobileWorkflowSteps() {
   const {
@@ -47,6 +51,9 @@ export default function MobileWorkflowSteps() {
   const ts = useSelector(sharedSelector, shallowEqual);
   const theme = useTheme();
   const getWfLabel = useWfLabel();
+  const { getOrgDefault } = useOrgDefaults();
+  const isStepProgression =
+    getOrgDefault(orgDefaultWorkflowProgression) === 'step';
   const t: IWorkflowStepsStrings = useSelector(
     workflowStepsSelector,
     shallowEqual
@@ -108,7 +115,8 @@ export default function MobileWorkflowSteps() {
   const stepRefs = useRef(new Map<string, HTMLElement>());
 
   useEffect(() => {
-    const el = stepRefs.current.get(currentstep);
+    const currentId = isStepProgression ? currentstep : (passage?.id ?? '');
+    const el = stepRefs.current.get(currentId);
     if (!el) return;
     el.scrollIntoView({
       behavior: didMountRef.current ? 'smooth' : 'auto',
@@ -116,7 +124,13 @@ export default function MobileWorkflowSteps() {
       inline: 'center',
     });
     didMountRef.current = true;
-  }, [currentstep, workflow.length]);
+  }, [
+    currentstep,
+    passage?.id,
+    workflow.length,
+    sectionPassages.length,
+    isStepProgression,
+  ]);
 
   return (
     <Box sx={{ px: 1.5, py: 1 }} data-cy="workflow-steps">
@@ -143,31 +157,46 @@ export default function MobileWorkflowSteps() {
             }}
             data-cy="passage-dropdown"
           >
-            {[passage?.attributes?.book, passage?.attributes?.reference]
-              .filter(Boolean)
-              .join(' ') || ''}
+            {isStepProgression
+              ? [passage?.attributes?.book, passage?.attributes?.reference]
+                  .filter(Boolean)
+                  .join(' ') || ''
+              : currentLabel}
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}
             open={Boolean(passageMenuAnchor)}
             onClose={() => setPassageMenuAnchor(null)}
           >
-            {sectionPassages.map((p) => (
-              <MenuItem
-                key={p.id}
-                selected={p.id === passage?.id}
-                onClick={() => {
-                  const remId = p.keys?.remoteId ?? p.id;
-                  rememberCurrentPassage(memory, remId);
-                  passageNavigate(`/detail/${prjId}/${remId}`);
-                  setPassageMenuAnchor(null);
-                }}
-              >
-                {[p.attributes.book, p.attributes.reference]
-                  .filter(Boolean)
-                  .join(' ')}
-              </MenuItem>
-            ))}
+            {isStepProgression
+              ? sectionPassages.map((p) => (
+                  <MenuItem
+                    key={p.id}
+                    selected={p.id === passage?.id}
+                    onClick={() => {
+                      const remId = p.keys?.remoteId ?? p.id;
+                      rememberCurrentPassage(memory, remId);
+                      passageNavigate(`/detail/${prjId}/${remId}`);
+                      setPassageMenuAnchor(null);
+                    }}
+                  >
+                    {[p.attributes.book, p.attributes.reference]
+                      .filter(Boolean)
+                      .join(' ')}
+                  </MenuItem>
+                ))
+              : workflow.map((step) => (
+                  <MenuItem
+                    key={step.id}
+                    selected={step.id === currentstep}
+                    onClick={() => {
+                      handleSelect(step.id)();
+                      setPassageMenuAnchor(null);
+                    }}
+                  >
+                    {getWfLabel(step.label)}
+                  </MenuItem>
+                ))}
           </Menu>
         </Box>
         {/* Workflow step parallelograms */}
@@ -181,66 +210,123 @@ export default function MobileWorkflowSteps() {
           }}
         >
           <Box sx={{ display: 'flex', mx: 'auto', pb: 0.25 }}>
-            {workflow.map((step) => {
-              const isCurrent = step.id === currentstep;
-              return (
-                <ButtonBase
-                  key={step.id}
-                  data-cy="workflow-step"
-                  role="button"
-                  onClick={handleSelect(step.id)}
-                  tabIndex={0}
-                  ref={(el) => {
-                    if (el) stepRefs.current.set(step.id, el);
-                    else stepRefs.current.delete(step.id);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                    }
-                  }}
-                  sx={{
-                    flex: '0 0 80px',
-                    height: 30,
-                    mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
-                    backgroundColor: isCurrent
-                      ? theme.palette.grey[700]
-                      : stepComplete(step.id)
-                        ? theme.palette.grey[400]
-                        : theme.palette.grey[200],
-                    clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                    cursor:
-                      recording || commentRecording ? 'not-allowed' : 'pointer',
-                  }}
-                />
-              );
-            })}
+            {isStepProgression
+              ? workflow.map((step) => {
+                  const isCurrent = step.id === currentstep;
+                  return (
+                    <ButtonBase
+                      key={step.id}
+                      data-cy="workflow-step"
+                      role="button"
+                      onClick={handleSelect(step.id)}
+                      tabIndex={0}
+                      ref={(el) => {
+                        if (el) stepRefs.current.set(step.id, el);
+                        else stepRefs.current.delete(step.id);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                        }
+                      }}
+                      sx={{
+                        flex: '0 0 80px',
+                        height: 30,
+                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
+                        backgroundColor: isCurrent
+                          ? theme.palette.grey[700]
+                          : stepComplete(step.id)
+                            ? theme.palette.grey[400]
+                            : theme.palette.grey[200],
+                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                        cursor:
+                          recording || commentRecording
+                            ? 'not-allowed'
+                            : 'pointer',
+                      }}
+                    />
+                  );
+                })
+              : sectionPassages.map((p) => {
+                  const isCurrent = p.id === passage?.id;
+                  const isComplete =
+                    (p.attributes.sequencenum ?? 0) <
+                    (passage?.attributes?.sequencenum ?? 0);
+                  return (
+                    <ButtonBase
+                      key={p.id}
+                      data-cy="passage-step"
+                      role="button"
+                      onClick={() => {
+                        if (recording || commentRecording) return;
+                        if (getGlobal('remoteBusy')) {
+                          showMessage(ts.wait);
+                          return;
+                        }
+                        const remId = p.keys?.remoteId ?? p.id;
+                        rememberCurrentPassage(memory, remId);
+                        passageNavigate(`/detail/${prjId}/${remId}`);
+                      }}
+                      tabIndex={0}
+                      ref={(el) => {
+                        if (el) stepRefs.current.set(p.id, el);
+                        else stepRefs.current.delete(p.id);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                        }
+                      }}
+                      sx={{
+                        flex: '0 0 80px',
+                        height: 30,
+                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
+                        backgroundColor: isCurrent
+                          ? theme.palette.grey[700]
+                          : isComplete
+                            ? theme.palette.grey[400]
+                            : theme.palette.grey[200],
+                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                        cursor:
+                          recording || commentRecording
+                            ? 'not-allowed'
+                            : 'pointer',
+                      }}
+                    />
+                  );
+                })}
             {/* Spacer to mirror the dropdown width so mx:auto centers the parallelograms */}
             <Box sx={{ flexShrink: 0, width: dropdownWidth }} />
           </Box>
         </Box>
       </Box>
-      {currentLabel && (
+      {(isStepProgression ? currentLabel : passage?.id) && (
         <Typography
           sx={{ mt: 1, textAlign: 'center' }}
           data-cy="workflow-step-label"
         >
-          {currentTip ? (
-            <ButtonBase
-              onClick={() => setTipOpen(true)}
-              data-cy="workflow-step-tip"
-              sx={{
-                borderRadius: 1,
-                fontWeight: 'inherit',
-                fontSize: 'inherit',
-              }}
-              aria-label={currentTip}
-            >
-              {getWfLabel(currentLabel) + '\u00A0'}
-              <InfoIcon color="info" fontSize="small" />
-            </ButtonBase>
+          {isStepProgression ? (
+            currentTip ? (
+              <ButtonBase
+                onClick={() => setTipOpen(true)}
+                data-cy="workflow-step-tip"
+                sx={{
+                  borderRadius: 1,
+                  fontWeight: 'inherit',
+                  fontSize: 'inherit',
+                }}
+                aria-label={currentTip}
+              >
+                {getWfLabel(currentLabel) + '\u00A0'}
+                <InfoIcon color="info" fontSize="small" />
+              </ButtonBase>
+            ) : (
+              getWfLabel(currentLabel)
+            )
           ) : (
-            getWfLabel(currentLabel)
+            [passage?.attributes?.book, passage?.attributes?.reference]
+              .filter(Boolean)
+              .join(' ')
           )}
         </Typography>
       )}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -80,7 +80,7 @@ export default function MobileWorkflowSteps() {
   }, [currentstep, workflow.length]);
 
   return (
-    <Box sx={{ px: 1.5, py: 0.5 }} data-cy="workflow-steps">
+    <Box sx={{ px: 1.5, py: 1 }} data-cy="workflow-steps">
       <Box
         sx={{
           display: 'flex',


### PR DESCRIPTION
**Changes:**
- Make the parallelograms (i.e., racetrack) bigger
- Add dropdown for passage navigation (and make sure it works differently depending on the passage progression mode) -- the actual button styling will need to be adjusted by theme control, which is out of scope for this PR
- Fix how the racetrack centers itself on bigger screens (e.g., tablets and laptop screens)

**Before:**
<img width="390" height="240" alt="Before" src="https://github.com/user-attachments/assets/47812024-7218-48e0-b769-fedcbecbf825" />

**After:**
<img width="390" height="271" alt="After" src="https://github.com/user-attachments/assets/6134e314-1ecb-4b10-ae5e-0e3ddb22577a" />