### PR TITLE
TT-7351 Refactor audio and navigation properties to use 'x-apmId' instead of 'apmId'

### DIFF
--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -284,7 +284,7 @@ describe('useBurritoAudio', () => {
     });
 
     const audioIngredient = Object.entries(metadata.ingredients).find(
-      ([, ing]) => ing?.properties?.apmId === '35928'
+      ([, ing]) => ing?.properties?.['x-apmId'] === '35928'
     );
     expect(audioIngredient).toBeDefined();
     expect(audioIngredient![0].toLowerCase().endsWith('.mp3')).toBe(true);
@@ -361,7 +361,7 @@ describe('useBurritoAudio', () => {
 
     expect(ipc.copyFile).toHaveBeenCalled();
     const ipIngredient = Object.entries(metadata.ingredients).find(
-      ([, ing]) => ing?.properties?.apmId === 'remote-ip-1'
+      ([, ing]) => ing?.properties?.['x-apmId'] === 'remote-ip-1'
     );
     expect(ipIngredient).toBeDefined();
     expect(ipIngredient![0]).toContain('rights-statement');

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -242,7 +242,7 @@ export const useBurritoAudio = (teamId: string) => {
         size,
         scope: { [book]: scopeRef ? [scopeRef] : [] },
         properties: {
-          apmId: m.keys?.remoteId || m.id,
+          'x-apmId': m.keys?.remoteId || m.id,
         },
       };
     };
@@ -265,7 +265,7 @@ export const useBurritoAudio = (teamId: string) => {
         size: attr.originalFile.length,
         scope: { [book]: scopeRef ? [scopeRef] : [] },
         properties: {
-          apmId: m.keys?.remoteId || m.id,
+          'x-apmId': m.keys?.remoteId || m.id,
         },
       };
     };
@@ -289,7 +289,7 @@ export const useBurritoAudio = (teamId: string) => {
         size: attr.originalFile.length,
         scope: { [book]: scopeRef ? [scopeRef] : [] },
         properties: {
-          apmId: m.keys?.remoteId || m.id,
+          'x-apmId': m.keys?.remoteId || m.id,
         },
       };
     };
@@ -311,7 +311,7 @@ export const useBurritoAudio = (teamId: string) => {
         size: url.length + 1,
         scope: { [book]: scopeRef ? [scopeRef] : [] },
         properties: {
-          apmId: m.keys?.remoteId || m.id,
+          'x-apmId': m.keys?.remoteId || m.id,
         },
       };
     };

--- a/src/renderer/src/burrito/useBurritoNavigation.ts
+++ b/src/renderer/src/burrito/useBurritoNavigation.ts
@@ -279,7 +279,7 @@ export const useBurritoNavigation = (teamId: string) => {
         size,
         scope: { [book]: scopeRef ? [scopeRef] : [] },
         properties: {
-          apmId: m.keys?.remoteId || m.id,
+          'x-apmId': m.keys?.remoteId || m.id,
         },
       };
       return true;
@@ -372,7 +372,7 @@ export const useBurritoNavigation = (teamId: string) => {
             size: stat?.size ?? 0,
             scope: { [book]: scopeRef ? [scopeRef] : [] },
             properties: {
-              apmId: g.keys?.remoteId || g.id,
+              'x-apmId': g.keys?.remoteId || g.id,
             },
           };
           graphicsManifest.push({


### PR DESCRIPTION
- Updated useBurritoAudio and useBurritoNavigation to change property key from 'apmId' to 'x-apmId' for consistency.
- Adjusted related test cases to reflect the property name change.