### PR TITLE
TT-7375 Implement edit reference normalization and save button state management in EditReferenceDropdown

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -13,6 +13,8 @@ import {
 import type { ChangeEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import {
+  editReferenceValuesEqual,
+  normalizeEditReferenceDraft,
   type PassageVerseOption,
   toPassageVerseKey,
 } from '../../../../utils/markVersesPassageVerses';
@@ -83,7 +85,13 @@ export default function EditReferenceDropdown({
   onSave,
 }: EditReferenceDropdownProps) {
   const [draft, setDraft] = useState<EditReferenceValue>(value);
+  const [initialSnapshot, setInitialSnapshot] =
+    useState<EditReferenceValue>(value);
   const endSelectValue = toPassageVerseKey(draft.endChapter, draft.endVerse);
+  const isDirty = useMemo(
+    () => !editReferenceValuesEqual(draft, initialSnapshot),
+    [draft, initialSnapshot]
+  );
 
   const resolvedEndOptions = useMemo(() => {
     if (endVerseOptions.length > 0) return endVerseOptions;
@@ -102,14 +110,9 @@ export default function EditReferenceDropdown({
 
   useEffect(() => {
     if (!open) return;
-    const splitVerse =
-      /^[a-e]$/i.test(value.startSuffix) || /^[a-e]$/i.test(value.endSuffix);
-    setDraft({
-      ...value,
-      splitVerse,
-      startSuffix: splitVerse ? value.startSuffix : '',
-      endSuffix: splitVerse ? value.endSuffix : '',
-    });
+    const normalized = normalizeEditReferenceDraft(value);
+    setDraft(normalized);
+    setInitialSnapshot(normalized);
   }, [open, value]);
 
   const handleSplitChange = (
@@ -274,7 +277,11 @@ export default function EditReferenceDropdown({
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
         <Button onClick={onCancel}>{cancelLabel}</Button>
-        <Button variant="contained" onClick={() => onSave(draft)}>
+        <Button
+          variant="contained"
+          disabled={!isDirty}
+          onClick={() => onSave(draft)}
+        >
           {saveLabel}
         </Button>
       </DialogActions>

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.test.tsx
@@ -513,6 +513,78 @@ test('opens and cancels the split verse dialog', async () => {
   ).not.toBeInTheDocument();
 });
 
+test('disables Save on Edit Reference until the reference changes', async () => {
+  const user = userEvent.setup();
+
+  runTest({ width: 375 });
+
+  await waitForPassageRowsReady();
+
+  act(() => {
+    mockPlayerAction?.(
+      '{"regions":"[{\\"start\\":0,\\"end\\":10},{\\"start\\":10,\\"end\\":20},{\\"start\\":20,\\"end\\":69}]"}',
+      false
+    );
+  });
+
+  await within(markVersesTbody()).findByText('0:00-0:10');
+
+  await clickMarkVersesRowByLimitsText(user, '0:00-0:10');
+  await user.click(screen.getByRole('button', { name: 'Edit Reference' }));
+
+  const saveButton = within(editReferenceDialog()).getByRole('button', {
+    name: 'Save',
+  });
+  expect(saveButton).toBeDisabled();
+
+  await user.selectOptions(
+    within(editReferenceDialog()).getByLabelText('end verse number'),
+    '2'
+  );
+  expect(saveButton).not.toBeDisabled();
+
+  await user.selectOptions(
+    within(editReferenceDialog()).getByLabelText('end verse number'),
+    '1'
+  );
+  expect(saveButton).toBeDisabled();
+});
+
+test('keeps Save disabled when Split Verse is toggled without suffix change', async () => {
+  const user = userEvent.setup();
+
+  runTest({ width: 375 });
+
+  await waitForPassageRowsReady();
+
+  act(() => {
+    mockPlayerAction?.(
+      '{"regions":"[{\\"start\\":0,\\"end\\":10},{\\"start\\":10,\\"end\\":20},{\\"start\\":20,\\"end\\":69}]"}',
+      false
+    );
+  });
+
+  await within(markVersesTbody()).findByText('0:00-0:10');
+
+  await clickMarkVersesRowByLimitsText(user, '0:00-0:10');
+  await user.click(screen.getByRole('button', { name: 'Edit Reference' }));
+
+  const saveButton = within(editReferenceDialog()).getByRole('button', {
+    name: 'Save',
+  });
+  expect(saveButton).toBeDisabled();
+
+  await user.click(
+    within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
+  );
+  expect(saveButton).toBeDisabled();
+
+  await user.click(
+    within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
+  );
+  expect(saveButton).toBeDisabled();
+});
+
 test('saves a split verse range and shifts following references up', async () => {
   const user = userEvent.setup();
 

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.tsx
@@ -57,11 +57,13 @@ import Confirm from '../../../AlertDialog';
 import { type WSAudioPlayerControls } from '../../../WSAudioPlayer';
 import { isMarkVersesTableTailIncomplete } from '../../../../utils/markVersesSegmentColors';
 import {
+  editReferenceValuesEqual,
   formatMarkVersesReference,
   getEndingVerseOptions,
   incrementMarkVersesReferenceSuffix,
   markVersesReferenceHasLetterSuffix,
   nextMarkVersesLetterSuffix,
+  normalizeEditReferenceDraft,
   parseMarkVersesReference,
 } from '../../../../utils/markVersesPassageVerses';
 import PassageDetailPlayer from '../../PassageDetailPlayer';
@@ -1001,6 +1003,12 @@ export default function PassageDetailMarkVersesIsMobile({
 
   const handleSaveSplitVerseDialog = (value: EditReferenceValue) => {
     if (!editReferenceDialog) return;
+
+    const openingValue = normalizeEditReferenceDraft(editReferenceDialog);
+    if (editReferenceValuesEqual(value, openingValue)) {
+      setEditReferenceDialog(undefined);
+      return;
+    }
 
     const saveValue: EditReferenceValue = value.splitVerse
       ? value

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVersesIsMobile.tsx
@@ -64,6 +64,7 @@ import {
   markVersesReferenceHasLetterSuffix,
   nextMarkVersesLetterSuffix,
   normalizeEditReferenceDraft,
+  normalizeEditReferenceForSave,
   parseMarkVersesReference,
 } from '../../../../utils/markVersesPassageVerses';
 import PassageDetailPlayer from '../../PassageDetailPlayer';
@@ -1005,14 +1006,14 @@ export default function PassageDetailMarkVersesIsMobile({
     if (!editReferenceDialog) return;
 
     const openingValue = normalizeEditReferenceDraft(editReferenceDialog);
+    // Defense in depth: EditReferenceDropdown disables Save via the same helper;
+    // keep both paths on editReferenceValuesEqual so semantics stay aligned.
     if (editReferenceValuesEqual(value, openingValue)) {
       setEditReferenceDialog(undefined);
       return;
     }
 
-    const saveValue: EditReferenceValue = value.splitVerse
-      ? value
-      : { ...value, startSuffix: '', endSuffix: '' };
+    const saveValue = normalizeEditReferenceForSave(value);
     pushUndoSnapshot();
     const newData = cloneTableData(dataRef.current);
     const startRowIndex = editReferenceDialog.rowIndex;

--- a/src/renderer/src/utils/markVersesPassageVerses.test.ts
+++ b/src/renderer/src/utils/markVersesPassageVerses.test.ts
@@ -1,4 +1,5 @@
 import {
+  editReferenceValuesEqual,
   formatMarkVersesReference,
   getEndingVerseOptions,
   incrementMarkVersesReferenceSuffix,
@@ -154,6 +155,68 @@ describe('markVersesPassageVerses', () => {
 
     it('returns undefined when the next letter would exceed e', () => {
       expect(incrementMarkVersesReferenceSuffix('1:11e')).toBeUndefined();
+    });
+  });
+
+  describe('editReferenceValuesEqual', () => {
+    const singleVerse = {
+      splitVerse: false,
+      startChapter: 1,
+      startVerse: 1,
+      startSuffix: '',
+      endChapter: 1,
+      endVerse: 1,
+      endSuffix: '',
+    };
+
+    it('treats identical single-verse values as equal', () => {
+      expect(editReferenceValuesEqual(singleVerse, { ...singleVerse })).toBe(
+        true
+      );
+    });
+
+    it('treats same range with split toggled and empty suffixes as equal', () => {
+      const range = {
+        splitVerse: false,
+        startChapter: 1,
+        startVerse: 1,
+        startSuffix: '',
+        endChapter: 1,
+        endVerse: 3,
+        endSuffix: '',
+      };
+      expect(
+        editReferenceValuesEqual(range, { ...range, splitVerse: true })
+      ).toBe(true);
+    });
+
+    it('treats different end verses as not equal', () => {
+      expect(
+        editReferenceValuesEqual(singleVerse, {
+          ...singleVerse,
+          endVerse: 2,
+        })
+      ).toBe(false);
+    });
+
+    it('treats letter-suffix references as not equal to plain references', () => {
+      expect(
+        editReferenceValuesEqual(singleVerse, {
+          ...singleVerse,
+          splitVerse: true,
+          startSuffix: 'a',
+          endSuffix: 'e',
+        })
+      ).toBe(false);
+    });
+
+    it('treats split toggled on and off without suffix change as equal to original', () => {
+      expect(
+        editReferenceValuesEqual(singleVerse, {
+          ...singleVerse,
+          splitVerse: true,
+        })
+      ).toBe(true);
     });
   });
 });

--- a/src/renderer/src/utils/markVersesPassageVerses.ts
+++ b/src/renderer/src/utils/markVersesPassageVerses.ts
@@ -255,9 +255,9 @@ export const normalizeEditReferenceDraft = <T extends EditReferenceComparable>(
 };
 
 /** Apply save-path normalization (strip suffixes when split is off). */
-export const normalizeEditReferenceForSave = (
-  value: EditReferenceComparable
-): EditReferenceComparable =>
+export const normalizeEditReferenceForSave = <T extends EditReferenceComparable>(
+  value: T
+): T =>
   value.splitVerse ? value : { ...value, startSuffix: '', endSuffix: '' };
 
 export const editReferenceValuesEqual = (

--- a/src/renderer/src/utils/markVersesPassageVerses.ts
+++ b/src/renderer/src/utils/markVersesPassageVerses.ts
@@ -228,3 +228,41 @@ export const formatMarkVersesReference = ({
 
   return `${startChapter}:${startVerse}${startSuffixPart}-${endChapter}:${endVerse}${endSuffixPart}`;
 };
+
+export interface EditReferenceComparable {
+  splitVerse: boolean;
+  startChapter: number;
+  startVerse: number;
+  startSuffix: string;
+  endChapter: number;
+  endVerse: number;
+  endSuffix: string;
+}
+
+/** Normalize Edit Reference props the same way the dialog initializes draft state. */
+export const normalizeEditReferenceDraft = <T extends EditReferenceComparable>(
+  value: T
+): T => {
+  const splitVerse =
+    MARK_VERSES_LETTER_SUFFIX.test(value.startSuffix) ||
+    MARK_VERSES_LETTER_SUFFIX.test(value.endSuffix);
+  return {
+    ...value,
+    splitVerse,
+    startSuffix: splitVerse ? value.startSuffix : '',
+    endSuffix: splitVerse ? value.endSuffix : '',
+  };
+};
+
+/** Apply save-path normalization (strip suffixes when split is off). */
+export const normalizeEditReferenceForSave = (
+  value: EditReferenceComparable
+): EditReferenceComparable =>
+  value.splitVerse ? value : { ...value, startSuffix: '', endSuffix: '' };
+
+export const editReferenceValuesEqual = (
+  a: EditReferenceComparable,
+  b: EditReferenceComparable
+): boolean =>
+  formatMarkVersesReference(normalizeEditReferenceForSave(a)) ===
+  formatMarkVersesReference(normalizeEditReferenceForSave(b));


### PR DESCRIPTION
- Added normalization logic for edit reference values to ensure consistent state handling.
- Introduced a mechanism to disable the Save button until changes are made to the reference.
- Enhanced tests to verify Save button behavior based on reference changes and Split Verse toggling.