### PR TITLE
TT-6741 Add MediaUpload tests and refactor size limit handling

### DIFF
--- a/src/renderer/src/components/MediaRecord.tsx
+++ b/src/renderer/src/components/MediaRecord.tsx
@@ -29,7 +29,7 @@ import {
 } from '../crud';
 import { useSnackBar } from '../hoc/SnackBar';
 import { UnsavedContext } from '../context/UnsavedContext';
-import { SIZELIMIT } from './MediaUpload';
+import { limitByType } from './uploadSizeLimits';
 import usePassageDetailContext from '../context/usePassageDetailContext';
 import { useStepTool } from '../crud/useStepTool';
 import { parseRecordCaptureAudioProcessing } from '../crud/useWavRecorder';
@@ -215,7 +215,7 @@ function MediaRecord(props: IProps) {
     () => ['mp3', 'mp3', 'webm', 'mka', 'm4a', 'wav', 'ogg'],
     []
   );
-  const sizeLimit = SIZELIMIT(UploadType.Media);
+  const sizeLimit = limitByType(UploadType.Media);
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
 
   const mimes = useMemo(
@@ -554,7 +554,11 @@ function MediaRecord(props: IProps) {
       if (blob) gotTheBlob(blob);
       else blobError(ts.mediaError);
     } catch (error) {
-      logError(Severity.error, reporter, infoMsg(error as Error, 'media load failed'));
+      logError(
+        Severity.error,
+        reporter,
+        infoMsg(error as Error, 'media load failed')
+      );
       blobError(ts.mediaError);
     }
   };

--- a/src/renderer/src/components/MediaUpload.test.ts
+++ b/src/renderer/src/components/MediaUpload.test.ts
@@ -1,4 +1,4 @@
-import { filterFilesBySizeLimit, SIZELIMIT } from './uploadSizeLimits';
+import { filterFilesBySizeLimit, limitByType } from './uploadSizeLimits';
 import { UploadType } from './UploadType';
 
 jest.mock('../../api-variable', () => ({
@@ -7,14 +7,14 @@ jest.mock('../../api-variable', () => ({
 
 const mb = (n: number) => n * 1000000;
 
-describe('SIZELIMIT', () => {
+describe('limitByType', () => {
   it('uses API size limit for section/passage resource uploads', () => {
-    expect(SIZELIMIT(UploadType.Resource)).toBe(30);
-    expect(SIZELIMIT(UploadType.Media)).toBe(30);
+    expect(limitByType(UploadType.Resource)).toBe(30);
+    expect(limitByType(UploadType.Media)).toBe(30);
   });
 
   it('uses 50 MB for general (project) resource uploads', () => {
-    expect(SIZELIMIT(UploadType.ProjectResource)).toBe(50);
+    expect(limitByType(UploadType.ProjectResource)).toBe(50);
   });
 });
 
@@ -40,7 +40,7 @@ describe('filterFilesBySizeLimit', () => {
     const files = [file('general.mp3', mb(31))];
     const { accepted, rejected } = filterFilesBySizeLimit(
       files,
-      SIZELIMIT(UploadType.ProjectResource)
+      limitByType(UploadType.ProjectResource)
     );
     expect(accepted).toEqual(files);
     expect(rejected).toHaveLength(0);
@@ -50,7 +50,7 @@ describe('filterFilesBySizeLimit', () => {
     const files = [file('section.mp3', mb(31))];
     const { accepted, rejected } = filterFilesBySizeLimit(
       files,
-      SIZELIMIT(UploadType.Resource)
+      limitByType(UploadType.Resource)
     );
     expect(accepted).toHaveLength(0);
     expect(rejected).toEqual(files);

--- a/src/renderer/src/components/MediaUpload.test.ts
+++ b/src/renderer/src/components/MediaUpload.test.ts
@@ -1,0 +1,58 @@
+import { filterFilesBySizeLimit, SIZELIMIT } from './uploadSizeLimits';
+import { UploadType } from './UploadType';
+
+jest.mock('../../api-variable', () => ({
+  API_CONFIG: { sizeLimit: '30' },
+}));
+
+const mb = (n: number) => n * 1000000;
+
+describe('SIZELIMIT', () => {
+  it('uses API size limit for section/passage resource uploads', () => {
+    expect(SIZELIMIT(UploadType.Resource)).toBe(30);
+    expect(SIZELIMIT(UploadType.Media)).toBe(30);
+  });
+
+  it('uses 50 MB for general (project) resource uploads', () => {
+    expect(SIZELIMIT(UploadType.ProjectResource)).toBe(50);
+  });
+});
+
+describe('filterFilesBySizeLimit', () => {
+  const file = (name: string, sizeBytes: number) =>
+    ({ name, size: sizeBytes }) as File;
+
+  it('accepts files at or under the limit', () => {
+    const files = [file('a.mp3', mb(30)), file('b.mp3', mb(10))];
+    const { accepted, rejected } = filterFilesBySizeLimit(files, 30);
+    expect(accepted).toHaveLength(2);
+    expect(rejected).toHaveLength(0);
+  });
+
+  it('rejects files over the limit', () => {
+    const files = [file('big.mp3', mb(31))];
+    const { accepted, rejected } = filterFilesBySizeLimit(files, 30);
+    expect(accepted).toHaveLength(0);
+    expect(rejected).toEqual(files);
+  });
+
+  it('accepts a 31 MB file under the 50 MB general limit', () => {
+    const files = [file('general.mp3', mb(31))];
+    const { accepted, rejected } = filterFilesBySizeLimit(
+      files,
+      SIZELIMIT(UploadType.ProjectResource)
+    );
+    expect(accepted).toEqual(files);
+    expect(rejected).toHaveLength(0);
+  });
+
+  it('rejects a 31 MB file under the 30 MB section limit', () => {
+    const files = [file('section.mp3', mb(31))];
+    const { accepted, rejected } = filterFilesBySizeLimit(
+      files,
+      SIZELIMIT(UploadType.Resource)
+    );
+    expect(accepted).toHaveLength(0);
+    expect(rejected).toEqual(files);
+  });
+});

--- a/src/renderer/src/components/MediaUpload.tsx
+++ b/src/renderer/src/components/MediaUpload.tsx
@@ -1,7 +1,6 @@
 import { shallowEqual, useSelector } from 'react-redux';
 import { IMediaUploadStrings } from '../model';
 import { mediaUploadSelector } from '../selector';
-import { API_CONFIG } from '../../api-variable';
 import BigDialog from '../hoc/BigDialog';
 import { BigDialogBp } from '../hoc/BigDialogBp';
 import MediaUploadContent from './MediaUploadContent';
@@ -14,21 +13,7 @@ export const MarkDownType = 'text/markdown';
 export const Mp3Type = 'audio/mpeg';
 export const FaithbridgeType = 'audio/mpeg/s3link';
 
-const PROJECTRESOURCE_SIZELIMIT = 50;
-const NO_SIZELIMIT = 10000;
-
-export const SIZELIMIT = (uploadType: UploadType) => {
-  switch (uploadType) {
-    case UploadType.ProjectResource:
-      return PROJECTRESOURCE_SIZELIMIT;
-    case UploadType.ITF:
-    case UploadType.PTF:
-    case UploadType.FaithbridgeLink:
-      return NO_SIZELIMIT;
-    default:
-      return parseInt(API_CONFIG.sizeLimit);
-  }
-};
+export { filterFilesBySizeLimit, SIZELIMIT } from './uploadSizeLimits';
 interface IProps {
   visible: boolean;
   onVisible: (v: boolean) => void;

--- a/src/renderer/src/components/MediaUpload.tsx
+++ b/src/renderer/src/components/MediaUpload.tsx
@@ -13,7 +13,6 @@ export const MarkDownType = 'text/markdown';
 export const Mp3Type = 'audio/mpeg';
 export const FaithbridgeType = 'audio/mpeg/s3link';
 
-export { filterFilesBySizeLimit, SIZELIMIT } from './uploadSizeLimits';
 interface IProps {
   visible: boolean;
   onVisible: (v: boolean) => void;

--- a/src/renderer/src/components/MediaUploadContent.tsx
+++ b/src/renderer/src/components/MediaUploadContent.tsx
@@ -19,11 +19,10 @@ import { MarkDownEdit } from '../control/MarkDownEdit';
 import { isUrl } from '../utils';
 import {
   FaithbridgeType,
-  filterFilesBySizeLimit,
   MarkDownType,
-  SIZELIMIT,
   UriLinkType,
 } from './MediaUpload';
+import { filterFilesBySizeLimit, limitByType } from './uploadSizeLimits';
 import { UploadType } from './UploadType';
 import { FileDrop } from 'react-file-drop';
 
@@ -58,14 +57,8 @@ interface ITargetProps {
 }
 
 const DropTarget = (targetProps: ITargetProps) => {
-  const {
-    name,
-    multiple,
-    acceptextension,
-    acceptmime,
-    handleFiles,
-    inputRef,
-  } = targetProps;
+  const { name, multiple, acceptextension, acceptmime, handleFiles, inputRef } =
+    targetProps;
   const t: IMediaUploadStrings = useSelector(mediaUploadSelector, shallowEqual);
 
   const handleNameChange = (
@@ -286,7 +279,7 @@ function MediaUploadContent(props: IProps) {
       }
       const nonAudio = goodFiles.some((f) => !f?.type.includes('audio'));
       if (onNonAudio) onNonAudio(nonAudio);
-      goodFiles = checkSizes(goodFiles, SIZELIMIT(uploadType));
+      goodFiles = checkSizes(goodFiles, limitByType(uploadType));
       setName(fileName(goodFiles));
       setFiles(goodFiles);
       if (goodFiles.length === 0) {
@@ -363,7 +356,7 @@ function MediaUploadContent(props: IProps) {
         'image/png, image/jpeg, image/jpeg, image/webp',
       ].map((s) => s)[uploadType] as string
     );
-    const size = SIZELIMIT(uploadType);
+    const size = limitByType(uploadType);
     clearFileInput();
     if (filesRef.current.length > 0) {
       const goodFiles = checkSizes(filesRef.current, size);

--- a/src/renderer/src/components/MediaUploadContent.tsx
+++ b/src/renderer/src/components/MediaUploadContent.tsx
@@ -19,6 +19,7 @@ import { MarkDownEdit } from '../control/MarkDownEdit';
 import { isUrl } from '../utils';
 import {
   FaithbridgeType,
+  filterFilesBySizeLimit,
   MarkDownType,
   SIZELIMIT,
   UriLinkType,
@@ -53,11 +54,18 @@ interface ITargetProps {
   acceptmime: string;
   multiple?: boolean;
   handleFiles: (files: FileList | undefined) => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 const DropTarget = (targetProps: ITargetProps) => {
-  const { name, multiple, acceptextension, acceptmime, handleFiles } =
-    targetProps;
+  const {
+    name,
+    multiple,
+    acceptextension,
+    acceptmime,
+    handleFiles,
+    inputRef,
+  } = targetProps;
   const t: IMediaUploadStrings = useSelector(mediaUploadSelector, shallowEqual);
 
   const handleNameChange = (
@@ -82,6 +90,7 @@ const DropTarget = (targetProps: ITargetProps) => {
           : name}
       </MyLabel>
       <HiddenInput
+        ref={inputRef}
         id="upload"
         type="file"
         accept={acceptextension}
@@ -99,6 +108,7 @@ const DropTarget = (targetProps: ITargetProps) => {
           : name}
       </MyLabel>
       <HiddenInput
+        ref={inputRef}
         id="upload"
         type="file"
         accept={acceptmime}
@@ -163,8 +173,8 @@ function MediaUploadContent(props: IProps) {
   const filesRef = useRef(files);
   const { showMessage } = useSnackBar();
   const [acceptextension, setAcceptExtension] = useState('');
-  const [sizeLimit, setSizeLimit] = useState(0);
   const [acceptmime, setAcceptMime] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [hasRights, setHasRight] = useState(!onSpeaker || Boolean(speaker));
   const [progress, setProgress] = useState(false);
   const t: IMediaUploadStrings = useSelector(mediaUploadSelector, shallowEqual);
@@ -225,6 +235,11 @@ function MediaUploadContent(props: IProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [saveDisabled]);
 
+  const clearFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
   const setFiles = (f: File[]) => {
     filesRef.current = f;
     setFilesx(f);
@@ -238,20 +253,15 @@ function MediaUploadContent(props: IProps) {
         : files.length.toString() + ' files selected';
   };
   const checkSizes = (files: File[], sizelimit: number) => {
-    const smallenoughfiles = Array.from(
-      files.filter((s) => s.size <= sizelimit * 1000000)
-    );
-    if (smallenoughfiles.length < files.length) {
-      const rejectedFiles = Array.from(files).filter(
-        (s) => s.size > sizelimit * 1000000
-      );
+    const { accepted, rejected } = filterFilesBySizeLimit(files, sizelimit);
+    if (rejected.length > 0) {
       showMessage(
         t.toobig
-          .replace('{0}', rejectedFiles.map((f) => f.name).join(', '))
+          .replace('{0}', rejected.map((f) => f.name).join(', '))
           .replace('{1}', sizelimit.toString())
       );
     }
-    return smallenoughfiles;
+    return accepted;
   };
   const handleFiles = (files: FileList | undefined) => {
     if (files) {
@@ -276,12 +286,16 @@ function MediaUploadContent(props: IProps) {
       }
       const nonAudio = goodFiles.some((f) => !f?.type.includes('audio'));
       if (onNonAudio) onNonAudio(nonAudio);
-      goodFiles = checkSizes(goodFiles, sizeLimit);
+      goodFiles = checkSizes(goodFiles, SIZELIMIT(uploadType));
       setName(fileName(goodFiles));
       setFiles(goodFiles);
+      if (goodFiles.length === 0) {
+        clearFileInput();
+      }
     } else {
       setFiles([]);
       setName('');
+      clearFileInput();
     }
   };
 
@@ -350,7 +364,7 @@ function MediaUploadContent(props: IProps) {
       ].map((s) => s)[uploadType] as string
     );
     const size = SIZELIMIT(uploadType);
-    setSizeLimit(size);
+    clearFileInput();
     if (filesRef.current.length > 0) {
       const goodFiles = checkSizes(filesRef.current, size);
       setName(fileName(goodFiles));
@@ -388,6 +402,7 @@ function MediaUploadContent(props: IProps) {
                 acceptextension={acceptextension}
                 acceptmime={acceptmime}
                 multiple={multiple ?? false}
+                inputRef={fileInputRef}
               />
             ) : (
               <MyLabel>{'\u00A0'}</MyLabel>

--- a/src/renderer/src/components/Uploader.tsx
+++ b/src/renderer/src/components/Uploader.tsx
@@ -8,7 +8,8 @@ import {
   MediaFileAttributes,
   MediaFileD,
 } from '../model';
-import MediaUpload, { FaithbridgeType, SIZELIMIT } from './MediaUpload';
+import MediaUpload, { FaithbridgeType } from './MediaUpload';
+import { limitByType } from './uploadSizeLimits';
 import {
   findRecord,
   pullTableList,
@@ -432,7 +433,10 @@ export const Uploader = (props: IProps) => {
               uploadError.indexOf('toobig:') + 'toobig:'.length
             )
           )
-          .replace('{2}', SIZELIMIT(uploadType ?? UploadType.Media).toString());
+          .replace(
+            '{2}',
+            limitByType(uploadType ?? UploadType.Media).toString()
+          );
       }
       errMsgs.push(msg);
       setBusy(false);

--- a/src/renderer/src/components/uploadSizeLimits.ts
+++ b/src/renderer/src/components/uploadSizeLimits.ts
@@ -4,7 +4,7 @@ import { UploadType } from './UploadType';
 const PROJECTRESOURCE_SIZELIMIT = 50;
 const NO_SIZELIMIT = 10000;
 
-export const SIZELIMIT = (uploadType: UploadType) => {
+export const limitByType = (uploadType: UploadType) => {
   switch (uploadType) {
     case UploadType.ProjectResource:
       return PROJECTRESOURCE_SIZELIMIT;

--- a/src/renderer/src/components/uploadSizeLimits.ts
+++ b/src/renderer/src/components/uploadSizeLimits.ts
@@ -1,0 +1,36 @@
+import { API_CONFIG } from '../../api-variable';
+import { UploadType } from './UploadType';
+
+const PROJECTRESOURCE_SIZELIMIT = 50;
+const NO_SIZELIMIT = 10000;
+
+export const SIZELIMIT = (uploadType: UploadType) => {
+  switch (uploadType) {
+    case UploadType.ProjectResource:
+      return PROJECTRESOURCE_SIZELIMIT;
+    case UploadType.ITF:
+    case UploadType.PTF:
+    case UploadType.FaithbridgeLink:
+      return NO_SIZELIMIT;
+    default:
+      return parseInt(API_CONFIG.sizeLimit);
+  }
+};
+
+/** Split files by client-side size limit (MB). Used by MediaUploadContent.checkSizes. */
+export const filterFilesBySizeLimit = (
+  files: File[],
+  sizeLimitMb: number
+): { accepted: File[]; rejected: File[] } => {
+  const maxBytes = sizeLimitMb * 1000000;
+  const accepted: File[] = [];
+  const rejected: File[] = [];
+  for (const file of files) {
+    if (file.size <= maxBytes) {
+      accepted.push(file);
+    } else {
+      rejected.push(file);
+    }
+  }
+  return { accepted, rejected };
+};

--- a/src/renderer/src/store/upload/actions.tsx
+++ b/src/renderer/src/store/upload/actions.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../utils';
 import { DateTime } from 'luxon';
 import _ from 'lodash';
-import { SIZELIMIT } from '../../components/MediaUpload';
+import { limitByType } from '../../components/uploadSizeLimits';
 import { UploadType } from '../../components/UploadType';
 import path from 'path-browserify';
 import bugsnagClient from '../../auth/bugsnagClient';
@@ -260,7 +260,7 @@ export const nextUpload =
       sendError(n, `${name}:unsupported`);
       return;
     }
-    if (size > SIZELIMIT(uploadType) * 1000000) {
+    if (size > limitByType(uploadType) * 1000000) {
       sendError(n, `${name}:toobig:${(size / 1000000).toFixed(2)}`);
       return;
     }

--- a/src/renderer/src/store/upload/actions.uploadBusy.test.ts
+++ b/src/renderer/src/store/upload/actions.uploadBusy.test.ts
@@ -8,8 +8,8 @@ import { waitForImportExportIdle } from './uploadRetry';
 jest.mock('../../../api-variable', () => ({
   API_CONFIG: { host: 'https://api.test', sizeLimit: '500' },
 }));
-jest.mock('../../components/MediaUpload', () => ({
-  SIZELIMIT: () => 500,
+jest.mock('../../components/uploadSizeLimits', () => ({
+  limitByType: () => 500,
 }));
 jest.mock('axios');
 jest.mock('../../auth/bugsnagClient', () => ({}));

--- a/src/renderer/src/utils/useCompression.ts
+++ b/src/renderer/src/utils/useCompression.ts
@@ -1,11 +1,12 @@
 import { shallowEqual, useSelector } from 'react-redux';
-import { SIZELIMIT } from '../components/MediaUpload';
+import { limitByType } from '../components/uploadSizeLimits';
 import { mediaTabSelector } from '../selector';
 import { IMediaTabStrings } from '../model';
 import imageCompression from 'browser-image-compression';
 import { useGlobal } from '../context/useGlobal';
 import { logError, Severity } from '../utils';
 import { blobToBase64 } from './blobToBase64';
+import { UploadType } from '../components/UploadType';
 
 // Converting to/from Blob: https://stackoverflow.com/questions/68276368/javascript-convert-a-blob-object-to-a-string-and-back
 // https://stackoverflow.com/questions/18650168/convert-blob-to-base64
@@ -57,7 +58,7 @@ export const useCompression = ({
 
   const showFile = (files: File[]) => {
     const options = {
-      maxSizeMb: SIZELIMIT,
+      maxSizeMb: limitByType(UploadType.Media),
       maxWidthOrHeight: 1024,
       useWebWorker: true,
     };
@@ -90,7 +91,7 @@ export const useCompression = ({
 
     for (const dim of dimension) {
       const options = {
-        maxSizeMb: SIZELIMIT,
+        maxSizeMb: limitByType(UploadType.Media),
         maxWidthOrHeight: dim,
         useWebWorker: true,
       };


### PR DESCRIPTION
- Introduced unit tests for file size filtering and size limit logic in MediaUpload.
- Moved size limit functions to a new `uploadSizeLimits.ts` file for better organization.
- Updated `MediaUpload` and `MediaUploadContent` components to utilize the new size limit functions and improve file handling logic.
- Enhanced file input management with a ref for better control over file selection.