### PR TITLE
TT-7354,TT-7368 handle mobile header with one passage and lots of drop down

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../context/PassageDetailContext';
 import { UnsavedContext } from '../../../context/UnsavedContext';
 import { OrbitContext } from '../../../hoc/OrbitContextProvider';
+import { BookName } from '../../../model';
 import MobileWorkflowSteps from './MobileWorkflowSteps';
 
 type RecordsByKey = Record<string, any>;
@@ -53,6 +54,18 @@ const stepProgressionOrgRecord = {
   },
 };
 
+const hierarchyPlanRecord = {
+  id: 'plan-1',
+  type: 'plan',
+  attributes: { name: 'Hierarchy Plan', flat: false },
+};
+
+const flatPlanRecord = {
+  id: 'plan-flat',
+  type: 'plan',
+  attributes: { name: 'Flat Plan', flat: true },
+};
+
 // Two passage records used in passage progression mode tests
 const mockSectionPassageRecords = {
   'passage:p-1': {
@@ -76,6 +89,7 @@ const mockSectionPassageRecordsWithPrior = {
 
 const mockSectionWithThreePassages = {
   id: 'section-1',
+  attributes: { sequencenum: 1, name: 'Section One' },
   relationships: {
     passages: {
       data: [
@@ -90,12 +104,23 @@ const mockSectionWithThreePassages = {
 // Section whose passages relationship points to the records above
 const mockSection = {
   id: 'section-1',
+  attributes: { sequencenum: 1, name: 'Section One' },
   relationships: {
     passages: {
       data: [
         { type: 'passage', id: 'p-1' },
         { type: 'passage', id: 'p-2' },
       ],
+    },
+  },
+} as any;
+
+const mockSinglePassageSection = {
+  id: 'section-1',
+  attributes: { sequencenum: 2, name: 'Luke Section' },
+  relationships: {
+    passages: {
+      data: [{ type: 'passage', id: 'p-1' }],
     },
   },
 } as any;
@@ -207,6 +232,8 @@ const createPassageDetailState = (
     passage: mockCurrentPassage,
     section: {} as any,
     prjId: 'proj-1',
+    allBookData: [],
+    sectionArr: [],
     ...overrides,
   }) as ICtxState;
 
@@ -218,8 +245,11 @@ const mountMobileWorkflowSteps = ({
   recording = false,
   commentRecording = false,
   isStepProgression = false,
+  isFlat = false,
   section,
   passage,
+  allBookData,
+  sectionArr,
   extraMemoryRecords = {},
 }: {
   currentstep?: string;
@@ -229,8 +259,11 @@ const mountMobileWorkflowSteps = ({
   recording?: boolean;
   commentRecording?: boolean;
   isStepProgression?: boolean;
+  isFlat?: boolean;
   section?: any;
   passage?: any;
+  allBookData?: BookName[];
+  sectionArr?: ICtxState['sectionArr'];
   extraMemoryRecords?: Record<string, any>;
 } = {}) => {
   const setCurrentStep = cy.stub().as('setCurrentStep');
@@ -242,14 +275,19 @@ const mountMobileWorkflowSteps = ({
     stepComplete: (id: string) => completedStepIds.includes(id),
     ...(section !== undefined ? { section } : {}),
     ...(passage !== undefined ? { passage } : {}),
+    ...(allBookData !== undefined ? { allBookData } : {}),
+    ...(sectionArr !== undefined ? { sectionArr } : {}),
   };
   if (workflow) ctxOverrides.workflow = workflow;
   const ctxState = createPassageDetailState(ctxOverrides);
 
+  const planId = isFlat ? 'plan-flat' : 'plan-1';
   const mem = createMockMemory({
     ...(isStepProgression
       ? { 'organization:test-org': stepProgressionOrgRecord }
       : {}),
+    'plan:plan-1': hierarchyPlanRecord,
+    'plan:plan-flat': flatPlanRecord,
     ...extraMemoryRecords,
   });
   const orbitCache = new Map<string, any[]>();
@@ -261,7 +299,11 @@ const mountMobileWorkflowSteps = ({
       else orbitCache.set(type, recs);
     },
   };
-  const initialState = createInitialState({ remoteBusy, memory: mem });
+  const initialState = createInitialState({
+    remoteBusy,
+    memory: mem,
+    plan: planId,
+  });
 
   cy.mount(
     <MemoryRouter>
@@ -394,10 +436,43 @@ describe('MobileWorkflowSteps', () => {
       cy.contains('Please wait').should('be.visible');
     });
 
-    it('dropdown shows current passage book and reference', () => {
+    it('dropdown shows current passage book and reference (scripture)', () => {
       mountMobileWorkflowSteps({ isStepProgression: true });
 
       cy.get('[data-cy="passage-dropdown"]').should('contain.text', 'GEN 1:1');
+    });
+
+    it('dropdown uses passage ref text for scripture even when a shared resource exists', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        passage: {
+          id: 'p-1',
+          attributes: { sequencenum: 1, reference: '1:1-4', book: 'LUK' },
+          relationships: {
+            sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+          },
+        },
+        section: mockSinglePassageSection,
+        extraMemoryRecords: {
+          'passage:p-1': {
+            id: 'p-1',
+            attributes: { sequencenum: 1, reference: '1:1-4', book: 'LUK' },
+            relationships: {
+              sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+            },
+          },
+          'sharedresource:sr-1': {
+            id: 'sr-1',
+            attributes: { title: 'LUK_c001_001-004' },
+          },
+        },
+      });
+
+      cy.get('[data-cy="passage-dropdown"]').should('contain.text', 'LUK 1:1-4');
+      cy.get('[data-cy="passage-dropdown"]').should(
+        'not.contain.text',
+        'LUK_c001_001-004'
+      );
     });
 
     it('dropdown opens section passages as menu items', () => {
@@ -412,6 +487,64 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[role="menu"]').should('be.visible');
       cy.get('[role="menuitem"]').should('have.length', 2);
       cy.get('[role="menuitem"]').eq(0).should('contain.text', 'GEN 1:1');
+    });
+
+    it('keeps racetrack visible when passage dropdown menu is open', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
+
+      cy.viewport(375, 667);
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('be.visible');
+      cy.get('[data-cy="racetrack-row"]').should('be.visible');
+      cy.get('[data-cy="workflow-step"]').should('have.length', 2);
+    });
+
+    it('constrains passage menu width and height for long references', () => {
+      const longReference =
+        'A very long general project topic title that should not widen the menu off screen';
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        isFlat: true,
+        section: {
+          id: 'section-1',
+          relationships: {
+            passages: { data: [{ type: 'passage', id: 'p-long' }] },
+          },
+        },
+        passage: {
+          id: 'p-long',
+          attributes: { sequencenum: 1, reference: longReference, book: '' },
+        },
+        extraMemoryRecords: {
+          'passage:p-long': {
+            id: 'p-long',
+            attributes: { sequencenum: 1, reference: longReference, book: '' },
+          },
+        },
+      });
+
+      cy.viewport(375, 667);
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]')
+        .closest('.MuiPaper-root')
+        .should(($paper) => {
+          const maxWidth = parseFloat($paper.css('max-width'));
+          expect(maxWidth).to.be.closeTo(375 - 24, 1);
+        });
+      cy.get('.MuiMenu-list').should(($list) => {
+        const maxHeight = parseFloat($list.css('max-height'));
+        expect(maxHeight).to.be.closeTo(667 * 0.45, 2);
+      });
+      cy.get('[role="menuitem"]')
+        .first()
+        .should('have.attr', 'title', longReference);
+      cy.get('[data-cy="racetrack-row"]').should('be.visible');
     });
 
     it('renders the step label as plain text when the current step has no tip', () => {
@@ -438,6 +571,38 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[data-cy="passage-step"]').should('have.length', 2);
     });
 
+    it('hides passage racetrack for a single passage in hierarchy projects', () => {
+      mountMobileWorkflowSteps({
+        section: mockSinglePassageSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+        sectionArr: [[2, '2']],
+      });
+
+      cy.get('[data-cy="passage-step"]').should('not.exist');
+      cy.get('[data-cy="racetrack-row"]').should('not.exist');
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'Luke Section'
+      );
+      cy.get('[data-cy="workflow-step-label"]').should('contain.text', 'GEN 1:1');
+    });
+
+    it('hides passage racetrack for a single passage in flat projects', () => {
+      mountMobileWorkflowSteps({
+        isFlat: true,
+        section: mockSinglePassageSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
+
+      cy.get('[data-cy="passage-step"]').should('not.exist');
+      cy.get('[data-cy="racetrack-row"]').should('not.exist');
+      cy.get('[data-cy="workflow-step-label"]').should('contain.text', 'GEN 1:1');
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'not.contain.text',
+        'Luke Section'
+      );
+    });
+
     it('shows a tip button left of the dropdown that opens a dialog', () => {
       mountMobileWorkflowSteps();
 
@@ -462,6 +627,20 @@ describe('MobileWorkflowSteps', () => {
 
       cy.get('[role="menu"]').should('be.visible');
       cy.get('[role="menuitem"]').should('have.length', 2);
+    });
+
+    it('keeps racetrack visible when workflow dropdown menu is open', () => {
+      mountMobileWorkflowSteps({
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
+
+      cy.viewport(375, 667);
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('be.visible');
+      cy.get('[data-cy="racetrack-row"]').should('be.visible');
+      cy.get('[data-cy="passage-step"]').should('have.length', 2);
     });
 
     it('blocks passage click while recording', () => {
@@ -494,15 +673,12 @@ describe('MobileWorkflowSteps', () => {
         extraMemoryRecords: mockSectionPassageRecordsWithPrior,
       });
 
-      // p-0 sequencenum 0 < current sequencenum 1 → complete
       cy.get('[data-cy="passage-step"]')
         .eq(0)
         .should('have.css', 'background-color', 'rgb(189, 189, 189)');
-      // p-1 is current passage
       cy.get('[data-cy="passage-step"]')
         .eq(1)
         .should('have.css', 'background-color', 'rgb(97, 97, 97)');
-      // p-2 sequencenum 2 > current sequencenum 1 → incomplete
       cy.get('[data-cy="passage-step"]')
         .eq(2)
         .should('have.css', 'background-color', 'rgb(238, 238, 238)');
@@ -514,6 +690,137 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[data-cy="workflow-step-label"]').should(
         'contain.text',
         'GEN 1:1'
+      );
+    });
+
+    it('step label uses passage ref text for scripture even when a shared resource exists', () => {
+      mountMobileWorkflowSteps({
+        section: mockSinglePassageSection,
+        passage: {
+          id: 'p-1',
+          attributes: { sequencenum: 1, reference: '1:1-4', book: 'LUK' },
+          relationships: {
+            sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+          },
+        },
+        extraMemoryRecords: {
+          'passage:p-1': {
+            id: 'p-1',
+            attributes: { sequencenum: 1, reference: '1:1-4', book: 'LUK' },
+            relationships: {
+              sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+            },
+          },
+          'sharedresource:sr-1': {
+            id: 'sr-1',
+            attributes: { title: 'LUK_c001_001-004' },
+          },
+        },
+      });
+
+      cy.get('[data-cy="workflow-step-label"]').should('contain.text', 'LUK 1:1-4');
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'not.contain.text',
+        'LUK_c001_001-004'
+      );
+    });
+
+    it('step label shows shared resource title for note passages in flat projects', () => {
+      mountMobileWorkflowSteps({
+        isFlat: true,
+        section: {
+          id: 'section-1',
+          attributes: { sequencenum: 1, name: 'Notes Section' },
+          relationships: {
+            passages: { data: [{ type: 'passage', id: 'p-note' }] },
+          },
+        },
+        passage: {
+          id: 'p-note',
+          attributes: {
+            sequencenum: 1,
+            reference: 'NOTE|Devotional Note',
+            book: '',
+          },
+          relationships: {
+            sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+          },
+        },
+        extraMemoryRecords: {
+          'passage:p-note': {
+            id: 'p-note',
+            attributes: {
+              sequencenum: 1,
+              reference: 'NOTE|Devotional Note',
+              book: '',
+            },
+            relationships: {
+              sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+            },
+          },
+          'sharedresource:sr-1': {
+            id: 'sr-1',
+            attributes: { title: 'My Devotional Title' },
+          },
+        },
+      });
+
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'My Devotional Title'
+      );
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'not.contain.text',
+        'NOTE|'
+      );
+    });
+
+    it('step label shows shared resource title for note passages in hierarchy projects', () => {
+      mountMobileWorkflowSteps({
+        section: {
+          id: 'section-1',
+          attributes: { sequencenum: 1, name: 'Notes Section' },
+          relationships: {
+            passages: { data: [{ type: 'passage', id: 'p-note' }] },
+          },
+        },
+        passage: {
+          id: 'p-note',
+          attributes: {
+            sequencenum: 1,
+            reference: 'NOTE|Devotional Note',
+            book: '',
+          },
+          relationships: {
+            sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+          },
+        },
+        extraMemoryRecords: {
+          'passage:p-note': {
+            id: 'p-note',
+            attributes: {
+              sequencenum: 1,
+              reference: 'NOTE|Devotional Note',
+              book: '',
+            },
+            relationships: {
+              sharedResource: { data: { type: 'sharedresource', id: 'sr-1' } },
+            },
+          },
+          'sharedresource:sr-1': {
+            id: 'sr-1',
+            attributes: { title: 'My Devotional Title' },
+          },
+        },
+      });
+
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'Notes Section'
+      );
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'My Devotional Title'
       );
     });
 

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -23,7 +23,8 @@ import { useWfLabel } from '../../../utils/useWfLabel';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings, PassageD } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
-import { related } from '../../../crud/related';
+import { related, useSharedResRead } from '../../../crud';
+import { usePlanType } from '../../../crud/usePlanType';
 import { findRecord } from '../../../crud/tryFindRecord';
 import { rememberCurrentPassage } from '../../../utils';
 import { usePassageNavigate } from '../usePassageNavigate';
@@ -35,6 +36,34 @@ import {
 import { ToolSlug, useStepTool } from '../../../crud';
 import { useRole } from '../../../crud/useRole';
 import { useStepPermissions } from '../../../utils/useStepPermission';
+import { passageHeaderLabel, passageLabelText } from './passageLabelText';
+
+const MENU_MAX_HEIGHT = '45vh';
+
+function TruncatedLabel({
+  text,
+  title,
+}: {
+  text: string;
+  title?: string;
+}) {
+  return (
+    <Box
+      component="span"
+      title={title ?? text}
+      sx={{
+        display: 'block',
+        minWidth: 0,
+        maxWidth: '100%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {text}
+    </Box>
+  );
+}
 
 export default function MobileWorkflowSteps() {
   const {
@@ -47,6 +76,8 @@ export default function MobileWorkflowSteps() {
     passage,
     section,
     prjId,
+    allBookData,
+    sectionArr,
   } = usePassageDetailContext();
   const { tool } = useStepTool(currentstep);
   const { userIsAdmin } = useRole();
@@ -54,6 +85,7 @@ export default function MobileWorkflowSteps() {
   const showPromptAdmin =
     userIsAdmin || (permissionsOn && canDoSectionStep(currentstep, section));
   const [memory] = useGlobal('memory');
+  const [plan] = useGlobal('plan');
   const passageNavigate = usePassageNavigate(() => {}, setCurrentStep);
   const getGlobal = useGetGlobal();
   const { showMessage } = useSnackBar();
@@ -61,8 +93,15 @@ export default function MobileWorkflowSteps() {
   const theme = useTheme();
   const getWfLabel = useWfLabel();
   const { getOrgDefault } = useOrgDefaults();
+  const planType = usePlanType();
+  const { getSharedResource } = useSharedResRead();
   const isStepProgression =
     getOrgDefault(orgDefaultWorkflowProgression) === 'step';
+  const isFlat = useMemo(() => planType(plan)?.flat ?? false, [plan, planType]);
+  const sectionMap = useMemo(
+    () => new Map<number, string>(sectionArr),
+    [sectionArr]
+  );
   const t: IWorkflowStepsStrings = useSelector(
     workflowStepsSelector,
     shallowEqual
@@ -77,6 +116,40 @@ export default function MobileWorkflowSteps() {
       )
       .sort((a, b) => a.attributes.sequencenum - b.attributes.sequencenum);
   }, [section, memory]);
+
+  const showPassageRacetrack =
+    isStepProgression || sectionPassages.length > 1;
+  const singlePassagePassageProgression =
+    !isStepProgression && sectionPassages.length <= 1;
+
+  const getPassageLabel = (p: PassageD, withSectionDescription = false) =>
+    passageHeaderLabel(p, {
+      allBookData,
+      section,
+      flat: isFlat,
+      sharedResource: getSharedResource(p),
+      sectionMap,
+      withSectionDescription,
+    });
+
+  const currentPassageLabel = useMemo(
+    () =>
+      passage
+        ? getPassageLabel(
+            passage,
+            singlePassagePassageProgression && !isFlat
+          )
+        : '',
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      passage,
+      allBookData,
+      section,
+      isFlat,
+      singlePassagePassageProgression,
+      sectionArr,
+    ]
+  );
 
   const [tipOpen, setTipOpen] = useState(false);
   const [passageMenuAnchor, setPassageMenuAnchor] =
@@ -121,7 +194,7 @@ export default function MobileWorkflowSteps() {
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [currentPassageLabel, currentLabel, isStepProgression]);
 
   const didMountRef = useRef(false);
   const stepRefs = useRef(new Map<string, HTMLElement>());
@@ -144,6 +217,30 @@ export default function MobileWorkflowSteps() {
     isStepProgression,
   ]);
 
+  const dropdownText = isStepProgression ? currentPassageLabel : currentLabel;
+  const menuSlotProps = useMemo(
+    () => ({
+      paper: {
+        sx: {
+          maxWidth: `calc(100vw - ${theme.spacing(3)})`,
+        },
+      },
+      list: {
+        sx: {
+          maxHeight: MENU_MAX_HEIGHT,
+          overflow: 'auto',
+        },
+      },
+    }),
+    [theme]
+  );
+  const menuItemSx = {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    display: 'block',
+  } as const;
+
   return (
     <Box sx={{ px: 1.5, py: 1 }} data-cy="workflow-steps">
       <Box
@@ -156,7 +253,14 @@ export default function MobileWorkflowSteps() {
         {/* Passage dropdown */}
         <Box
           ref={dropdownRef}
-          sx={{ flexShrink: 0, mr: 1, display: 'flex', alignItems: 'center' }}
+          sx={{
+            flexShrink: showPassageRacetrack ? 1 : 0,
+            minWidth: 0,
+            maxWidth: showPassageRacetrack ? '50%' : '100%',
+            mr: 1,
+            display: 'flex',
+            alignItems: 'center',
+          }}
         >
           {!isStepProgression && currentTip && (
             <IconButton
@@ -172,7 +276,11 @@ export default function MobileWorkflowSteps() {
           <Button
             size="small"
             endIcon={<ArrowDropDownIcon />}
-            sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+            sx={{
+              minWidth: 'auto',
+              maxWidth: '100%',
+              overflow: 'hidden',
+            }}
             onClick={(e) => {
               if (recording || commentRecording) return;
               if (getGlobal('remoteBusy')) {
@@ -182,149 +290,164 @@ export default function MobileWorkflowSteps() {
               setPassageMenuAnchor(e.currentTarget);
             }}
             data-cy="passage-dropdown"
+            title={dropdownText}
           >
-            {isStepProgression
-              ? [passage?.attributes?.book, passage?.attributes?.reference]
-                  .filter(Boolean)
-                  .join(' ') || ''
-              : currentLabel}
+            <TruncatedLabel text={dropdownText} />
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}
             open={Boolean(passageMenuAnchor)}
             onClose={() => setPassageMenuAnchor(null)}
+            slotProps={menuSlotProps}
           >
             {isStepProgression
-              ? sectionPassages.map((p) => (
-                  <MenuItem
-                    key={p.id}
-                    selected={p.id === passage?.id}
-                    onClick={() => {
-                      const remId = p.keys?.remoteId ?? p.id;
-                      rememberCurrentPassage(memory, remId);
-                      passageNavigate(`/detail/${prjId}/${remId}`);
-                      setPassageMenuAnchor(null);
-                    }}
-                  >
-                    {[p.attributes.book, p.attributes.reference]
-                      .filter(Boolean)
-                      .join(' ')}
-                  </MenuItem>
-                ))
-              : workflow.map((step) => (
-                  <MenuItem
-                    key={step.id}
-                    selected={step.id === currentstep}
-                    onClick={() => {
-                      handleSelect(step.id)();
-                      setPassageMenuAnchor(null);
-                    }}
-                  >
-                    {getWfLabel(step.label)}
-                  </MenuItem>
-                ))}
-          </Menu>
-        </Box>
-        {/* Workflow step parallelograms */}
-        <Box
-          sx={{
-            flex: 1,
-            display: 'flex',
-            overflowX: 'auto',
-            overflowY: 'hidden',
-            WebkitOverflowScrolling: 'touch',
-          }}
-        >
-          <Box sx={{ display: 'flex', mx: 'auto', pb: 0.25 }}>
-            {isStepProgression
-              ? workflow.map((step) => {
-                  const isCurrent = step.id === currentstep;
-                  return (
-                    <ButtonBase
-                      key={step.id}
-                      data-cy="workflow-step"
-                      role="button"
-                      onClick={handleSelect(step.id)}
-                      tabIndex={0}
-                      ref={(el) => {
-                        if (el) stepRefs.current.set(step.id, el);
-                        else stepRefs.current.delete(step.id);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                        }
-                      }}
-                      sx={{
-                        flex: '0 0 80px',
-                        height: 30,
-                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
-                        backgroundColor: isCurrent
-                          ? theme.palette.grey[700]
-                          : stepComplete(step.id)
-                            ? theme.palette.grey[400]
-                            : theme.palette.grey[200],
-                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                        cursor:
-                          recording || commentRecording
-                            ? 'not-allowed'
-                            : 'pointer',
-                      }}
-                    />
+              ? sectionPassages.map((p) => {
+                  const label = passageLabelText(
+                    p,
+                    allBookData,
+                    getSharedResource(p),
+                    section
                   );
-                })
-              : sectionPassages.map((p) => {
-                  const isCurrent = p.id === passage?.id;
-                  const isComplete =
-                    (p.attributes.sequencenum ?? 0) <
-                    (passage?.attributes?.sequencenum ?? 0);
                   return (
-                    <ButtonBase
+                    <MenuItem
                       key={p.id}
-                      data-cy="passage-step"
-                      role="button"
+                      selected={p.id === passage?.id}
+                      title={label}
                       onClick={() => {
-                        if (recording || commentRecording) return;
-                        if (getGlobal('remoteBusy')) {
-                          showMessage(ts.wait);
-                          return;
-                        }
                         const remId = p.keys?.remoteId ?? p.id;
                         rememberCurrentPassage(memory, remId);
                         passageNavigate(`/detail/${prjId}/${remId}`);
+                        setPassageMenuAnchor(null);
                       }}
-                      tabIndex={0}
-                      ref={(el) => {
-                        if (el) stepRefs.current.set(p.id, el);
-                        else stepRefs.current.delete(p.id);
+                      sx={menuItemSx}
+                    >
+                      {label}
+                    </MenuItem>
+                  );
+                })
+              : workflow.map((step) => {
+                  const label = getWfLabel(step.label);
+                  return (
+                    <MenuItem
+                      key={step.id}
+                      selected={step.id === currentstep}
+                      title={label}
+                      onClick={() => {
+                        handleSelect(step.id)();
+                        setPassageMenuAnchor(null);
                       }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                        }
-                      }}
-                      sx={{
-                        flex: '0 0 80px',
-                        height: 30,
-                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
-                        backgroundColor: isCurrent
-                          ? theme.palette.grey[700]
-                          : isComplete
-                            ? theme.palette.grey[400]
-                            : theme.palette.grey[200],
-                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                        cursor:
-                          recording || commentRecording
-                            ? 'not-allowed'
-                            : 'pointer',
-                      }}
-                    />
+                      sx={menuItemSx}
+                    >
+                      {label}
+                    </MenuItem>
                   );
                 })}
-            {/* Spacer to mirror the dropdown width so mx:auto centers the parallelograms */}
-            <Box sx={{ flexShrink: 0, width: dropdownWidth }} />
-          </Box>
+          </Menu>
         </Box>
+        {/* Workflow step parallelograms */}
+        {showPassageRacetrack && (
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              overflowX: 'auto',
+              overflowY: 'hidden',
+              WebkitOverflowScrolling: 'touch',
+            }}
+            data-cy="racetrack-row"
+          >
+            <Box sx={{ display: 'flex', mx: 'auto', pb: 0.25 }}>
+              {isStepProgression
+                ? workflow.map((step) => {
+                    const isCurrent = step.id === currentstep;
+                    return (
+                      <ButtonBase
+                        key={step.id}
+                        data-cy="workflow-step"
+                        role="button"
+                        onClick={handleSelect(step.id)}
+                        tabIndex={0}
+                        ref={(el) => {
+                          if (el) stepRefs.current.set(step.id, el);
+                          else stepRefs.current.delete(step.id);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                          }
+                        }}
+                        sx={{
+                          flex: '0 0 80px',
+                          height: 30,
+                          mr: -0.25,
+                          backgroundColor: isCurrent
+                            ? theme.palette.grey[700]
+                            : stepComplete(step.id)
+                              ? theme.palette.grey[400]
+                              : theme.palette.grey[200],
+                          clipPath:
+                            'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                          cursor:
+                            recording || commentRecording
+                              ? 'not-allowed'
+                              : 'pointer',
+                        }}
+                      />
+                    );
+                  })
+                : sectionPassages.map((p) => {
+                    const isCurrent = p.id === passage?.id;
+                    const isComplete =
+                      (p.attributes.sequencenum ?? 0) <
+                      (passage?.attributes?.sequencenum ?? 0);
+                    return (
+                      <ButtonBase
+                        key={p.id}
+                        data-cy="passage-step"
+                        role="button"
+                        onClick={() => {
+                          if (recording || commentRecording) return;
+                          if (getGlobal('remoteBusy')) {
+                            showMessage(ts.wait);
+                            return;
+                          }
+                          const remId = p.keys?.remoteId ?? p.id;
+                          rememberCurrentPassage(memory, remId);
+                          passageNavigate(`/detail/${prjId}/${remId}`);
+                        }}
+                        tabIndex={0}
+                        ref={(el) => {
+                          if (el) stepRefs.current.set(p.id, el);
+                          else stepRefs.current.delete(p.id);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                          }
+                        }}
+                        sx={{
+                          flex: '0 0 80px',
+                          height: 30,
+                          mr: -0.25,
+                          backgroundColor: isCurrent
+                            ? theme.palette.grey[700]
+                            : isComplete
+                              ? theme.palette.grey[400]
+                              : theme.palette.grey[200],
+                          clipPath:
+                            'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                          cursor:
+                            recording || commentRecording
+                              ? 'not-allowed'
+                              : 'pointer',
+                        }}
+                      />
+                    );
+                  })}
+              <Box sx={{ flexShrink: 0, width: dropdownWidth }} />
+            </Box>
+          </Box>
+        )}
       </Box>
       {(isStepProgression ? currentLabel : passage?.id) && (
         <Typography
@@ -350,9 +473,7 @@ export default function MobileWorkflowSteps() {
               getWfLabel(currentLabel)
             )
           ) : (
-            [passage?.attributes?.book, passage?.attributes?.reference]
-              .filter(Boolean)
-              .join(' ')
+            currentPassageLabel
           )}
         </Typography>
       )}

--- a/src/renderer/src/components/PassageDetail/mobile/passageLabelText.ts
+++ b/src/renderer/src/components/PassageDetail/mobile/passageLabelText.ts
@@ -1,0 +1,60 @@
+import { passageTypeFromRef } from '../../../control/passageTypeFromRef';
+import { passageRefText } from '../../../crud/passage';
+import { sectionDescription } from '../../../crud/section';
+import { BookName, Passage, Section, SharedResourceD } from '../../../model';
+import { PassageTypeEnum } from '../../../model/passageType';
+
+/** Plain-text label matching PassageDetailChooser display rules. */
+export function passageLabelText(
+  passage: Passage,
+  allBookData: BookName[],
+  sharedResource?: SharedResourceD,
+  section?: Section
+): string {
+  const psgType = passageTypeFromRef(passage?.attributes?.reference, false);
+
+  if (psgType === PassageTypeEnum.PASSAGE) {
+    let ref = passageRefText(passage, allBookData).trim();
+    if (ref.length === 0 && section) {
+      ref = `${section.attributes?.sequencenum ?? ''}.${
+        passage.attributes?.sequencenum || 1
+      }`.replace(/^\./, '');
+    }
+    return ref;
+  }
+
+  if (sharedResource?.attributes?.title) {
+    return sharedResource.attributes.title;
+  }
+  const ref = passage?.attributes?.reference ?? '';
+  if (!ref) return '';
+  return String(ref).substring(psgType.length + 1);
+}
+
+export function passageHeaderLabel(
+  passage: Passage,
+  options: {
+    allBookData: BookName[];
+    section?: Section;
+    flat: boolean;
+    sharedResource?: SharedResourceD;
+    sectionMap?: Map<number, string>;
+    withSectionDescription?: boolean;
+  }
+): string {
+  const {
+    allBookData,
+    section,
+    flat,
+    sharedResource,
+    sectionMap,
+    withSectionDescription,
+  } = options;
+  const label = passageLabelText(passage, allBookData, sharedResource, section);
+  if (withSectionDescription && section && !flat) {
+    const desc = sectionDescription(section, sectionMap, passage);
+    const delim = label ? '\u00A0-\u00A0' : '';
+    return desc + delim + label;
+  }
+  return label;
+}


### PR DESCRIPTION
Enhance MobileWorkflowSteps component with new passage handling and UI improvements

- Introduced new passage records and updated mock data for testing.
- Added support for displaying passage dropdown with truncated labels for better UI.
- Implemented logic to conditionally show/hide the passage racetrack based on the number of passages.
- Refactored state management to include plan type and section array for improved functionality.
- Added new utility functions for generating passage labels and headers.