### PR TITLE
TT-7380 fix: auto-save when editing Segment Reference in Mark Verse step

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.test.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.test.tsx
@@ -537,12 +537,21 @@ test('blocks autosave when markup has hard reference errors', async () => {
     ?.firstChild as HTMLElement;
   await waitFor(() => expect(tbody.children.length).toBeTruthy());
 
+  // Load saved segment data with an out-of-passage ref ("9:9") into the table.
   act(() => {
     if (mockPlayerAction) {
       mockPlayerAction(
         '{"regions":"[{\\"start\\":0,\\"end\\":5,\\"label\\":\\"9:9\\"}]"}',
-        false
+        true
       );
+    }
+  });
+
+  // Simulate a user boundary edit (init=false) so checkBlockersAndScheduleAutosave
+  // runs with "9:9" still in the table — the blocker should be detected and warned.
+  act(() => {
+    if (mockPlayerAction) {
+      mockPlayerAction('{"regions":"[{\\"start\\":0,\\"end\\":6}]"}', false);
     }
   });
 

--- a/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.tsx
@@ -185,7 +185,6 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
   const {
     toolChanged,
     toolsChanged,
-    isChanged,
     saveRequested,
     saveCompleted,
     clearRequested,
@@ -617,9 +616,7 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
         resetSegments(regions);
       }
       if (!init) {
-        if (!isChanged(verseToolId)) {
-          toolChanged(verseToolId);
-        }
+        toolChanged(verseToolId);
         checkBlockersAndScheduleAutosave();
       }
     }
@@ -745,9 +742,7 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
     if (changed) {
       setData(newData);
       setSegments();
-      if (!isChanged(verseToolId)) {
-        toolChanged(verseToolId);
-      }
+      toolChanged(verseToolId);
       checkBlockersAndScheduleAutosave();
     }
   };

--- a/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailMarkVerses.tsx
@@ -616,7 +616,12 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
       if (reset) {
         resetSegments(regions);
       }
-      if (!init && !isChanged(verseToolId)) toolChanged(verseToolId);
+      if (!init) {
+        if (!isChanged(verseToolId)) {
+          toolChanged(verseToolId);
+        }
+        checkBlockersAndScheduleAutosave();
+      }
     }
   };
 
@@ -740,7 +745,10 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
     if (changed) {
       setData(newData);
       setSegments();
-      toolChanged(verseToolId);
+      if (!isChanged(verseToolId)) {
+        toolChanged(verseToolId);
+      }
+      checkBlockersAndScheduleAutosave();
     }
   };
 
@@ -845,8 +853,8 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toolsChanged, scheduleAutosave]);
 
-  useEffect(() => {
-    if (!isChanged(verseToolId) || !hasPermission || savingRef.current) return;
+  const checkBlockersAndScheduleAutosave = () => {
+    if (!hasPermission) return;
     const allIssues = checkRefs();
     const blockers = checkAutosaveBlockers();
     setSaveIssues(allIssues);
@@ -885,8 +893,7 @@ export function PassageDetailMarkVerses({ width }: MarkVersesProps) {
       setIssuesDialogOpen(false);
     }
     scheduleAutosave();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toolsChanged, hasPermission, scheduleAutosave]);
+  };
 
   return Boolean(mediafileId) && passType !== PassageTypeEnum.NOTE ? (
     <Box>

--- a/src/renderer/src/hoc/SnackBar.tsx
+++ b/src/renderer/src/hoc/SnackBar.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { useGlobal } from '../context/useGlobal';
 import {
   Snackbar as MuiSnackbar,
@@ -45,8 +45,9 @@ function SimpleSnackbar(props: ISBProps) {
   };
 
   useEffect(() => {
-    if ((message?.type === 'span') !== open) {
-      setOpen(!open);
+    const hasMessage = !!message && message.type !== Fragment;
+    if (hasMessage !== open) {
+      setOpen(hasMessage);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message]);


### PR DESCRIPTION
## Summary

- Converts autosave logic in `PassageDetailMarkVerses` from a `useEffect` (triggered by `toolsChanged` state) to a direct `checkBlockersAndScheduleAutosave()` function called on every cell/segment change — this ensures autosave fires immediately when a user edits a Segment Reference cell rather than waiting for a separate state update cycle.

- Fixes `SnackBar` open-state detection: replaces the brittle `message?.type === 'span'` check with `!!message && message.type !== Fragment` so snackbar correctly opens/closes when message content is a non-span React element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)