### PR TITLE
TT-7354 Single passage or step dropdown display small box

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -103,6 +103,20 @@ const mockSection = {
   },
 } as any;
 
+// Section with only the current passage (single dropdown option)
+const mockSectionSinglePassage = {
+  id: 'section-1',
+  relationships: {
+    passages: {
+      data: [{ type: 'passage', id: 'p-1' }],
+    },
+  },
+} as any;
+
+const mockSectionPassageRecordsSingle = {
+  'passage:p-1': mockSectionPassageRecords['passage:p-1'],
+};
+
 const mockCurrentPassage = {
   id: 'p-1',
   attributes: { sequencenum: 1, reference: '1:1', book: 'GEN' },
@@ -389,7 +403,12 @@ describe('MobileWorkflowSteps', () => {
     });
 
     it('blocks passage dropdown and shows wait message when remote is busy', () => {
-      mountMobileWorkflowSteps({ isStepProgression: true, remoteBusy: true });
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        remoteBusy: true,
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
 
       cy.get('[data-cy="passage-dropdown"]').click();
 
@@ -415,6 +434,23 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[role="menu"]').should('be.visible');
       cy.get('[role="menuitem"]').should('have.length', 2);
       cy.get('[role="menuitem"]').eq(0).should('contain.text', 'GEN 1:1');
+    });
+
+    it('does not open the dropdown when the section has only one passage', () => {
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        section: mockSectionSinglePassage,
+        extraMemoryRecords: mockSectionPassageRecordsSingle,
+      });
+
+      cy.get('[data-cy="passage-dropdown"]')
+        .should('contain.text', 'GEN 1:1')
+        .find('[data-testid="ArrowDropDownIcon"]')
+        .should('not.exist');
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('not.exist');
     });
 
     it('renders the step label as plain text when the current step has no tip', () => {
@@ -465,6 +501,21 @@ describe('MobileWorkflowSteps', () => {
 
       cy.get('[role="menu"]').should('be.visible');
       cy.get('[role="menuitem"]').should('have.length', 2);
+    });
+
+    it('does not open the dropdown when there is only one workflow step', () => {
+      mountMobileWorkflowSteps({
+        workflow: [{ id: 'step-1', label: 'Record' }],
+      });
+
+      cy.get('[data-cy="passage-dropdown"]')
+        .should('contain.text', 'Record')
+        .find('[data-testid="ArrowDropDownIcon"]')
+        .should('not.exist');
+
+      cy.get('[data-cy="passage-dropdown"]').click();
+
+      cy.get('[role="menu"]').should('not.exist');
     });
 
     it('blocks passage click while recording', () => {

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -540,20 +540,4 @@ describe('MobileWorkflowSteps', () => {
       cy.get('@setCurrentStep').should('not.have.been.called');
     });
   });
-
-  describe('spacer responsive behavior', () => {
-    it('hides the spacer below 840px to prevent extra horizontal scroll', () => {
-      cy.viewport(839, 600);
-      mountMobileWorkflowSteps({ isStepProgression: true });
-
-      cy.get('[data-cy="step-spacer"]').should('have.css', 'display', 'none');
-    });
-
-    it('shows the spacer at 840px and above to preserve parallelogram centering', () => {
-      cy.viewport(840, 600);
-      mountMobileWorkflowSteps({ isStepProgression: true });
-
-      cy.get('[data-cy="step-spacer"]').should('have.css', 'display', 'block');
-    });
-  });
 });

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -275,13 +275,13 @@ export default function MobileWorkflowSteps() {
             overflowX: 'auto',
             display: 'flex',
             flex: { xs: 1, md: 'none' },
-            justifyContent: {
-              xs: 'flex-start',
-              md: 'center',
-            },
             position: { md: 'absolute' },
             left: { md: 0 },
             right: { md: 0 },
+            '&::before, &::after': {
+              content: '""',
+              margin: 'auto',
+            },
           }}
         >
           {steps.map((step) => {

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -234,7 +234,7 @@ export default function MobileWorkflowSteps() {
             }}
             data-cy="passage-dropdown"
           >
-            {isStepProgression ? passageRef(passage) : currentLabel}
+            {isStepProgression ? passageRef(passage) : getWfLabel(currentLabel)}
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -72,7 +72,7 @@ export default function MobileWorkflowSteps() {
   const didMountRef = useRef(false);
   const stepRefs = useRef(new Map<string, HTMLElement>());
 
-  // Ordered list of passages in the current section, excluding publishing-title rows, sorted by sequence number.
+  // Ordered list of passages in the current section, excluding publishing-title rows, sorted by sequence number
   const sectionPassages = useMemo<PassageD[]>(() => {
     const passRecIds = related(section, 'passages');
     if (!Array.isArray(passRecIds)) return [];
@@ -114,6 +114,10 @@ export default function MobileWorkflowSteps() {
     rememberCurrentPassage(memory, remId);
     passageNavigate(`/detail/${prjId}/${remId}`);
   };
+
+  // Check if the dropdown has more than one option to pick from
+  const dropdownOptions = isStepProgression ? sectionPassages : workflow;
+  const hasMultipleOptions = dropdownOptions.length > 1;
 
   const handleSelect = (id: string) => () => {
     if (getGlobal('remoteBusy')) {
@@ -219,12 +223,13 @@ export default function MobileWorkflowSteps() {
           )}
           <Button
             size="small"
-            endIcon={<ArrowDropDownIcon />}
+            endIcon={hasMultipleOptions ? <ArrowDropDownIcon /> : undefined}
             sx={{
               whiteSpace: 'nowrap',
               minWidth: 'auto',
             }}
             onClick={(e) => {
+              if (!hasMultipleOptions) return;
               if (recording || commentRecording) return;
               if (getGlobal('remoteBusy')) {
                 showMessage(ts.wait);

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -20,7 +20,7 @@ import { useSnackBar } from '../../../hoc/SnackBar';
 import { sharedSelector, workflowStepsSelector } from '../../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useWfLabel } from '../../../utils/useWfLabel';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings, PassageD } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
 import { related } from '../../../crud/related';
@@ -67,6 +67,12 @@ export default function MobileWorkflowSteps() {
     workflowStepsSelector,
     shallowEqual
   );
+
+  // Refs used to scroll the current step/passage into view
+  const didMountRef = useRef(false);
+  const stepRefs = useRef(new Map<string, HTMLElement>());
+
+  // Ordered list of passages in the current section, excluding publishing-title rows, sorted by sequence number.
   const sectionPassages = useMemo<PassageD[]>(() => {
     const passRecIds = related(section, 'passages');
     if (!Array.isArray(passRecIds)) return [];
@@ -82,20 +88,13 @@ export default function MobileWorkflowSteps() {
   const [passageMenuAnchor, setPassageMenuAnchor] =
     useState<HTMLElement | null>(null);
 
-  const handleSelect = (id: string) => () => {
-    if (getGlobal('remoteBusy')) {
-      showMessage(ts.wait);
-      return;
-    }
-    if (!recording && !commentRecording && id !== currentstep) {
-      setCurrentStep(id);
-    }
-  };
-
+  // The display label of the currently workflow step
   const currentLabel = useMemo(
     () => workflow.find((w) => w.id === currentstep)?.label ?? '',
     [currentstep, workflow]
   );
+
+  // The tip text for the current workflow step
   const currentTip = useMemo(() => {
     if (!currentLabel) return '';
     if (tool === ToolSlug.Prompt && showPromptAdmin) {
@@ -107,25 +106,57 @@ export default function MobileWorkflowSteps() {
       : '';
   }, [currentLabel, t, tool, showPromptAdmin]);
 
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [dropdownWidth, setDropdownWidth] = useState(0);
+  const passageRef = (p?: PassageD) =>
+    [p?.attributes?.book, p?.attributes?.reference].filter(Boolean).join(' ');
 
-  useLayoutEffect(() => {
-    const el = dropdownRef.current;
-    if (!el) return;
-    const update = () =>
-      setDropdownWidth(
-        el.offsetWidth + parseFloat(window.getComputedStyle(el).marginRight)
-      );
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  const navigateToPassage = (p: PassageD) => {
+    const remId = p.keys?.remoteId ?? p.id;
+    rememberCurrentPassage(memory, remId);
+    passageNavigate(`/detail/${prjId}/${remId}`);
+  };
 
-  const didMountRef = useRef(false);
-  const stepRefs = useRef(new Map<string, HTMLElement>());
+  const handleSelect = (id: string) => () => {
+    if (getGlobal('remoteBusy')) {
+      showMessage(ts.wait);
+      return;
+    }
+    if (!recording && !commentRecording && id !== currentstep) {
+      setCurrentStep(id);
+    }
+  };
 
+  const isInteractionBlocked = () => {
+    if (recording || commentRecording) return true;
+    if (getGlobal('remoteBusy')) {
+      showMessage(ts.wait);
+      return true;
+    }
+    return false;
+  };
+
+  // The step/passage data model for the parallelograms
+  const steps = isStepProgression
+    ? workflow.map((s) => ({
+        id: s.id,
+        dataCy: 'workflow-step',
+        isCurrent: s.id === currentstep,
+        isComplete: stepComplete(s.id),
+        onClick: handleSelect(s.id),
+      }))
+    : sectionPassages.map((p) => ({
+        id: p.id,
+        dataCy: 'passage-step',
+        isCurrent: p.id === passage?.id,
+        isComplete:
+          (p.attributes.sequencenum ?? 0) <
+          (passage?.attributes?.sequencenum ?? 0),
+        onClick: () => {
+          if (isInteractionBlocked()) return;
+          navigateToPassage(p);
+        },
+      }));
+
+  // Keep the current step/passage scrolled into view
   useEffect(() => {
     const currentId = isStepProgression ? currentstep : (passage?.id ?? '');
     const el = stepRefs.current.get(currentId);
@@ -145,18 +176,35 @@ export default function MobileWorkflowSteps() {
   ]);
 
   return (
-    <Box sx={{ px: 1.5, py: 1 }} data-cy="workflow-steps">
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        py: 1,
+        px: 1.5,
+      }}
+      data-cy="workflow-steps"
+    >
+      {/* Top row with the passage dropdown and parallelograms */}
       <Box
         sx={{
+          position: 'relative',
           display: 'flex',
-          alignItems: 'flex-start',
+          alignItems: 'center',
           width: '100%',
         }}
       >
         {/* Passage dropdown */}
         <Box
-          ref={dropdownRef}
-          sx={{ flexShrink: 0, mr: 1, display: 'flex', alignItems: 'center' }}
+          sx={{
+            flexShrink: 0,
+            position: 'relative',
+            zIndex: 1,
+            mr: 1,
+            display: 'flex',
+            alignItems: 'center',
+          }}
         >
           {!isStepProgression && currentTip && (
             <IconButton
@@ -172,7 +220,10 @@ export default function MobileWorkflowSteps() {
           <Button
             size="small"
             endIcon={<ArrowDropDownIcon />}
-            sx={{ whiteSpace: 'nowrap', minWidth: 'auto' }}
+            sx={{
+              whiteSpace: 'nowrap',
+              minWidth: 'auto',
+            }}
             onClick={(e) => {
               if (recording || commentRecording) return;
               if (getGlobal('remoteBusy')) {
@@ -183,11 +234,7 @@ export default function MobileWorkflowSteps() {
             }}
             data-cy="passage-dropdown"
           >
-            {isStepProgression
-              ? [passage?.attributes?.book, passage?.attributes?.reference]
-                  .filter(Boolean)
-                  .join(' ') || ''
-              : currentLabel}
+            {isStepProgression ? passageRef(passage) : currentLabel}
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}
@@ -200,15 +247,11 @@ export default function MobileWorkflowSteps() {
                     key={p.id}
                     selected={p.id === passage?.id}
                     onClick={() => {
-                      const remId = p.keys?.remoteId ?? p.id;
-                      rememberCurrentPassage(memory, remId);
-                      passageNavigate(`/detail/${prjId}/${remId}`);
+                      navigateToPassage(p);
                       setPassageMenuAnchor(null);
                     }}
                   >
-                    {[p.attributes.book, p.attributes.reference]
-                      .filter(Boolean)
-                      .join(' ')}
+                    {passageRef(p)}
                   </MenuItem>
                 ))
               : workflow.map((step) => (
@@ -225,145 +268,83 @@ export default function MobileWorkflowSteps() {
                 ))}
           </Menu>
         </Box>
-        {/* Workflow step parallelograms */}
+
+        {/* Step/passage parallelograms */}
         <Box
           sx={{
-            flex: 1,
-            display: 'flex',
             overflowX: 'auto',
-            overflowY: 'hidden',
-            WebkitOverflowScrolling: 'touch',
+            display: 'flex',
+            flex: { xs: 1, md: 'none' },
+            justifyContent: {
+              xs: 'flex-start',
+              md: 'center',
+            },
+            position: { md: 'absolute' },
+            left: { md: 0 },
+            right: { md: 0 },
           }}
         >
-          <Box sx={{ display: 'flex', mx: 'auto', pb: 0.25 }}>
-            {isStepProgression
-              ? workflow.map((step) => {
-                  const isCurrent = step.id === currentstep;
-                  return (
-                    <ButtonBase
-                      key={step.id}
-                      data-cy="workflow-step"
-                      role="button"
-                      onClick={handleSelect(step.id)}
-                      tabIndex={0}
-                      ref={(el) => {
-                        if (el) stepRefs.current.set(step.id, el);
-                        else stepRefs.current.delete(step.id);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                        }
-                      }}
-                      sx={{
-                        flex: '0 0 80px',
-                        height: 30,
-                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
-                        backgroundColor: isCurrent
-                          ? theme.palette.grey[700]
-                          : stepComplete(step.id)
-                            ? theme.palette.grey[400]
-                            : theme.palette.grey[200],
-                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                        cursor:
-                          recording || commentRecording
-                            ? 'not-allowed'
-                            : 'pointer',
-                      }}
-                    />
-                  );
-                })
-              : sectionPassages.map((p) => {
-                  const isCurrent = p.id === passage?.id;
-                  const isComplete =
-                    (p.attributes.sequencenum ?? 0) <
-                    (passage?.attributes?.sequencenum ?? 0);
-                  return (
-                    <ButtonBase
-                      key={p.id}
-                      data-cy="passage-step"
-                      role="button"
-                      onClick={() => {
-                        if (recording || commentRecording) return;
-                        if (getGlobal('remoteBusy')) {
-                          showMessage(ts.wait);
-                          return;
-                        }
-                        const remId = p.keys?.remoteId ?? p.id;
-                        rememberCurrentPassage(memory, remId);
-                        passageNavigate(`/detail/${prjId}/${remId}`);
-                      }}
-                      tabIndex={0}
-                      ref={(el) => {
-                        if (el) stepRefs.current.set(p.id, el);
-                        else stepRefs.current.delete(p.id);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                        }
-                      }}
-                      sx={{
-                        flex: '0 0 80px',
-                        height: 30,
-                        mr: -0.25, // Overlap adjacent parallelograms so their edges meet cleanly
-                        backgroundColor: isCurrent
-                          ? theme.palette.grey[700]
-                          : isComplete
-                            ? theme.palette.grey[400]
-                            : theme.palette.grey[200],
-                        clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
-                        cursor:
-                          recording || commentRecording
-                            ? 'not-allowed'
-                            : 'pointer',
-                      }}
-                    />
-                  );
-                })}
-            {/* Spacer to mirror the dropdown width so mx:auto centers the parallelograms */}
-            <Box
-              data-cy="step-spacer"
-              sx={{
-                flexShrink: 0,
-                width: dropdownWidth,
-                display: 'none',
-                '@media (min-width: 840px)': { display: 'block' },
-              }}
-            />
-          </Box>
-        </Box>
-      </Box>
-      {(isStepProgression ? currentLabel : passage?.id) && (
-        <Typography
-          sx={{ mt: 1, textAlign: 'center' }}
-          data-cy="workflow-step-label"
-        >
-          {isStepProgression ? (
-            currentTip ? (
-              <ButtonBase
-                onClick={() => setTipOpen(true)}
-                data-cy="workflow-step-tip"
-                sx={{
-                  borderRadius: 1,
-                  fontWeight: 'inherit',
-                  fontSize: 'inherit',
+          {steps.map((step) => {
+            const color = step.isCurrent
+              ? theme.palette.grey[700]
+              : step.isComplete
+                ? theme.palette.grey[400]
+                : theme.palette.grey[200];
+            return (
+              <Box
+                key={step.id}
+                data-cy={step.dataCy}
+                ref={(el: HTMLElement | null) => {
+                  if (el) stepRefs.current.set(step.id, el);
+                  else stepRefs.current.delete(step.id);
                 }}
-                aria-label={currentTip}
-              >
-                {getWfLabel(currentLabel) + '\u00A0'}
-                <InfoIcon color="info" fontSize="small" />
-              </ButtonBase>
-            ) : (
-              getWfLabel(currentLabel)
-            )
+                onClick={step.onClick}
+                sx={{
+                  flex: '0 0 80px',
+                  height: 30,
+                  bgcolor: color,
+                  mr: -0.25,
+                  clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                  cursor:
+                    recording || commentRecording ? 'not-allowed' : 'pointer',
+                }}
+              />
+            );
+          })}
+        </Box>
+
+        {/* Spacer to center the parallelograms in the top row on desktop screens */}
+        <Box
+          sx={{ height: 30, flex: 1, display: { xs: 'none', md: 'block' } }}
+        />
+      </Box>
+
+      {/* Bottom row with the labels */}
+      <Typography sx={{ mt: 1 }} data-cy="workflow-step-label">
+        {isStepProgression ? (
+          currentTip ? (
+            <ButtonBase
+              onClick={() => setTipOpen(true)}
+              data-cy="workflow-step-tip"
+              sx={{
+                borderRadius: 1,
+                fontWeight: 'inherit',
+                fontSize: 'inherit',
+              }}
+              aria-label={currentTip}
+            >
+              {getWfLabel(currentLabel) + '\u00A0'}
+              <InfoIcon color="info" fontSize="small" />
+            </ButtonBase>
           ) : (
-            [passage?.attributes?.book, passage?.attributes?.reference]
-              .filter(Boolean)
-              .join(' ')
-          )}
-        </Typography>
-      )}
+            getWfLabel(currentLabel)
+          )
+        ) : (
+          passageRef(passage)
+        )}
+      </Typography>
+
+      {/* Tip dialog */}
       <Dialog open={tipOpen} onClose={() => setTipOpen(false)}>
         <DialogTitle>{getWfLabel(currentLabel)}</DialogTitle>
         <DialogContent>{currentTip}</DialogContent>


### PR DESCRIPTION
Changes:

- Made changes to how parallelograms are drawn so that they are correctly positioned and centered across desktop and mobile screen sizes (this was an unidentified bug in the screenshots shown in the Jira issue).
- Updated the dropdown to use localized labels (another unidentified bug).
- When there is just a single element in the dropdown (in either passage or step progression mode), disable the dropdown rather than showing the one element (this addresses the problem by avoiding it altogether).