### PR TITLE
TT-7368 Race track hidden when general project dropdown expands with long values

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -269,6 +269,12 @@ export default function MobileWorkflowSteps() {
                       navigateToPassage(p);
                       setPassageMenuAnchor(null);
                     }}
+                    sx={{
+                      display: 'block',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
                   >
                     {passageRef(p)}
                   </MenuItem>
@@ -280,6 +286,12 @@ export default function MobileWorkflowSteps() {
                     onClick={() => {
                       handleSelect(step.id)();
                       setPassageMenuAnchor(null);
+                    }}
+                    sx={{
+                      display: 'block',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
                     }}
                   >
                     {getWfLabel(step.label)}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -225,8 +225,10 @@ export default function MobileWorkflowSteps() {
             size="small"
             endIcon={hasMultipleOptions ? <ArrowDropDownIcon /> : undefined}
             sx={{
-              whiteSpace: 'nowrap',
               minWidth: 'auto',
+              // These per-breakpoint widths are fine-tuned to constrain the dropdown so
+              // its label truncates before it can overlap the parallelograms
+              maxWidth: { xs: '45vw', md: '20vw', lg: '25vw' },
             }}
             onClick={(e) => {
               if (!hasMultipleOptions) return;
@@ -239,7 +241,19 @@ export default function MobileWorkflowSteps() {
             }}
             data-cy="passage-dropdown"
           >
-            {isStepProgression ? passageRef(passage) : getWfLabel(currentLabel)}
+            <Box
+              component="span"
+              sx={{
+                minWidth: 0,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {isStepProgression
+                ? passageRef(passage)
+                : getWfLabel(currentLabel)}
+            </Box>
           </Button>
           <Menu
             anchorEl={passageMenuAnchor}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -226,6 +226,7 @@ export default function MobileWorkflowSteps() {
             endIcon={hasMultipleOptions ? <ArrowDropDownIcon /> : undefined}
             sx={{
               minWidth: 'auto',
+              textTransform: 'none',
               // These per-breakpoint widths are fine-tuned to constrain the dropdown so
               // its label truncates before it can overlap the parallelograms
               maxWidth: { xs: '45vw', md: '20vw', lg: '25vw' },


### PR DESCRIPTION
Changes:

- Made the dropdown menu label truncate with ellipsis when it reaches certain viewport size breakpoint
- Made the dropdown menu item label truncate with ellipsis so that it appears less jarring than when it is clipped
- Disabled the dropdown menu label capitalization to improve consistency