### PR TITLE
TT-7437,7438,7439 feat: implement segment locking during recording and saving processes

### DIFF
--- a/migration/usj-structure.test.mjs
+++ b/migration/usj-structure.test.mjs
@@ -10,10 +10,16 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function fixture(name) {
   return fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf-8');
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function pickShape(structure) {
   return {
     sections: structure.sections.map((section) => ({

--- a/src/renderer/src/components/MediaRecord.tsx
+++ b/src/renderer/src/components/MediaRecord.tsx
@@ -398,6 +398,19 @@ function MediaRecord(props: IProps) {
     setConverting(false);
     if (onReady) onReady();
   };
+
+  const handleSaveFailed = useCallback(
+    (error: unknown) => {
+      saveRef.current = false;
+      setUploading(false);
+      setConverting(false);
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'Save failed');
+      saveCompleted(toolId, message);
+      onReady?.();
+    },
+    [toolId, saveCompleted, onReady]
+  );
   useEffect(() => {
     const limit = sizeLimit * compression;
     const big = (audioBlob?.size ?? 0) > limit * 1000000;
@@ -434,9 +447,11 @@ function MediaRecord(props: IProps) {
             setConverting(true);
             convertToFormat(audioBlob, mimeType)
               .then((convert_blob) =>
-                doUpload(convert_blob, mimeType, filetype).then(() => {
-                  convertComplete();
-                })
+                doUpload(convert_blob, mimeType, filetype)
+                  .then(() => {
+                    convertComplete();
+                  })
+                  .catch(handleSaveFailed)
               )
               .catch((error) => {
                 // If conversion fails, show error and save as WAV instead
@@ -445,14 +460,18 @@ function MediaRecord(props: IProps) {
                   (error instanceof Error ? '    ' + error.message : '');
                 showMessage(errorMessage);
                 setConverting(false);
-                doUpload(audioBlob, 'audio/wav', 'wav').then(() => {
-                  onReady && onReady();
-                });
+                doUpload(audioBlob, 'audio/wav', 'wav')
+                  .then(() => {
+                    onReady && onReady();
+                  })
+                  .catch(handleSaveFailed);
               });
           } else {
-            doUpload(audioBlob, mimeType, filetype).then(() => {
-              onReady && onReady();
-            });
+            doUpload(audioBlob, mimeType, filetype)
+              .then(() => {
+                onReady && onReady();
+              })
+              .catch(handleSaveFailed);
           }
           return;
         } else {

--- a/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.test.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.test.tsx
@@ -406,7 +406,24 @@ describe('PassageDetailCarefulSpeech — recording segment lock (TT-7437)', () =
 });
 
 describe('PassageDetailCarefulSpeech — save in progress (TT-7439)', () => {
-  it('disables Next Clause and locks segments while upload is saving', async () => {
+  it('disables Next Clause and locks segments once save begins', async () => {
+    mockCompleted = new Set([0, 1]);
+    await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(true);
+      (controlsProps?.onRecording as (active: boolean) => void)(false);
+    });
+    await act(async () => {
+      (controlsProps?.setCanSave as (v: boolean) => void)(true);
+    });
+
+    expect(controlsProps?.savingRecording).toBe(true);
+    expect(playerProps?.lockSegmentSelection).toBe(true);
+  });
+
+  it('does not stick saving when recording never started', async () => {
     mockCompleted = new Set([0, 1]);
     await mountAndSettle();
     await firePlaybackEnd(2);
@@ -415,8 +432,8 @@ describe('PassageDetailCarefulSpeech — save in progress (TT-7439)', () => {
       (controlsProps?.onRecording as (active: boolean) => void)(false);
     });
 
-    expect(controlsProps?.savingRecording).toBe(true);
-    expect(playerProps?.lockSegmentSelection).toBe(true);
+    expect(controlsProps?.savingRecording).toBe(false);
+    expect(controlsProps?.phase).toBe('recordReady');
   });
 
   it('re-enables Next Clause after upload completes', async () => {
@@ -425,7 +442,11 @@ describe('PassageDetailCarefulSpeech — save in progress (TT-7439)', () => {
     await firePlaybackEnd(2);
 
     await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(true);
       (controlsProps?.onRecording as (active: boolean) => void)(false);
+    });
+    await act(async () => {
+      (controlsProps?.setCanSave as (v: boolean) => void)(true);
     });
     await act(async () => {
       await (

--- a/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.test.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.test.tsx
@@ -356,3 +356,86 @@ describe('PassageDetailCarefulSpeech — recording-pass playback', () => {
     expect(stubControls.setPlay).toHaveBeenCalledWith(true);
   });
 });
+
+describe('PassageDetailCarefulSpeech — recording segment lock (TT-7437)', () => {
+  it('locks the source player while a clause recording is in progress', async () => {
+    mockCompleted = new Set([0, 1]);
+    await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(true);
+    });
+
+    expect(playerProps?.lockSegmentSelection).toBe(true);
+  });
+
+  it('ignores segment changes while recording is in progress', async () => {
+    mockCompleted = new Set([0, 1]);
+    const { rerender } = await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(true);
+    });
+
+    stubControls.setPlay.mockClear();
+    stubControls.gotoTime.mockClear();
+
+    await moveEngineToClause(6, rerender);
+
+    expect(stubControls.setPlay).not.toHaveBeenCalledWith(true);
+    expect(stubControls.gotoTime).not.toHaveBeenCalledWith(
+      seekFor(6),
+      regions[6]
+    );
+    expect(controlsProps?.phase).toBe('recording');
+  });
+
+  it('sets context recording while a clause recording is in progress', async () => {
+    mockCompleted = new Set([0, 1]);
+    await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(true);
+    });
+
+    expect(ctx.setRecording).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('PassageDetailCarefulSpeech — save in progress (TT-7439)', () => {
+  it('disables Next Clause and locks segments while upload is saving', async () => {
+    mockCompleted = new Set([0, 1]);
+    await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(false);
+    });
+
+    expect(controlsProps?.savingRecording).toBe(true);
+    expect(playerProps?.lockSegmentSelection).toBe(true);
+  });
+
+  it('re-enables Next Clause after upload completes', async () => {
+    mockCompleted = new Set([0, 1]);
+    await mountAndSettle();
+    await firePlaybackEnd(2);
+
+    await act(async () => {
+      (controlsProps?.onRecording as (active: boolean) => void)(false);
+    });
+    await act(async () => {
+      await (
+        controlsProps?.afterUploadCb as (
+          mediaId: string | undefined
+        ) => Promise<void>
+      )('media-new');
+    });
+
+    expect(controlsProps?.savingRecording).toBe(false);
+    expect(playerProps?.lockSegmentSelection).toBe(false);
+  });
+});

--- a/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.tsx
@@ -147,7 +147,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
   // value; reading this ref makes the recording/listen branch decision reflect
   // intent immediately rather than waiting for a render (TT-7360).
   const recordingPassStartedRef = useRef(false);
-  /** Set synchronously in onRecording so segment navigation is blocked before React re-renders (TT-7437). */
+  /** Mirrors context recording for segment-lock checks once capture is active. */
   const recordingActiveRef = useRef(false);
   // Set true when we park after an auto-play. The playback overshoot into the
   // next clause (or a recorder-mount-induced region-in) advances by exactly one
@@ -355,7 +355,10 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
   }, [currentRegion, currentIndex]);
 
   useEffect(() => {
-    if (canSave) startSave(toolId);
+    if (canSave) {
+      setSavingRecording(true);
+      startSave(toolId);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canSave]);
 
@@ -1143,14 +1146,21 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
           recordingMediaId={recordingRow?.mediafile?.id}
           afterUploadCb={afterUploadCb}
           onRecording={(active) => {
-            recordingActiveRef.current = active;
-            setRecording(active);
             if (active) {
+              recordingActiveRef.current = true;
+              setRecording(true);
               setPhase('recording');
-            } else if (showRecorder) {
-              setSavingRecording(true);
-              setPhase('recorded');
+              return;
             }
+            const wasRecording = recordingActiveRef.current;
+            recordingActiveRef.current = false;
+            setRecording(false);
+            if (!showRecorder) return;
+            if (!wasRecording) {
+              setSavingRecording(false);
+              return;
+            }
+            setPhase('recorded');
           }}
           resetMedia={resetMedia}
           setResetMedia={setResetMedia}

--- a/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailCarefulSpeech.tsx
@@ -139,6 +139,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
   const [resetMedia, setResetMedia] = useState(false);
   const [statusText, setStatusText] = useState('');
   const [canSave, setCanSave] = useState(false);
+  const [savingRecording, setSavingRecording] = useState(false);
   const [recordingPassStarted, setRecordingPassStarted] = useState(false);
   // Mirror of recordingPassStarted set synchronously at the call sites below.
   // region-out can fire before React commits the state-update render, leaving
@@ -146,6 +147,8 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
   // value; reading this ref makes the recording/listen branch decision reflect
   // intent immediately rather than waiting for a render (TT-7360).
   const recordingPassStartedRef = useRef(false);
+  /** Set synchronously in onRecording so segment navigation is blocked before React re-renders (TT-7437). */
+  const recordingActiveRef = useRef(false);
   // Set true when we park after an auto-play. The playback overshoot into the
   // next clause (or a recorder-mount-induced region-in) advances by exactly one
   // clause; this lets the recording effect swallow that single +1 advance while
@@ -480,6 +483,8 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
     setCurrentIndex(0);
     setRecordingPassStarted(false);
     recordingPassStartedRef.current = false;
+    recordingActiveRef.current = false;
+    setSavingRecording(false);
     pendingOvershootSwallowRef.current = false;
     setHeardIndices([]);
     setCurrentClausePlayed(false);
@@ -712,6 +717,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
     const seg = getCurrentSegment();
     if (!seg || clauseRegions.length === 0 || !recordingPassStarted) return;
     if (!entryPositioned) return;
+    if (recordingActiveRef.current || savingRecording) return;
     const idx = findClauseIndex(clauseRegions, seg);
     if (idx < 0) return;
 
@@ -771,6 +777,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
     setCurrentSegment,
     playCurrentClause,
     snapToClauseStart,
+    savingRecording,
   ]);
 
   useEffect(() => {
@@ -959,6 +966,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
   ]);
 
   const handleNextClause = useCallback(async () => {
+    if (savingRecording) return;
     const effectiveCompleted = new Set(completedIndices);
     effectiveCompleted.add(currentIndex);
     const next = firstIncompleteClauseIndex(clauseRegions, effectiveCompleted);
@@ -988,11 +996,13 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
     setCurrentSegment,
     playCurrentClause,
     applyColors,
+    savingRecording,
   ]);
 
   const afterUploadCb = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async (_mediaId: string | undefined) => {
+      setSavingRecording(false);
       forceRefresh();
       setPhase('recorded');
       setResetMedia(false);
@@ -1084,6 +1094,7 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
           highlightPlay={highlightPlayButton}
           onPlayStatusNotify={handlePlayStatusNotify}
           beforePlay={handleBeforeSourcePlay}
+          lockSegmentSelection={phase === 'recording' || savingRecording}
           allowZoom={true}
         />
       )}
@@ -1120,6 +1131,9 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
           allClausesComplete={allClausesComplete}
           highlightSpeaker={highlightSpeaker}
           allowRecord={allowRecord}
+          savingRecording={savingRecording}
+          onSaving={() => setSavingRecording(true)}
+          onSaveSettled={() => setSavingRecording(false)}
           toolId={toolId}
           passageId={related(playerMediafile, 'passage') ?? passage?.id}
           artifactId={artifactTypeId}
@@ -1129,10 +1143,12 @@ export function PassageDetailCarefulSpeech({ width }: IProps) {
           recordingMediaId={recordingRow?.mediafile?.id}
           afterUploadCb={afterUploadCb}
           onRecording={(active) => {
+            recordingActiveRef.current = active;
             setRecording(active);
             if (active) {
               setPhase('recording');
             } else if (showRecorder) {
+              setSavingRecording(true);
               setPhase('recorded');
             }
           }}

--- a/src/renderer/src/components/PassageDetail/PassageDetailChooser.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailChooser.tsx
@@ -43,17 +43,20 @@ export const PassageDetailChooser = ({ width, sx }: IProps) => {
     chooserSize,
     setChooserSize,
     setCurrentStep,
-    recording,
-    commentRecording,
+    isNavigationBlocked,
   } = usePassageDetailContext();
   const [passageCount, setPassageCount] = useState(0);
   const [value, setValue] = useState(0);
   const marks = useRef<Array<Mark>>([]);
   const [view, setView] = useState('');
   const { getSharedResource } = useSharedResRead();
-  const passageNavigate = usePassageNavigate(() => {
-    setView('');
-  }, setCurrentStep);
+  const passageNavigate = usePassageNavigate(
+    () => {
+      setView('');
+    },
+    setCurrentStep,
+    isNavigationBlocked
+  );
 
   const t = useSelector(
     passageChooserSelector,
@@ -61,7 +64,7 @@ export const PassageDetailChooser = ({ width, sx }: IProps) => {
   ) as IPassageChooserStrings;
 
   const handleChange = (event: React.SyntheticEvent, newValue: any) => {
-    if (recording || commentRecording) return;
+    if (isNavigationBlocked()) return;
     if (typeof newValue === 'number') {
       if (newValue !== value) {
         const selId = marks.current[newValue]?.id;

--- a/src/renderer/src/components/PassageDetail/PassageDetailChooser.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailChooser.tsx
@@ -35,13 +35,21 @@ interface IProps {
 
 export const PassageDetailChooser = ({ width, sx }: IProps) => {
   const [memory] = useGlobal('memory');
-  const { passage, section, prjId, allBookData, chooserSize, setChooserSize } =
-    usePassageDetailContext();
+  const {
+    passage,
+    section,
+    prjId,
+    allBookData,
+    chooserSize,
+    setChooserSize,
+    setCurrentStep,
+    recording,
+    commentRecording,
+  } = usePassageDetailContext();
   const [passageCount, setPassageCount] = useState(0);
   const [value, setValue] = useState(0);
   const marks = useRef<Array<Mark>>([]);
   const [view, setView] = useState('');
-  const { setCurrentStep } = usePassageDetailContext();
   const { getSharedResource } = useSharedResRead();
   const passageNavigate = usePassageNavigate(() => {
     setView('');
@@ -53,6 +61,7 @@ export const PassageDetailChooser = ({ width, sx }: IProps) => {
   ) as IPassageChooserStrings;
 
   const handleChange = (event: React.SyntheticEvent, newValue: any) => {
+    if (recording || commentRecording) return;
     if (typeof newValue === 'number') {
       if (newValue !== value) {
         const selId = marks.current[newValue]?.id;

--- a/src/renderer/src/components/PassageDetail/PassageDetailPlayer.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailPlayer.tsx
@@ -103,6 +103,8 @@ export interface DetailPlayerProps {
   setPlayingOverride?: (playing: boolean) => void;
   /** Invoked before starting playback. Return false to skip default play handling. */
   beforePlay?: () => void | Promise<void | boolean>;
+  /** When true, waveform region clicks cannot change the selected segment. */
+  lockSegmentSelection?: boolean;
 }
 
 export function PassageDetailPlayer(props: DetailPlayerProps) {
@@ -140,6 +142,7 @@ export function PassageDetailPlayer(props: DetailPlayerProps) {
     playing: playingOverride,
     setPlayingOverride,
     beforePlay,
+    lockSegmentSelection,
   } = props;
 
   const allowZoom = allowZoomProp ?? allowZoomAndSpeed ?? false;
@@ -405,6 +408,7 @@ export function PassageDetailPlayer(props: DetailPlayerProps) {
         isPlaying={requestPlay.play}
         regionOnly={requestPlay.regionOnly}
         forceRegionOnly={forceRegionOnly}
+        lockSegmentSelection={lockSegmentSelection}
         request={requestPlay.request}
         loading={loading}
         busy={pdBusy}

--- a/src/renderer/src/components/PassageDetail/PassageDetailStepComplete.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailStepComplete.tsx
@@ -31,6 +31,7 @@ export const PassageDetailStepComplete = () => {
     recording,
     isBoldWorkflow,
     mediafileId,
+    isNavigationBlocked,
   } = usePassageDetailContext();
   const { tool } = useStepTool(currentstep);
   const { isMobile } = useMobile();
@@ -43,9 +44,13 @@ export const PassageDetailStepComplete = () => {
     passageDetailStepCompleteSelector,
     shallowEqual
   );
-  const passageNavigate = usePassageNavigate(() => {
-    setView('');
-  }, setCurrentStep);
+  const passageNavigate = usePassageNavigate(
+    () => {
+      setView('');
+    },
+    setCurrentStep,
+    isNavigationBlocked
+  );
   const { isChanged, startSave, waitForSave } =
     useContext(UnsavedContext).state;
   const { showMessage } = useSnackBar();

--- a/src/renderer/src/components/PassageDetail/WorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/WorkflowSteps.tsx
@@ -89,6 +89,7 @@ export function WorkflowSteps() {
   };
 
   const handleSelect = (item: string) => {
+    if (recording || commentRecording) return;
     if (getGlobal('remoteBusy')) {
       showMessage(ts.wait);
       return;

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
@@ -114,4 +114,19 @@ describe('CarefulSpeechControls — Next Clause completion state', () => {
     expect(next).toBeTruthy();
     expect(next?.disabled).toBe(true);
   });
+
+  it('Next Clause is disabled while the recording upload is in progress', () => {
+    const { container } = render(
+      <CarefulSpeechControls
+        {...baseProps}
+        allClausesComplete={false}
+        savingRecording={true}
+      />
+    );
+    const next = container.querySelector(
+      '#careful-speech-next'
+    ) as HTMLButtonElement | null;
+    expect(next).toBeTruthy();
+    expect(next?.disabled).toBe(true);
+  });
 });

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
@@ -50,6 +50,9 @@ interface Props {
   allClausesComplete: boolean;
   highlightSpeaker: boolean;
   allowRecord: boolean;
+  savingRecording?: boolean;
+  onSaving?: () => void;
+  onSaveSettled?: () => void;
   toolId: string;
   passageId: string | undefined;
   artifactId: string | null;
@@ -89,6 +92,9 @@ export default function CarefulSpeechControls({
   allClausesComplete,
   highlightSpeaker,
   allowRecord,
+  savingRecording = false,
+  onSaving,
+  onSaveSettled,
   toolId,
   passageId,
   artifactId,
@@ -291,6 +297,8 @@ export default function CarefulSpeechControls({
                 height={160}
                 width={width - 80}
                 afterUploadCb={afterUploadCb}
+                onSaving={onSaving}
+                onReady={onSaveSettled}
                 setCanSave={setCanSave}
                 setStatusText={setStatusText}
                 doReset={resetMedia}
@@ -317,7 +325,7 @@ export default function CarefulSpeechControls({
                 <PriButton
                   id="careful-speech-next"
                   onClick={onNextClause}
-                  disabled={allClausesComplete}
+                  disabled={allClausesComplete || savingRecording}
                   sx={primaryHighlightSx}
                 >
                   {strings.nextClause} &gt;

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -221,6 +221,7 @@ const createPassageDetailState = (
     commentRecording: false,
     stepComplete: () => false,
     setCurrentStep: cy.stub(),
+    isNavigationBlocked: () => false,
     passage: mockCurrentPassage,
     section: {} as any,
     prjId: 'proj-1',

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -47,6 +47,7 @@ export default function MobileWorkflowSteps() {
     passage,
     section,
     prjId,
+    isNavigationBlocked,
   } = usePassageDetailContext();
   const { tool } = useStepTool(currentstep);
   const { userIsAdmin } = useRole();
@@ -54,7 +55,11 @@ export default function MobileWorkflowSteps() {
   const showPromptAdmin =
     userIsAdmin || (permissionsOn && canDoSectionStep(currentstep, section));
   const [memory] = useGlobal('memory');
-  const passageNavigate = usePassageNavigate(() => {}, setCurrentStep);
+  const passageNavigate = usePassageNavigate(
+    () => {},
+    setCurrentStep,
+    isNavigationBlocked
+  );
   const getGlobal = useGetGlobal();
   const { showMessage } = useSnackBar();
   const ts = useSelector(sharedSelector, shallowEqual);

--- a/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.cy.tsx
@@ -152,6 +152,7 @@ const createPassageDetailState = (
     setStepComplete: cy.stub().resolves(),
     gotoNextStep: cy.stub(),
     setCurrentStep: cy.stub(),
+    isNavigationBlocked: () => false,
     rowData: [],
     promptPlaybackComplete: false,
     setPromptPlaybackComplete: cy.stub(),

--- a/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.tsx
@@ -60,6 +60,7 @@ export default function PassageDetailMobileFooter() {
     orgWorkflowSteps = [],
     isBoldWorkflow,
     rowData,
+    isNavigationBlocked,
   } = usePassageDetailContext();
   const { tool } = useStepTool(currentstep);
   const { hasPrompt } = usePromptSectionResource(rowData, section, currentstep);
@@ -70,7 +71,11 @@ export default function PassageDetailMobileFooter() {
   const t: IMobileStrings = useSelector(mobileSelector, shallowEqual);
   const [memory] = useGlobal('memory');
   const { prjId } = useParams();
-  const passageNavigate = usePassageNavigate(() => {}, setCurrentStep);
+  const passageNavigate = usePassageNavigate(
+    () => {},
+    setCurrentStep,
+    isNavigationBlocked
+  );
   const { getOrgDefault } = useOrgDefaults();
   const { localizedWorkStepFromId } = useOrgWorkflowSteps();
 

--- a/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
+++ b/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
@@ -6,16 +6,21 @@ import usePassageDetailContext from '../../context/usePassageDetailContext';
 
 export const usePassageNavigate = (
   cb: () => void,
-  setCurrentStep: (step: string) => void
+  setCurrentStep: (step: string) => void,
+  /** When omitted, reads from PassageDetailContext (must be under Provider). */
+  isNavigationBlockedFromCaller?: () => boolean
 ) => {
   const { pathname } = useLocation();
   const navigate = useMyNavigate();
-  const { isNavigationBlocked } = usePassageDetailContext();
+  const { isNavigationBlocked: isNavigationBlockedFromContext } =
+    usePassageDetailContext();
+  const isNavigationBlocked =
+    isNavigationBlockedFromCaller ?? isNavigationBlockedFromContext;
   const { checkSavedFn } = useContext(UnsavedContext).state;
 
   return (view: string) => {
     if (view && view !== pathname) {
-      if (isNavigationBlocked()) return;
+      if (isNavigationBlocked?.()) return;
       checkSavedFn(() => {
         if (!view.endsWith('null'))
           localStorage.setItem(localUserKey(LocalKey.url), view);

--- a/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
+++ b/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
@@ -2,25 +2,19 @@ import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { UnsavedContext } from '../../context/UnsavedContext';
 import { LocalKey, localUserKey, useMyNavigate } from '../../utils';
-import usePassageDetailContext from '../../context/usePassageDetailContext';
 
 export const usePassageNavigate = (
   cb: () => void,
   setCurrentStep: (step: string) => void,
-  /** When omitted, reads from PassageDetailContext (must be under Provider). */
-  isNavigationBlockedFromCaller?: () => boolean
+  isNavigationBlocked: () => boolean
 ) => {
   const { pathname } = useLocation();
   const navigate = useMyNavigate();
-  const { isNavigationBlocked: isNavigationBlockedFromContext } =
-    usePassageDetailContext();
-  const isNavigationBlocked =
-    isNavigationBlockedFromCaller ?? isNavigationBlockedFromContext;
   const { checkSavedFn } = useContext(UnsavedContext).state;
 
   return (view: string) => {
     if (view && view !== pathname) {
-      if (isNavigationBlocked?.()) return;
+      if (isNavigationBlocked()) return;
       checkSavedFn(() => {
         if (!view.endsWith('null'))
           localStorage.setItem(localUserKey(LocalKey.url), view);

--- a/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
+++ b/src/renderer/src/components/PassageDetail/usePassageNavigate.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { UnsavedContext } from '../../context/UnsavedContext';
 import { LocalKey, localUserKey, useMyNavigate } from '../../utils';
+import usePassageDetailContext from '../../context/usePassageDetailContext';
 
 export const usePassageNavigate = (
   cb: () => void,
@@ -9,11 +10,12 @@ export const usePassageNavigate = (
 ) => {
   const { pathname } = useLocation();
   const navigate = useMyNavigate();
-  //const { setCurrentStep } = usePassageDetailContext();
+  const { isNavigationBlocked } = usePassageDetailContext();
   const { checkSavedFn } = useContext(UnsavedContext).state;
 
   return (view: string) => {
     if (view && view !== pathname) {
+      if (isNavigationBlocked()) return;
       checkSavedFn(() => {
         if (!view.endsWith('null'))
           localStorage.setItem(localUserKey(LocalKey.url), view);

--- a/src/renderer/src/components/WSAudioPlayer.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.tsx
@@ -167,6 +167,8 @@ interface IProps {
   onCurrentSegment?: (currentSegment: IRegion | undefined) => void;
   onSegmentPlaybackEnd?: (segment: IRegion) => void;
   forceRegionOnly?: boolean;
+  /** When true, region clicks and prev/next segment navigation are ignored. */
+  lockSegmentSelection?: boolean;
   onMarkerClick?: (time: number) => void;
   reload?: (blob: Blob) => void;
   noNewVoice?: boolean;
@@ -310,6 +312,7 @@ function WSAudioPlayer(props: IProps) {
     onCurrentSegment,
     onSegmentPlaybackEnd,
     forceRegionOnly,
+    lockSegmentSelection,
     onMarkerClick,
     reload,
     noNewVoice,
@@ -640,7 +643,8 @@ function WSAudioPlayer(props: IProps) {
     onSegmentPlaybackEnd ? onSegmentPlaybackEnd : undefined,
     verses,
     hasSegmentUndo,
-    applyRegionColor
+    applyRegionColor,
+    lockSegmentSelection
   );
 
   //because we have to call hooks consistently, call this even if we aren't going to record
@@ -748,9 +752,10 @@ function WSAudioPlayer(props: IProps) {
       recordStartPosition.current = wsPosition();
       wsStartRecord();
       recordingStartPendingRef.current = true;
+      setRecording(true);
       startRecording(RECORD_PREVIEW_TIMESLICE_MS).then((value) => {
         recordingStartPendingRef.current = false;
-        setRecording(value);
+        if (!value) setRecording(false);
       });
 
       insertingRef.current = durationRef.current > 0;

--- a/src/renderer/src/components/WSAudioPlayer.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.tsx
@@ -167,7 +167,7 @@ interface IProps {
   onCurrentSegment?: (currentSegment: IRegion | undefined) => void;
   onSegmentPlaybackEnd?: (segment: IRegion) => void;
   forceRegionOnly?: boolean;
-  /** When true, region clicks and prev/next segment navigation are ignored. */
+  /** When true, user-initiated selection (clicks, prev/next) is ignored. Playhead-driven region-in is not blocked; consumers that must hold the current clause during recording/saving should guard their segment effects separately (e.g. Careful Speech). */
   lockSegmentSelection?: boolean;
   onMarkerClick?: (time: number) => void;
   reload?: (blob: Blob) => void;
@@ -752,10 +752,12 @@ function WSAudioPlayer(props: IProps) {
       recordStartPosition.current = wsPosition();
       wsStartRecord();
       recordingStartPendingRef.current = true;
-      setRecording(true);
+      // onRecording(true) fires only after startRecording succeeds — not while
+      // the mic is still being acquired (see recordingStartPendingRef for that
+      // window). Consumers should treat onRecording(true) as "capture active".
       startRecording(RECORD_PREVIEW_TIMESLICE_MS).then((value) => {
         recordingStartPendingRef.current = false;
-        if (!value) setRecording(false);
+        if (value) setRecording(true);
       });
 
       insertingRef.current = durationRef.current > 0;

--- a/src/renderer/src/context/PassageDetailContext.tsx
+++ b/src/renderer/src/context/PassageDetailContext.tsx
@@ -99,6 +99,7 @@ import { useProjectPermissions } from '../utils/useProjectPermissions';
 import { PlayInPlayer } from './PlayInPlayer';
 import { SectionArray } from '@model/SectionArray';
 import { boldDefaultSegParams } from '../components/PassageDetail/carefulSpeech/boldCarefulSpeechSegParams';
+import { isPassageNavigationBlocked } from './passageDetailNavigationBlocked';
 
 export interface IRow {
   id: string;
@@ -197,6 +198,7 @@ const initState = {
   setRecording: (_recording: boolean) => {},
   commentRecording: false,
   setCommentRecording: (_commentRecording: boolean) => {},
+  isNavigationBlocked: () => false,
   wfStr: {} as IWorkflowStepsStrings,
   handleItemPlayEnd: () => {},
   handleItemTogglePlay: () => {},
@@ -297,6 +299,8 @@ const PassageDetailProvider = (props: IProps) => {
     useContext(UnsavedContext).state;
   const highlightRef = useRef<number | undefined>(undefined);
   const refreshRef = useRef<number>(0);
+  const recordingRef = useRef(false);
+  const commentRecordingRef = useRef(false);
   const settingSegmentRef = useRef(false);
   const inPlayerRef = useRef<string | undefined>(undefined);
   const { getOrgDefault } = useOrgDefaults();
@@ -312,6 +316,12 @@ const PassageDetailProvider = (props: IProps) => {
     const step = state.psgCompleted.find((s) => s.stepid === stepid);
     return Boolean(step?.complete);
   };
+
+  const isNavigationBlocked = () =>
+    isPassageNavigationBlocked(
+      recordingRef.current,
+      commentRecordingRef.current
+    );
 
   const handleSetCurrentStep = (stepId: string) => {
     const step = state.orgWorkflowSteps.find((s) => s.id === stepId);
@@ -347,6 +357,7 @@ const PassageDetailProvider = (props: IProps) => {
   };
 
   const attemptSetCurrentStep = (stepId: string) => {
+    if (isNavigationBlocked()) return;
     if (needsStepNavigationConfirm(state.currentstep, stepId, stepComplete)) {
       setIncompleteNavTarget(stepId);
       return;
@@ -355,6 +366,7 @@ const PassageDetailProvider = (props: IProps) => {
   };
 
   const setCurrentStep = (stepId: string) => {
+    if (isNavigationBlocked()) return;
     if (getGlobal('changed')) {
       setConfirm(stepId);
     } else {
@@ -446,6 +458,7 @@ const PassageDetailProvider = (props: IProps) => {
   );
 
   const setRecording = (recording: boolean) => {
+    recordingRef.current = recording;
     setState((state: ICtxState) => {
       return {
         ...state,
@@ -458,6 +471,7 @@ const PassageDetailProvider = (props: IProps) => {
     });
   };
   const setCommentRecording = (commentRecording: boolean) => {
+    commentRecordingRef.current = commentRecording;
     setState((state: ICtxState) => {
       return {
         ...state,
@@ -737,12 +751,14 @@ const PassageDetailProvider = (props: IProps) => {
   };
 
   const handleIncompleteNavContinue = () => {
+    if (isNavigationBlocked()) return;
     const target = incompleteNavTarget;
     setIncompleteNavTarget('');
     if (target) handleSetCurrentStep(target);
   };
 
   const handleIncompleteNavComplete = () => {
+    if (isNavigationBlocked()) return;
     const target = incompleteNavTarget;
     const fromStep = state.currentstep;
     setIncompleteNavTarget('');
@@ -1217,6 +1233,7 @@ const PassageDetailProvider = (props: IProps) => {
           gotoNextStep,
           setRecording,
           setCommentRecording,
+          isNavigationBlocked,
           setMediaSelected,
           toggleDone,
           handleItemPlayEnd,

--- a/src/renderer/src/context/PassageDetailContext.tsx
+++ b/src/renderer/src/context/PassageDetailContext.tsx
@@ -374,7 +374,11 @@ const PassageDetailProvider = (props: IProps) => {
     }
   };
 
-  const passageNavigate = usePassageNavigate(() => {}, setCurrentStep);
+  const passageNavigate = usePassageNavigate(
+    () => {},
+    setCurrentStep,
+    isNavigationBlocked
+  );
 
   const forceRefresh = (rowData?: IRow[]) => {
     refreshRef.current = refreshRef.current + 1;

--- a/src/renderer/src/context/passageDetailNavigationBlocked.test.ts
+++ b/src/renderer/src/context/passageDetailNavigationBlocked.test.ts
@@ -1,0 +1,15 @@
+import { isPassageNavigationBlocked } from './passageDetailNavigationBlocked';
+
+describe('isPassageNavigationBlocked', () => {
+  it('blocks when vernacular recording is active', () => {
+    expect(isPassageNavigationBlocked(true, false)).toBe(true);
+  });
+
+  it('blocks when comment recording is active', () => {
+    expect(isPassageNavigationBlocked(false, true)).toBe(true);
+  });
+
+  it('allows navigation when no recording is active', () => {
+    expect(isPassageNavigationBlocked(false, false)).toBe(false);
+  });
+});

--- a/src/renderer/src/context/passageDetailNavigationBlocked.ts
+++ b/src/renderer/src/context/passageDetailNavigationBlocked.ts
@@ -1,0 +1,7 @@
+/** True when workflow/passage navigation must be blocked (active mic capture). */
+export function isPassageNavigationBlocked(
+  recording: boolean,
+  commentRecording: boolean
+): boolean {
+  return recording || commentRecording;
+}

--- a/src/renderer/src/crud/useWaveSurfer.tsx
+++ b/src/renderer/src/crud/useWaveSurfer.tsx
@@ -50,7 +50,8 @@ export function useWaveSurfer(
   onRegionPlayEnd?: (region: IRegion) => void,
   verses?: string,
   hasSegmentUndo?: boolean,
-  applyRegionColor?: ApplyRegionColor
+  applyRegionColor?: ApplyRegionColor,
+  lockSegmentSelection?: boolean
 ) {
   const { isMobile } = useMobile();
   const [errorReporter] = useGlobal('errorReporter');
@@ -261,7 +262,8 @@ export function useWaveSurfer(
     onMarkerClick,
     verses,
     hasSegmentUndo,
-    applyRegionColor
+    applyRegionColor,
+    lockSegmentSelection
   );
 
   const setPlayingx = (value: boolean, regionOnly: boolean) => {

--- a/src/renderer/src/crud/useWavesurferRegions.tsx
+++ b/src/renderer/src/crud/useWavesurferRegions.tsx
@@ -111,7 +111,8 @@ export function useWaveSurferRegions(
   onMarkerClick?: (time: number) => void,
   verses?: string,
   hasSegmentUndo?: boolean,
-  applyRegionColor?: ApplyRegionColor
+  applyRegionColor?: ApplyRegionColor,
+  lockSegmentSelection?: boolean
 ) {
   const theme = useTheme();
   const wsRef = useRef<WaveSurfer | null>(ws);
@@ -135,6 +136,7 @@ export function useWaveSurferRegions(
   const applyRegionColorRef = useRef<ApplyRegionColor | undefined>(
     applyRegionColor
   );
+  const lockSegmentSelectionRef = useRef(lockSegmentSelection ?? false);
   const regionBeforeClickRef = useRef<Region | undefined>(undefined);
   const playTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
   /** Suppress region-in while the playhead is moved programmatically (table row click). */
@@ -162,6 +164,10 @@ export function useWaveSurferRegions(
   useEffect(() => {
     applyRegionColorRef.current = applyRegionColor;
   }, [applyRegionColor]);
+
+  useEffect(() => {
+    lockSegmentSelectionRef.current = lockSegmentSelection ?? false;
+  }, [lockSegmentSelection]);
 
   const regionColor = (
     role: RegionColorRole,
@@ -246,6 +252,7 @@ export function useWaveSurferRegions(
   // handle region clicks with deduplication
   // This is an event handler, not a render function, so Date.now() is safe here
   const handleRegionClick = (r: Region, e: Event) => {
+    if (lockSegmentSelectionRef.current) return;
     const currentTime = getCurrentTime();
     const timeSinceLastClick = currentTime - lastClickTimeRef.current;
     const isSameRegion = lastClickedRegionRef.current === r.id;
@@ -1160,6 +1167,7 @@ export function useWaveSurferRegions(
     return findClauseSplitPoint(peaks, duration(), clause, params);
   }
   const wsPrevRegion = () => {
+    if (lockSegmentSelectionRef.current) return false;
     const r = findPrevRegion(currentRegion() as Region);
     if (r) {
       onStartRegion && onStartRegion(r.start);
@@ -1177,6 +1185,7 @@ export function useWaveSurferRegions(
     }
   };
   const wsNextRegion = () => {
+    if (lockSegmentSelectionRef.current) return false;
     //TT-2825 changing selfIfAtStart to false
     //but I coded that in there for this call, so
     //wonder what case I was handling then????

--- a/src/renderer/src/crud/useWavesurferRegions.tsx
+++ b/src/renderer/src/crud/useWavesurferRegions.tsx
@@ -561,8 +561,8 @@ export function useWaveSurferRegions(
         // Ignore region-in for any region other than the one we're targeting so
         // the adjacent segment isn't spuriously selected.
         if (playRegionRef.current && r.id !== playRegionRef.current.id) return;
-        //TODO!! need to check for user interaction vs looping
-        //this comes before the region-out
+        // lockSegmentSelection does not apply here — playhead-driven updates must
+        // still flow so playback/overshoot logic works; consumers guard effects.
         if (!loopingRef.current) setCurrentRegion(r);
       });
       regionsPlugin.on('region-out', function (r: Region) {


### PR DESCRIPTION
- Added `lockSegmentSelection` prop to WSAudioPlayer and PassageDetail components to prevent segment navigation during recording.
- Introduced state management for `savingRecording` in PassageDetail to disable navigation and controls while uploads are in progress.
- Updated tests to verify that segment selection is correctly locked during recording and saving operations.
- Enhanced context to block navigation when recording or comment recording is active.