### PR TITLE
TT-6980 fix: remove confusing scrolling on mobile Projects page

### DIFF
--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -220,7 +220,14 @@ export const ProjectsScreenInner: React.FC = () => {
   }
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box
+      sx={{
+        width: '100%',
+        minHeight: '100dvh',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <AppHead />
       <ProjectsBox
         id="ProjectsScreen"
@@ -229,11 +236,11 @@ export const ProjectsScreenInner: React.FC = () => {
           paddingTop: '80px',
           px: 2,
           pb: 8,
-          mx: 'auto',
           display: 'flex',
           flexDirection: 'column',
           gap: 2,
-          minHeight: '100vh',
+          flex: 1,
+          minHeight: 0,
         }}
       >
         <Grid container spacing={1}>


### PR DESCRIPTION
A first project could be added scrolled out of view, so its card was initially not visible. I adjusted the component size so that there is now no scrolling for the first few projects, where there is no reason for it