### PR TITLE
TT-7472 Revamp header/footer step (or passage) navigation

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MobileStepComplete.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileStepComplete.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useGlobal } from '../../../context/useGlobal';
 import { Box, Button } from '@mui/material';
 import CompleteIcon from '@mui/icons-material/CheckBox';
@@ -31,7 +31,6 @@ export default function MobileStepComplete() {
   const { showMessage } = useSnackBar();
   const [busy] = useGlobal('remoteBusy');
   const [importexportBusy] = useGlobal('importexportBusy');
-  const [view] = useState('');
   const t: IPassageDetailStepCompleteStrings = useSelector(
     passageDetailStepCompleteSelector,
     shallowEqual
@@ -83,9 +82,7 @@ export default function MobileStepComplete() {
       size="small"
       title={t.title}
       onClick={handleToggleComplete}
-      disabled={
-        !hasPermission || view !== '' || recording || busy || importexportBusy
-      }
+      disabled={!hasPermission || recording || busy || importexportBusy}
       startIcon={
         complete ? (
           <CompleteIcon
@@ -100,6 +97,7 @@ export default function MobileStepComplete() {
       sx={{
         minWidth: 0,
         maxWidth: '100%',
+        '@media (max-width:405px)': { px: 1 },
       }}
     >
       <Box

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -124,6 +124,12 @@ const mockCurrentPassage = {
   attributes: { sequencenum: 1, reference: '1:1', book: 'GEN' },
 } as any;
 
+const RACETRACK_STATE_COLOR = {
+  current: 'rgb(51, 51, 51)',
+  complete: 'rgb(168, 168, 168)',
+  incomplete: 'rgb(224, 224, 224)',
+};
+
 const createInitialState = (
   overrides: Partial<GlobalState> = {}
 ): GlobalState => ({
@@ -332,13 +338,17 @@ describe('MobileWorkflowSteps', () => {
 
       cy.get('[data-cy="workflow-step"]')
         .eq(0)
-        .should('have.css', 'background-color', 'rgb(51, 51, 51)');
+        .should('have.css', 'background-color', RACETRACK_STATE_COLOR.current);
       cy.get('[data-cy="workflow-step"]')
         .eq(1)
-        .should('have.css', 'background-color', 'rgb(168, 168, 168)');
+        .should('have.css', 'background-color', RACETRACK_STATE_COLOR.complete);
       cy.get('[data-cy="workflow-step"]')
         .eq(2)
-        .should('have.css', 'background-color', 'rgb(224, 224, 224)');
+        .should(
+          'have.css',
+          'background-color',
+          RACETRACK_STATE_COLOR.incomplete
+        );
     });
 
     it('shows a tip button in the step label area that opens a dialog', () => {
@@ -556,15 +566,19 @@ describe('MobileWorkflowSteps', () => {
       // p-0 sequencenum 0 < current sequencenum 1 → complete
       cy.get('[data-cy="passage-step"]')
         .eq(0)
-        .should('have.css', 'background-color', 'rgb(168, 168, 168)');
+        .should('have.css', 'background-color', RACETRACK_STATE_COLOR.complete);
       // p-1 is current passage
       cy.get('[data-cy="passage-step"]')
         .eq(1)
-        .should('have.css', 'background-color', 'rgb(51, 51, 51)');
+        .should('have.css', 'background-color', RACETRACK_STATE_COLOR.current);
       // p-2 sequencenum 2 > current sequencenum 1 → incomplete
       cy.get('[data-cy="passage-step"]')
         .eq(2)
-        .should('have.css', 'background-color', 'rgb(224, 224, 224)');
+        .should(
+          'have.css',
+          'background-color',
+          RACETRACK_STATE_COLOR.incomplete
+        );
     });
 
     it('step label shows current passage book and reference', () => {

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.cy.tsx
@@ -332,13 +332,13 @@ describe('MobileWorkflowSteps', () => {
 
       cy.get('[data-cy="workflow-step"]')
         .eq(0)
-        .should('have.css', 'background-color', 'rgb(17, 17, 17)');
+        .should('have.css', 'background-color', 'rgb(51, 51, 51)');
       cy.get('[data-cy="workflow-step"]')
         .eq(1)
-        .should('have.css', 'background-color', 'rgb(136, 136, 136)');
+        .should('have.css', 'background-color', 'rgb(168, 168, 168)');
       cy.get('[data-cy="workflow-step"]')
         .eq(2)
-        .should('have.css', 'background-color', 'rgb(204, 204, 204)');
+        .should('have.css', 'background-color', 'rgb(224, 224, 224)');
     });
 
     it('shows a tip button in the step label area that opens a dialog', () => {
@@ -399,7 +399,12 @@ describe('MobileWorkflowSteps', () => {
     });
 
     it('blocks passage dropdown while recording', () => {
-      mountMobileWorkflowSteps({ isStepProgression: true, recording: true });
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        recording: true,
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
 
       cy.get('[data-cy="passage-dropdown"]').click();
 
@@ -421,7 +426,11 @@ describe('MobileWorkflowSteps', () => {
     });
 
     it('dropdown shows current passage book and reference', () => {
-      mountMobileWorkflowSteps({ isStepProgression: true });
+      mountMobileWorkflowSteps({
+        isStepProgression: true,
+        section: mockSection,
+        extraMemoryRecords: mockSectionPassageRecords,
+      });
 
       cy.get('[data-cy="passage-dropdown"]').should('contain.text', 'GEN 1:1');
     });
@@ -440,21 +449,15 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[role="menuitem"]').eq(0).should('contain.text', 'GEN 1:1');
     });
 
-    it('does not open the dropdown when the section has only one passage', () => {
+    it('hides the dropdown when the section has only one passage', () => {
       mountMobileWorkflowSteps({
         isStepProgression: true,
         section: mockSectionSinglePassage,
         extraMemoryRecords: mockSectionPassageRecordsSingle,
       });
 
-      cy.get('[data-cy="passage-dropdown"]')
-        .should('contain.text', 'GEN 1:1')
-        .find('[data-testid="ArrowDropDownIcon"]')
-        .should('not.exist');
-
-      cy.get('[data-cy="passage-dropdown"]').click();
-
-      cy.get('[role="menu"]').should('not.exist');
+      cy.get('[data-cy="workflow-step"]').should('have.length', 2);
+      cy.get('[data-cy="passage-dropdown"]').should('not.exist');
     });
 
     it('renders the step label as plain text when the current step has no tip', () => {
@@ -507,19 +510,17 @@ describe('MobileWorkflowSteps', () => {
       cy.get('[role="menuitem"]').should('have.length', 2);
     });
 
-    it('does not open the dropdown when there is only one workflow step', () => {
+    it('hides the dropdown when there is only one workflow step', () => {
       mountMobileWorkflowSteps({
         workflow: [{ id: 'step-1', label: 'Record' }],
       });
 
-      cy.get('[data-cy="passage-dropdown"]')
-        .should('contain.text', 'Record')
-        .find('[data-testid="ArrowDropDownIcon"]')
-        .should('not.exist');
-
-      cy.get('[data-cy="passage-dropdown"]').click();
-
-      cy.get('[role="menu"]').should('not.exist');
+      cy.get('[data-cy="passage-dropdown"]').should('not.exist');
+      // The passage reference falls back to the plain label row
+      cy.get('[data-cy="workflow-step-label"]').should(
+        'contain.text',
+        'GEN 1:1'
+      );
     });
 
     it('blocks passage click while recording', () => {
@@ -555,15 +556,15 @@ describe('MobileWorkflowSteps', () => {
       // p-0 sequencenum 0 < current sequencenum 1 → complete
       cy.get('[data-cy="passage-step"]')
         .eq(0)
-        .should('have.css', 'background-color', 'rgb(136, 136, 136)');
+        .should('have.css', 'background-color', 'rgb(168, 168, 168)');
       // p-1 is current passage
       cy.get('[data-cy="passage-step"]')
         .eq(1)
-        .should('have.css', 'background-color', 'rgb(17, 17, 17)');
+        .should('have.css', 'background-color', 'rgb(51, 51, 51)');
       // p-2 sequencenum 2 > current sequencenum 1 → incomplete
       cy.get('[data-cy="passage-step"]')
         .eq(2)
-        .should('have.css', 'background-color', 'rgb(204, 204, 204)');
+        .should('have.css', 'background-color', 'rgb(224, 224, 224)');
     });
 
     it('step label shows current passage book and reference', () => {

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -35,6 +35,8 @@ import { ToolSlug, useStepTool } from '../../../crud';
 import { useRole } from '../../../crud/useRole';
 import { useStepPermissions } from '../../../utils/useStepPermission';
 
+const DESKTOP_BREAKPOINT = '@media (min-width:1401px)';
+
 export default function MobileWorkflowSteps() {
   const {
     workflow,
@@ -338,7 +340,7 @@ export default function MobileWorkflowSteps() {
             overflowX: 'auto',
             display: 'flex',
             flex: 1,
-            '@media (min-width:1401px)': {
+            [DESKTOP_BREAKPOINT]: {
               flex: 'none',
               position: 'absolute',
               left: 0,
@@ -416,7 +418,7 @@ export default function MobileWorkflowSteps() {
             height: 30,
             flex: 1,
             display: 'none',
-            '@media (min-width:1401px)': { display: 'block' },
+            [DESKTOP_BREAKPOINT]: { display: 'block' },
           }}
         />
       </Box>

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -378,7 +378,7 @@ export default function MobileWorkflowSteps() {
                   justifyContent: 'center',
                   // Horizontal padding clears the slanted edges so the label
                   // isn't clipped by the parallelogram's angled corners
-                  px: 1.5,
+                  px: 1,
                 }}
               >
                 <Typography

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -334,10 +334,13 @@ export default function MobileWorkflowSteps() {
           sx={{
             overflowX: 'auto',
             display: 'flex',
-            flex: { xs: 1, md: 'none' },
-            position: { md: 'absolute' },
-            left: { md: 0 },
-            right: { md: 0 },
+            flex: 1,
+            '@media (min-width:1401px)': {
+              flex: 'none',
+              position: 'absolute',
+              left: 0,
+              right: 0,
+            },
             '&::before, &::after': {
               content: '""',
               margin: 'auto',
@@ -386,7 +389,7 @@ export default function MobileWorkflowSteps() {
                   }}
                   sx={{
                     color: textColor,
-                    fontSize: '0.7rem',
+                    fontSize: '11px',
                     lineHeight: 1,
                     textAlign: 'center',
                     overflow: 'hidden',
@@ -406,7 +409,12 @@ export default function MobileWorkflowSteps() {
 
         {/* Spacer to center the parallelograms in the top row on desktop screens */}
         <Box
-          sx={{ height: 30, flex: 1, display: { xs: 'none', md: 'block' } }}
+          sx={{
+            height: 30,
+            flex: 1,
+            display: 'none',
+            '@media (min-width:1401px)': { display: 'block' },
+          }}
         />
       </Box>
 

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -273,6 +273,7 @@ export default function MobileWorkflowSteps() {
             <Box
               component="span"
               sx={{
+                fontSize: 'small',
                 minWidth: 0,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -378,7 +379,7 @@ export default function MobileWorkflowSteps() {
                   justifyContent: 'center',
                   // Horizontal padding clears the slanted edges so the label
                   // isn't clipped by the parallelogram's angled corners
-                  px: 1,
+                  px: 2,
                 }}
               >
                 <Typography
@@ -389,7 +390,7 @@ export default function MobileWorkflowSteps() {
                   }}
                   sx={{
                     color: textColor,
-                    fontSize: '11px',
+                    fontSize: '0.75rem',
                     lineHeight: 1,
                     textAlign: 'center',
                     overflow: 'hidden',
@@ -418,28 +419,42 @@ export default function MobileWorkflowSteps() {
         />
       </Box>
 
-      {/* Bottom row with the labels */}
-      <Typography sx={{ mt: 1 }} data-cy="workflow-step-label">
-        {isStepProgression ? (
-          currentTip ? (
-            <ButtonBase
-              onClick={() => setTipOpen(true)}
-              data-cy="workflow-step-tip"
-              sx={{
-                borderRadius: 1,
-                fontWeight: 'inherit',
-                fontSize: 'inherit',
-              }}
-              aria-label={currentTip}
-            >
-              {getWfLabel(currentLabel) + '\u00A0'}
-              <InfoIcon sx={{ color: 'primary.light' }} fontSize="small" />
-            </ButtonBase>
-          ) : (
-            getWfLabel(currentLabel)
-          )
-        ) : (
-          passageRef(passage)
+      {/* Bottom row with label and tip button */}
+      <Typography
+        component="div"
+        sx={{
+          mt: 1,
+          maxWidth: '80vw',
+          display: 'flex',
+          alignItems: 'center',
+          minWidth: 0,
+        }}
+        data-cy="workflow-step-label"
+      >
+        {/* Label */}
+        <Box
+          component="span"
+          sx={{
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {isStepProgression ? getWfLabel(currentLabel) : passageRef(passage)}
+        </Box>
+
+        {/* Tip button */}
+        {isStepProgression && currentTip && (
+          <ButtonBase
+            onClick={() => setTipOpen(true)}
+            data-cy="workflow-step-tip"
+            centerRipple
+            sx={{ borderRadius: '50%', p: 0.5, ml: 0.5, flexShrink: 0 }}
+            aria-label={currentTip}
+          >
+            <InfoIcon sx={{ color: 'primary.light' }} fontSize="small" />
+          </ButtonBase>
         )}
       </Typography>
 

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -226,109 +226,111 @@ export default function MobileWorkflowSteps() {
         }}
       >
         {/* Passage dropdown */}
-        <Box
-          sx={{
-            flexShrink: 0,
-            position: 'relative',
-            zIndex: 1,
-            mr: 1,
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          <Button
-            size="small"
-            startIcon={
-              !isStepProgression && currentTip ? (
-                <InfoIcon
-                  sx={{ color: 'primary.light' }}
-                  fontSize="small"
-                  data-cy="workflow-step-tip"
-                  aria-label={currentTip}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setTipOpen(true);
-                  }}
-                />
-              ) : undefined
-            }
-            endIcon={hasMultipleOptions ? <ArrowDropDownIcon /> : undefined}
+        {hasMultipleOptions && (
+          <Box
             sx={{
-              minWidth: 'auto',
-              // These per-breakpoint widths are fine-tuned to constrain the dropdown so
-              // its label truncates before it can overlap the parallelograms
-              maxWidth: { xs: '45vw', md: '20vw', lg: '25vw' },
+              flexShrink: 0,
+              position: 'relative',
+              zIndex: 1,
+              mr: 1,
+              display: 'flex',
+              alignItems: 'center',
             }}
-            onClick={(e) => {
-              if (!hasMultipleOptions) return;
-              if (recording || commentRecording) return;
-              if (getGlobal('remoteBusy')) {
-                showMessage(ts.wait);
-                return;
-              }
-              setPassageMenuAnchor(e.currentTarget);
-            }}
-            data-cy="passage-dropdown"
           >
-            <Box
-              component="span"
+            <Button
+              size="small"
+              startIcon={
+                !isStepProgression && currentTip ? (
+                  <InfoIcon
+                    sx={{ color: 'primary.light' }}
+                    fontSize="small"
+                    data-cy="workflow-step-tip"
+                    aria-label={currentTip}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setTipOpen(true);
+                    }}
+                  />
+                ) : undefined
+              }
+              endIcon={<ArrowDropDownIcon />}
               sx={{
-                fontSize: 'small',
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
+                minWidth: 'auto',
+                // These per-breakpoint widths are fine-tuned to constrain the dropdown so
+                // its label truncates before it can overlap the parallelograms
+                maxWidth: { xs: '45vw', md: '20vw', lg: '25vw' },
               }}
+              onClick={(e) => {
+                if (!hasMultipleOptions) return;
+                if (recording || commentRecording) return;
+                if (getGlobal('remoteBusy')) {
+                  showMessage(ts.wait);
+                  return;
+                }
+                setPassageMenuAnchor(e.currentTarget);
+              }}
+              data-cy="passage-dropdown"
+            >
+              <Box
+                component="span"
+                sx={{
+                  fontSize: 'small',
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {isStepProgression
+                  ? passageRef(passage)
+                  : getWfLabel(currentLabel)}
+              </Box>
+            </Button>
+            <Menu
+              anchorEl={passageMenuAnchor}
+              open={Boolean(passageMenuAnchor)}
+              onClose={() => setPassageMenuAnchor(null)}
             >
               {isStepProgression
-                ? passageRef(passage)
-                : getWfLabel(currentLabel)}
-            </Box>
-          </Button>
-          <Menu
-            anchorEl={passageMenuAnchor}
-            open={Boolean(passageMenuAnchor)}
-            onClose={() => setPassageMenuAnchor(null)}
-          >
-            {isStepProgression
-              ? sectionPassages.map((p) => (
-                  <MenuItem
-                    key={p.id}
-                    selected={p.id === passage?.id}
-                    onClick={() => {
-                      navigateToPassage(p);
-                      setPassageMenuAnchor(null);
-                    }}
-                    sx={{
-                      display: 'block',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {passageRef(p)}
-                  </MenuItem>
-                ))
-              : workflow.map((step) => (
-                  <MenuItem
-                    key={step.id}
-                    selected={step.id === currentstep}
-                    onClick={() => {
-                      handleSelect(step.id)();
-                      setPassageMenuAnchor(null);
-                    }}
-                    sx={{
-                      display: 'block',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {getWfLabel(step.label)}
-                  </MenuItem>
-                ))}
-          </Menu>
-        </Box>
+                ? sectionPassages.map((p) => (
+                    <MenuItem
+                      key={p.id}
+                      selected={p.id === passage?.id}
+                      onClick={() => {
+                        navigateToPassage(p);
+                        setPassageMenuAnchor(null);
+                      }}
+                      sx={{
+                        display: 'block',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {passageRef(p)}
+                    </MenuItem>
+                  ))
+                : workflow.map((step) => (
+                    <MenuItem
+                      key={step.id}
+                      selected={step.id === currentstep}
+                      onClick={() => {
+                        handleSelect(step.id)();
+                        setPassageMenuAnchor(null);
+                      }}
+                      sx={{
+                        display: 'block',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {getWfLabel(step.label)}
+                    </MenuItem>
+                  ))}
+            </Menu>
+          </Box>
+        )}
 
         {/* Step/passage parallelograms */}
         <Box

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -18,7 +18,7 @@ import { useSnackBar } from '../../../hoc/SnackBar';
 import { sharedSelector, workflowStepsSelector } from '../../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useWfLabel } from '../../../utils/useWfLabel';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { IWorkflowStepsStrings, PassageD } from '../../../model';
 import { toCamel } from '../../../utils/toCamel';
 import { related } from '../../../crud/related';
@@ -74,6 +74,10 @@ export default function MobileWorkflowSteps() {
   // Refs used to scroll the current step/passage into view
   const didMountRef = useRef(false);
   const stepRefs = useRef(new Map<string, HTMLElement>());
+
+  // Refs to each parallelogram's label, used to size every parallelogram to the width of the longest one
+  const labelRefs = useRef(new Map<string, HTMLElement>());
+  const [stepWidth, setStepWidth] = useState<number | undefined>(undefined);
 
   // Ordered list of passages in the current section, excluding publishing-title rows, sorted by sequence number
   const sectionPassages = useMemo<PassageD[]>(() => {
@@ -165,6 +169,22 @@ export default function MobileWorkflowSteps() {
         },
       }));
 
+  // The labels joined together, used to re-measure when any label changes (e.g. localization)
+  const labelKey = steps.map((s) => s.label).join(' ');
+
+  // Measure every label and size all parallelograms to the widest one so they are all of equal length
+  useLayoutEffect(() => {
+    let max = 0;
+    labelRefs.current.forEach((el) => {
+      max = Math.max(max, el.scrollWidth);
+    });
+    if (max > 0) {
+      // Add 12 px horizontal padding to each side of the label
+      // Cap the maximum width of the parallelograms at 120 px
+      setStepWidth(Math.min(Math.ceil(max) + 12, 120));
+    }
+  }, [labelKey]);
+
   // Keep the current step/passage scrolled into view
   useEffect(() => {
     const currentId = isStepProgression ? currentstep : (passage?.id ?? '');
@@ -182,6 +202,7 @@ export default function MobileWorkflowSteps() {
     workflow.length,
     sectionPassages.length,
     isStepProgression,
+    stepWidth,
   ]);
 
   return (
@@ -340,11 +361,13 @@ export default function MobileWorkflowSteps() {
                 }}
                 onClick={step.onClick}
                 sx={{
-                  flex: '0 0 80px',
+                  flex: stepWidth ? `0 0 ${stepWidth}px` : '0 0 80px',
+                  minWidth: 0,
                   height: 30,
                   bgcolor: color,
                   mr: -0.25,
-                  clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
+                  clipPath:
+                    'polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%)',
                   cursor:
                     recording || commentRecording ? 'not-allowed' : 'pointer',
                   display: 'flex',
@@ -357,6 +380,10 @@ export default function MobileWorkflowSteps() {
               >
                 <Typography
                   component="span"
+                  ref={(el: HTMLElement | null) => {
+                    if (el) labelRefs.current.set(step.id, el);
+                    else labelRefs.current.delete(step.id);
+                  }}
                   sx={{
                     color: textColor,
                     fontSize: '0.7rem',
@@ -365,6 +392,7 @@ export default function MobileWorkflowSteps() {
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
+                    minWidth: 0,
                     maxWidth: '100%',
                     pointerEvents: 'none',
                   }}

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -329,6 +329,7 @@ export default function MobileWorkflowSteps() {
               : step.isComplete
                 ? 'custom.racetrackComplete'
                 : 'custom.racetrackIncomplete';
+            const textColor = step.isCurrent ? 'common.white' : 'common.black';
             return (
               <Box
                 key={step.id}
@@ -357,7 +358,7 @@ export default function MobileWorkflowSteps() {
                 <Typography
                   component="span"
                   sx={{
-                    color: 'common.white',
+                    color: textColor,
                     fontSize: '0.7rem',
                     lineHeight: 1,
                     textAlign: 'center',

--- a/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MobileWorkflowSteps.tsx
@@ -146,6 +146,7 @@ export default function MobileWorkflowSteps() {
     ? workflow.map((s) => ({
         id: s.id,
         dataCy: 'workflow-step',
+        label: getWfLabel(s.label),
         isCurrent: s.id === currentstep,
         isComplete: stepComplete(s.id),
         onClick: handleSelect(s.id),
@@ -153,6 +154,7 @@ export default function MobileWorkflowSteps() {
     : sectionPassages.map((p) => ({
         id: p.id,
         dataCy: 'passage-step',
+        label: passageRef(p),
         isCurrent: p.id === passage?.id,
         isComplete:
           (p.attributes.sequencenum ?? 0) <
@@ -344,8 +346,31 @@ export default function MobileWorkflowSteps() {
                   clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)',
                   cursor:
                     recording || commentRecording ? 'not-allowed' : 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  // Horizontal padding clears the slanted edges so the label
+                  // isn't clipped by the parallelogram's angled corners
+                  px: 1.5,
                 }}
-              />
+              >
+                <Typography
+                  component="span"
+                  sx={{
+                    color: 'common.white',
+                    fontSize: '0.7rem',
+                    lineHeight: 1,
+                    textAlign: 'center',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '100%',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  {step.label}
+                </Typography>
+              </Box>
             );
           })}
         </Box>

--- a/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.cy.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.cy.tsx
@@ -307,8 +307,10 @@ describe('PassageDetailMobileFooter', () => {
 
     mountFooter({ passages, currentPassageId: 'passage-2' });
 
-    cy.contains('button', '1:1').should('be.visible');
-    cy.contains('button', '3:3').should('be.visible');
+    cy.contains('button', 'Previous').should('be.visible');
+    cy.contains('button', 'Next').should('be.visible');
+    cy.get('span[title="1:1"]').should('exist');
+    cy.get('span[title="3:3"]').should('exist');
     cy.get('#mobile-complete').should('exist');
   });
 
@@ -339,7 +341,7 @@ describe('PassageDetailMobileFooter', () => {
     });
 
     cy.clock();
-    cy.contains('button', '3:3').click();
+    cy.contains('button', 'Next').click();
     cy.tick(1000);
 
     cy.get('[data-cy="location"]').should(
@@ -381,8 +383,9 @@ describe('PassageDetailMobileFooter', () => {
     });
 
     cy.contains('button', 'Previous').closest('button').should('be.disabled');
-    cy.contains('button', 'Record').should('be.visible');
-    cy.contains('button', 'Record').click();
+    cy.contains('button', 'Next').should('be.visible');
+    cy.get('span[title="Record"]').should('exist');
+    cy.contains('button', 'Next').click();
     cy.get('@setCurrentStep').should('have.been.calledWith', 'step-2');
   });
 
@@ -417,8 +420,9 @@ describe('PassageDetailMobileFooter', () => {
 
     cy.get('#mobile-complete').should('not.exist');
     cy.contains('button', '2:2').should('not.exist');
-    cy.contains('button', 'Record').should('be.visible');
-    cy.contains('button', 'Record').click();
+    cy.contains('button', 'Next').should('be.visible');
+    cy.get('span[title="Record"]').should('exist');
+    cy.contains('button', 'Next').click();
     cy.get('@setCurrentStep').should('have.been.calledWith', 'step-2');
     cy.get('[data-cy="location"]').should(
       'have.text',
@@ -490,8 +494,9 @@ describe('PassageDetailMobileFooter', () => {
       },
     });
 
-    cy.contains('button', 'Record').should('be.visible').and('not.be.disabled');
-    cy.contains('button', 'Record').click();
+    cy.contains('button', 'Next').should('be.visible').and('not.be.disabled');
+    cy.get('span[title="Record"]').should('exist');
+    cy.contains('button', 'Next').click();
     cy.get('@setCurrentStep').should('have.been.calledWith', 'step-record');
   });
 });

--- a/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/PassageDetailMobileFooter.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useMemo } from 'react';
 import usePassageDetailContext from '../../../context/usePassageDetailContext';
 import MobileStepComplete from './MobileStepComplete';
@@ -128,11 +128,8 @@ export default function PassageDetailMobileFooter() {
       : ''
     : (nextPassRec?.attributes?.reference ?? '');
 
-  const prevButtonText =
-    prevNavEnabled && prevLabelFull
-      ? prevLabelFull
-      : (t?.previous ?? 'Previous');
-  const nextButtonText = nextLabelFull || (t?.next ?? 'Next');
+  const prevButtonText = t?.previous ?? 'Previous';
+  const nextButtonText = t?.next ?? 'Next';
 
   const handleNavigate = (forward: boolean) => {
     if (isStepProgression) {
@@ -151,8 +148,9 @@ export default function PassageDetailMobileFooter() {
 
   const navButtonSx = {
     flex: 1,
-    minWidth: 'clamp(60px, 16vw, 100px)',
+    minWidth: 0,
     maxWidth: 'clamp(110px, 30vw, 190px)',
+    '@media (max-width:405px)': { px: 1 },
   } as const;
 
   return (
@@ -167,10 +165,13 @@ export default function PassageDetailMobileFooter() {
     >
       <Button
         size="small"
-        startIcon={<ArrowBackIcon fontSize="small" />}
+        startIcon={<ChevronLeftIcon fontSize="small" />}
         onClick={() => handleNavigate(false)}
         disabled={!prevNavEnabled}
-        sx={{ ...navButtonSx, justifyContent: 'center' }}
+        sx={{
+          ...navButtonSx,
+          justifyContent: 'center',
+        }}
       >
         <NavButtonLabel
           text={prevButtonText}
@@ -181,10 +182,13 @@ export default function PassageDetailMobileFooter() {
       {!isBoldWorkflow && <MobileStepComplete />}
       <Button
         size="small"
-        endIcon={<ArrowForwardIcon fontSize="small" />}
+        endIcon={<ChevronRightIcon fontSize="small" />}
         onClick={() => handleNavigate(true)}
         disabled={!nextNavEnabled}
-        sx={{ ...navButtonSx, justifyContent: 'center' }}
+        sx={{
+          ...navButtonSx,
+          justifyContent: 'center',
+        }}
       >
         <NavButtonLabel
           text={nextButtonText}

--- a/src/renderer/src/theme.ts
+++ b/src/renderer/src/theme.ts
@@ -35,9 +35,9 @@ export const createAppTheme = (lang: string) =>
         custom: {
           currentRegion: '#66FF0080',
           headerBackground: '#EEEEEE',
-          racetrackCurrent: '#111',
-          racetrackComplete: '#888',
-          racetrackIncomplete: '#ccc',
+          racetrackCurrent: '#333',
+          racetrackComplete: '#a8a8a8',
+          racetrackIncomplete: '#e0e0e0',
         },
       },
       typography: {


### PR DESCRIPTION
Changes:
- Added the step/passage labels in the racetrack itself, so that users can easily peek, scroll, and navigate to different steps/passages.
- On mobile screens, not labeling the bottom navigation buttons with the next or previous step/passage, but keeping them strictly "Next" or "Previous".