### PR TITLE
fix: prevent HMR crash from empty React context default values

### DIFF
--- a/docs/ai/localization.md
+++ b/docs/ai/localization.md
@@ -73,7 +73,10 @@ language changes.
 - A provider may still read a string layout it needs **internally** (e.g.
   `sharedStrings` for `useFlatAdd`), but it must not expose strings on context
   state for components to consume.
-- Do not add string-typed fields back to any context `initState`.
+- Do not add **localized-string fields** (any `I*Strings` layout / `LocalizedStrings`
+  snapshot) back to a context `initState`. Plain non-localized `string` values
+  (ids, paths, user-entered text) are fine — the hazard is only the in-place-mutated
+  localized objects.
 
 ### Read the current language from Redux, not global state
 

--- a/src/renderer/src/components/Sheet/PassageCard.cy.tsx
+++ b/src/renderer/src/components/Sheet/PassageCard.cy.tsx
@@ -135,7 +135,6 @@ describe('PassageCard', () => {
   const createPlanContextState = (
     overrides: Partial<ICtxState> = {}
   ): ICtxState => ({
-    t: {} as any,
     connected: true,
     mediafiles: [],
     discussions: [],

--- a/src/renderer/src/components/Sheet/PassageRef.cy.tsx
+++ b/src/renderer/src/components/Sheet/PassageRef.cy.tsx
@@ -110,7 +110,6 @@ describe('PassageRef', () => {
   const createPlanContextState = (
     overrides: Partial<ICtxState> = {}
   ): ICtxState => ({
-    t: {} as any,
     connected: true,
     mediafiles: [],
     discussions: [],

--- a/src/renderer/src/context/GlobalContext.tsx
+++ b/src/renderer/src/context/GlobalContext.tsx
@@ -57,7 +57,14 @@ export interface GlobalCtxType {
   setGlobalState: React.Dispatch<React.SetStateAction<GlobalState>>;
 }
 
-const GlobalContext = React.createContext<GlobalCtxType | undefined>(undefined);
+// Default wrapper object (not `undefined`) so consumers can safely destructure
+// `globalState`/`setGlobalState` during a transient default-context render (e.g.
+// HMR/Fast Refresh) instead of throwing. `useGlobal` already guards
+// `globalState === undefined` and returns an empty result in that case.
+const GlobalContext = React.createContext<GlobalCtxType | undefined>({
+  globalState: undefined as unknown as GlobalState,
+  setGlobalState: () => {},
+});
 
 interface GlobalProps {
   init: GlobalState;

--- a/src/renderer/src/context/HotKeyContext.tsx
+++ b/src/renderer/src/context/HotKeyContext.tsx
@@ -22,7 +22,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const HotKeyContext = React.createContext({} as IContext);
+const HotKeyContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 interface hotKeyInfo {
   key: string;
   ctrl?: boolean;

--- a/src/renderer/src/context/PassageDetailContext.tsx
+++ b/src/renderer/src/context/PassageDetailContext.tsx
@@ -234,7 +234,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const PassageDetailContext = React.createContext({} as IContext);
+const PassageDetailContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 
 interface IProps {
   children: React.ReactElement;

--- a/src/renderer/src/context/PlanContext.tsx
+++ b/src/renderer/src/context/PlanContext.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 // see: https://upmostly.com/tutorials/how-to-use-the-usecontext-hook-in-react
 import { useGlobal } from '../context/useGlobal';
 import {
-  IMainStrings,
   ProjectD,
   DiscussionD,
   MediaFileD,
@@ -21,7 +20,6 @@ import { SectionArray } from '../model/SectionArray';
 export interface IRowData {}
 
 const initState = {
-  t: {} as IMainStrings,
   connected: false,
   mediafiles: [] as MediaFileD[],
   discussions: [] as DiscussionD[],

--- a/src/renderer/src/context/PlanContext.tsx
+++ b/src/renderer/src/context/PlanContext.tsx
@@ -48,7 +48,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const PlanContext = React.createContext({} as IContext);
+const PlanContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 
 interface IProps {
   children: React.ReactElement;

--- a/src/renderer/src/context/TeamContext.tsx
+++ b/src/renderer/src/context/TeamContext.tsx
@@ -144,7 +144,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const TeamContext = React.createContext({} as IContext);
+const TeamContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 
 interface IProps {
   children: React.ReactElement;

--- a/src/renderer/src/context/TokenProvider.tsx
+++ b/src/renderer/src/context/TokenProvider.tsx
@@ -39,7 +39,10 @@ export interface ITokenContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const TokenContext = React.createContext({} as ITokenContext);
+const TokenContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as ITokenContext);
 
 interface IProps {
   children: React.JSX.Element;

--- a/src/renderer/src/context/TranscriberContext.tsx
+++ b/src/renderer/src/context/TranscriberContext.tsx
@@ -118,7 +118,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const TranscriberContext = React.createContext({} as IContext);
+const TranscriberContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 
 interface IProps {
   children: React.ReactElement;

--- a/src/renderer/src/context/UnsavedContext.tsx
+++ b/src/renderer/src/context/UnsavedContext.tsx
@@ -50,7 +50,10 @@ interface IContext {
   setState: React.Dispatch<React.SetStateAction<ICtxState>>;
 }
 
-const UnsavedContext = React.createContext({} as IContext);
+const UnsavedContext = React.createContext({
+  state: initState as ICtxState,
+  setState: () => {},
+} as IContext);
 
 const UnsavedProvider = (props: PropsWithChildren) => {
   const t: IMainStrings = useSelector(mainSelector);

--- a/src/renderer/src/context/UnsavedContext.tsx
+++ b/src/renderer/src/context/UnsavedContext.tsx
@@ -6,7 +6,7 @@ import { IMainStrings } from '../model';
 import { waitForIt } from '../utils/waitForIt';
 import { useSnackBar } from '../hoc/SnackBar';
 import Confirm from '../components/AlertDialog';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { mainSelector } from '../selector';
 
 export interface IRowData {}
@@ -24,7 +24,6 @@ const initState = {
   checkSavedFn: (method: () => void) => {
     return;
   },
-  t: {} as IMainStrings,
   handleSaveConfirmed: () => {},
   handleSaveRefused: () => {},
   toolChanged: (toolId: string, changed?: boolean, toolErr?: string) => {},
@@ -56,14 +55,13 @@ const UnsavedContext = React.createContext({
 } as IContext);
 
 const UnsavedProvider = (props: PropsWithChildren) => {
-  const t: IMainStrings = useSelector(mainSelector);
+  const t: IMainStrings = useSelector(mainSelector, shallowEqual);
   const [, setBusy] = useGlobal('remoteBusy');
   const [alertOpen, setAlertOpen] = useGlobal('alertOpen'); //global because planSheet checks it //verified this is not used in a function 2/18/25
   const saveConfirm = React.useRef<(() => any) | undefined>(undefined);
   const { showMessage } = useSnackBar();
   const [state, setState] = useState({
     ...initState,
-    t,
   });
   const saveErr = useRef<string | undefined>(undefined);
   const [saveResult, setSaveResult] = useGlobal('saveResult'); //verified this is not used in a function 2/18/25

--- a/src/renderer/src/context/useGlobal.ts
+++ b/src/renderer/src/context/useGlobal.ts
@@ -38,6 +38,8 @@ export const useGetGlobal = (): GetGlobalType => {
   const { globalState } = useContext(GlobalContext) as GlobalCtxType;
   return (prop) => {
     // console.log(`useGetGlobal ${prop} is ${changes[prop]}`);
-    return changes[prop] ?? globalState[prop];
+    // globalState may be undefined during a transient default-context render
+    // (e.g. HMR before the provider mounts); optional chaining avoids throwing.
+    return changes[prop] ?? globalState?.[prop];
   };
 };


### PR DESCRIPTION
## What

Several React contexts were created with an empty default value — `React.createContext({} as IContext)` (and `undefined` for `GlobalContext`). During Vite Fast Refresh (hot reload), a consumer can briefly render against that **default** value before its provider is re-established. Destructuring a nested object off the default then throws a `TypeError` (e.g. `Cannot destructure property 'currentstep' of 'ctx.state' as it is undefined`), which trips the app's error boundary and forces a full **log out / re-navigate** to recover.

This was originally hit via `PassageDetailGrids` → `PassageDetailContext`. The same latent bug existed in every context using the `{ state, setState }` shape with an empty default.

## Changes

Give each context a real default so a transient default-context render shows empty values for one frame instead of crashing:

- `{ state: initState, setState: () => {} }` for the `{state,setState}` contexts: **PassageDetail, Token, Unsaved, Team, Plan, Transcriber, HotKey**.
- A defined wrapper object for **GlobalContext** (`{ globalState: undefined, setGlobalState: () => {} }`) so `useGlobal`'s *existing* `globalState === undefined` guard runs instead of the destructure throwing. This is the highest-impact one since `useGlobal` is used app-wide.

No behavior change at runtime once providers are mounted — the default only matters during the brief HMR window (and the design already tolerates empty/initial state).

## Known follow-up (not in this PR)

`OrbitContext` (`useOrbitData`) has the same class of risk against its `{}` default, but it can't be fixed with a default value (it needs a real Orbit `memory`/cache); it would require guarding `useOrbitData`. Left for a separate change.

## Test plan

- `tsc --noEmit` passes (all `initState as ICtxState` casts compile).
- Manual: with `npm start`, editing a string rendered under the Passage Detail / Team / Plan screens no longer throws the "Something went wrong … ctx.state is undefined" error boundary on hot reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up cleanup (added in 45471ba)

While auditing the context defaults this PR touches, I found two contexts still snapshotting **localized strings** into context state — the TT-6225 stale-on-language-change anti-pattern:

- **PlanContext** — `t: {} as IMainStrings` was fully dead (never assigned by the provider, no consumer reads `state.t`). Removed the field, the unused `IMainStrings` import, and the matching `t` keys in the `PassageCard` / `PassageRef` Cypress mocks.
- **UnsavedContext** — the confirm dialog/messages correctly use a fresh local `t = useSelector(mainSelector)`, but that value was *also* snapshotted into `useState` initial state (goes stale on language switch). Dropped the dead `state.t` (initState field + `useState` spread); no consumer reads it. Added `shallowEqual` to the selector to match the documented pattern.

Also narrowed the `docs/ai/localization.md` guidance: the hazard is *localized-string* fields (`I*Strings` / `LocalizedStrings` snapshots), not plain strings.

`tsc --noEmit` still passes.
