### PR TITLE
TT-7187 feat(burrito): add James speaker rights fixture and related functionality

### DIFF
--- a/src/renderer/src/burrito/jamesSpeakerRightsFixture.ts
+++ b/src/renderer/src/burrito/jamesSpeakerRightsFixture.ts
@@ -1,0 +1,151 @@
+import type { IntellectualPropertyD } from '../model';
+import type { MediaFileD } from '../model';
+import type { ProjectD } from '../model';
+
+export const JAMES_SPEAKER_TEAM_ID = 'team-speakers';
+
+export const JAMES_SPEAKER_HOLDERS = [
+  'Greg',
+  'Fred',
+  'Alex',
+  'Sam',
+  'Jane',
+] as const;
+
+export type JamesSpeakerHolder = (typeof JAMES_SPEAKER_HOLDERS)[number];
+
+const SPEAKER_MEDIA: Array<{
+  holder: JamesSpeakerHolder;
+  id: string;
+  filename: string;
+  contentType: string;
+}> = [
+  {
+    holder: 'Greg',
+    id: 'media-greg',
+    filename: 'greg-rights.mp3',
+    contentType: 'audio/mpeg',
+  },
+  {
+    holder: 'Fred',
+    id: 'media-fred',
+    filename: 'fred-release.pdf',
+    contentType: 'application/pdf',
+  },
+  {
+    holder: 'Alex',
+    id: 'media-alex',
+    filename: 'alex-consent.png',
+    contentType: 'image/png',
+  },
+  {
+    holder: 'Sam',
+    id: 'media-sam',
+    filename: 'sam-statement.mp3',
+    contentType: 'audio/mpeg',
+  },
+  {
+    holder: 'Jane',
+    id: 'media-jane',
+    filename: 'jane-rights.pdf',
+    contentType: 'application/pdf',
+  },
+];
+
+export interface JamesSpeakerRightsFixture {
+  teamId: string;
+  project: ProjectD;
+  intellectualproperties: IntellectualPropertyD[];
+  mediafiles: MediaFileD[];
+}
+
+export function buildJamesSpeakerRightsFixture(): JamesSpeakerRightsFixture {
+  const teamId = JAMES_SPEAKER_TEAM_ID;
+  const project = {
+    id: 'proj-james',
+    type: 'project',
+    attributes: {
+      name: 'James Project',
+      language: 'eng',
+      defaultParams: '{}',
+    },
+    relationships: { organization: { data: { id: teamId } } },
+  } as ProjectD;
+
+  const mediafiles = SPEAKER_MEDIA.map(
+    ({ id, filename, contentType }) =>
+      ({
+        id,
+        type: 'mediafile',
+        attributes: {
+          audioUrl: `/media/${filename}`,
+          originalFile: filename,
+          contentType,
+          versionNumber: 1,
+        },
+      }) as MediaFileD
+  );
+
+  const intellectualproperties = SPEAKER_MEDIA.map(
+    ({ holder, id }, index) =>
+      ({
+        id: `ip-${holder.toLowerCase()}`,
+        type: 'intellectualproperty',
+        attributes: {
+          rightsHolder: holder,
+          notes: JSON.stringify({ fullName: holder }),
+        },
+        relationships: {
+          organization: { data: { id: teamId } },
+          releaseMediafile: { data: { id } },
+        },
+        keys: { remoteId: `ip-remote-${index + 1}` },
+      }) as unknown as IntellectualPropertyD
+  );
+
+  return { teamId, project, intellectualproperties, mediafiles };
+}
+
+export function speakerRightsHolders(json: string): string[] {
+  const parsed = JSON.parse(json) as {
+    data: Array<{ attributes: { rightsHolder?: string } }>;
+  };
+  return parsed.data
+    .map((r) => r.attributes.rightsHolder)
+    .filter((h): h is string => Boolean(h));
+}
+
+export function releaseMediaDests(ipc: {
+  copyFile: { mock: { calls: unknown[][] } };
+}): string[] {
+  return ipc.copyFile.mock.calls.map((c) => c[1] as string);
+}
+
+export function buildSpeakerRightsMemoryStub(
+  fixture: JamesSpeakerRightsFixture
+): { keyMap: Record<string, unknown>; cache: { query: (fn: (q: unknown) => unknown) => unknown } } {
+  const records: Record<string, unknown[]> = {
+    intellectualproperty: fixture.intellectualproperties,
+    mediafile: fixture.mediafiles,
+    organization: [
+      {
+        id: fixture.teamId,
+        type: 'organization',
+        attributes: { name: 'Speaker Team' },
+        keys: { remoteId: 'org-remote' },
+      },
+    ],
+  };
+
+  return {
+    keyMap: {},
+    cache: {
+      query: (fn: (q: unknown) => unknown) => {
+        const q = {
+          findRecords: (type: string) => records[type] ?? [],
+        };
+        return fn(q);
+      },
+    },
+  };
+}

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
@@ -47,21 +47,28 @@ function defaultExportPayload(fixture = buildJamesSpeakerRightsFixture()) {
   };
 }
 
-function loadIpHookForApi(
+/**
+ * `useBurritoIntellectualProperty` reads `window.api` at module load.
+ * `jest.resetModules()` plus dynamic `import()` (not top-level import of the
+ * hook) keeps `renderHook` and the hook on one React instance.
+ */
+async function loadIpHookForApi(
   api: unknown,
   exportPayload = defaultExportPayload()
 ) {
   jest.resetModules();
   (window as unknown as { api?: unknown }).api = api;
-  const { renderHook, act } = require('@testing-library/react/pure');
-  const {
-    getOrganizationIntellectualPropertyFiles,
-  } = require('../store/importexport/projectDataExport');
-  getOrganizationIntellectualPropertyFiles.mockReturnValue(exportPayload);
+  const { renderHook, act } = await import('@testing-library/react/pure');
+  const { getOrganizationIntellectualPropertyFiles } =
+    await import('../store/importexport/projectDataExport');
+  (getOrganizationIntellectualPropertyFiles as jest.Mock).mockReturnValue(
+    exportPayload
+  );
   const memoryStub = buildSpeakerRightsMemoryStub(
     buildJamesSpeakerRightsFixture()
   ) as unknown as Memory;
-  const { useBurritoIntellectualProperty } = require('./useBurritoIntellectualProperty');
+  const { useBurritoIntellectualProperty } =
+    await import('./useBurritoIntellectualProperty');
   return {
     renderHook,
     act,
@@ -117,7 +124,7 @@ describe('useBurritoIntellectualProperty', () => {
       useBurritoIntellectualProperty,
       getOrganizationIntellectualPropertyFiles,
       memoryStub,
-    } = loadIpHookForApi(
+    } = await loadIpHookForApi(
       { createFolder, write, copyFile, md5File, exists, stat },
       defaultExportPayload(fixture)
     );
@@ -141,7 +148,9 @@ describe('useBurritoIntellectualProperty', () => {
     );
 
     const ipWrite = write.mock.calls.find((c) =>
-      String(c[0]).endsWith('intellectualproperty/data/I_intellectualpropertys.json')
+      String(c[0]).endsWith(
+        'intellectualproperty/data/I_intellectualpropertys.json'
+      )
     );
     expect(ipWrite).toBeDefined();
     expect(speakerRightsHolders(ipWrite![1] as string)).toEqual(

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
@@ -1,0 +1,182 @@
+import type { Burrito } from './data/types';
+import type Memory from '@orbit/memory';
+import {
+  JAMES_SPEAKER_HOLDERS,
+  JAMES_SPEAKER_TEAM_ID,
+  buildJamesSpeakerRightsFixture,
+  buildSpeakerRightsMemoryStub,
+  releaseMediaDests,
+  speakerRightsHolders,
+} from './jamesSpeakerRightsFixture';
+
+jest.mock('../store/importexport/projectDataExport', () => ({
+  getOrganizationIntellectualPropertyFiles: jest.fn(),
+}));
+
+jest.mock('../utils/dataPath', () => ({
+  __esModule: true,
+  PathType: { MEDIA: 'MEDIA' },
+  default: jest.fn(async (_url: string, _pathType: unknown, local: any) => {
+    local.localname = '/local/source.dat';
+    return local.localname;
+  }),
+}));
+
+function defaultExportPayload(fixture = buildJamesSpeakerRightsFixture()) {
+  const ipJson = JSON.stringify({
+    data: fixture.intellectualproperties.map((ip) => ({
+      type: 'intellectualproperties',
+      id: ip.id,
+      attributes: { rightsHolder: ip.attributes.rightsHolder },
+      relationships: ip.relationships,
+    })),
+  });
+  const mediaJson = JSON.stringify({
+    data: fixture.mediafiles.map((m) => ({
+      type: 'mediafiles',
+      id: m.id,
+      attributes: m.attributes,
+    })),
+  });
+  return {
+    dataFiles: {
+      'data/I_intellectualpropertys.json': ipJson,
+      'data/H_mediafiles.json': mediaJson,
+    },
+    releaseMediafiles: fixture.mediafiles,
+  };
+}
+
+function loadIpHookForApi(
+  api: unknown,
+  exportPayload = defaultExportPayload()
+) {
+  jest.resetModules();
+  (window as unknown as { api?: unknown }).api = api;
+  const { renderHook, act } = require('@testing-library/react/pure');
+  const {
+    getOrganizationIntellectualPropertyFiles,
+  } = require('../store/importexport/projectDataExport');
+  getOrganizationIntellectualPropertyFiles.mockReturnValue(exportPayload);
+  const memoryStub = buildSpeakerRightsMemoryStub(
+    buildJamesSpeakerRightsFixture()
+  ) as unknown as Memory;
+  const { useBurritoIntellectualProperty } = require('./useBurritoIntellectualProperty');
+  return {
+    renderHook,
+    act,
+    useBurritoIntellectualProperty,
+    getOrganizationIntellectualPropertyFiles,
+    memoryStub,
+  };
+}
+
+function burritoFixture(): Burrito {
+  return {
+    format: 'burrito',
+    meta: {
+      version: '0.1',
+      category: 'scripture',
+      generator: {
+        softwareName: 'apm',
+        softwareVersion: '1',
+        userName: 'tester',
+      },
+      defaultLocale: 'en',
+      dateCreated: '2020-01-01',
+      comments: [],
+    },
+    ingredients: {},
+    type: {
+      flavorType: {
+        name: 'typeName',
+        flavor: { name: 'flavorName' },
+        currentScope: {},
+      },
+    },
+  };
+}
+
+describe('useBurritoIntellectualProperty', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exports team-level speaker JSON, release media, and metadata (TT-7187)', async () => {
+    const createFolder = jest.fn().mockResolvedValue(undefined);
+    const write = jest.fn().mockResolvedValue(undefined);
+    const copyFile = jest.fn().mockResolvedValue(undefined);
+    const md5File = jest.fn().mockResolvedValue('deadbeef');
+    const exists = jest.fn().mockResolvedValue(true);
+    const stat = jest.fn().mockResolvedValue(JSON.stringify({ size: 1024 }));
+
+    const fixture = buildJamesSpeakerRightsFixture();
+    const {
+      renderHook,
+      act,
+      useBurritoIntellectualProperty,
+      getOrganizationIntellectualPropertyFiles,
+      memoryStub,
+    } = loadIpHookForApi(
+      { createFolder, write, copyFile, md5File, exists, stat },
+      defaultExportPayload(fixture)
+    );
+
+    const { result } = renderHook(() =>
+      useBurritoIntellectualProperty(memoryStub, JAMES_SPEAKER_TEAM_ID)
+    );
+
+    let updated: Burrito;
+    await act(async () => {
+      updated = await result.current({
+        metadata: burritoFixture(),
+        partPath: '/burrito/TST/intellectualproperty',
+        preLen: 0,
+      });
+    });
+
+    expect(getOrganizationIntellectualPropertyFiles).toHaveBeenCalledWith(
+      memoryStub,
+      JAMES_SPEAKER_TEAM_ID
+    );
+
+    const ipWrite = write.mock.calls.find((c) =>
+      String(c[0]).endsWith('intellectualproperty/data/I_intellectualpropertys.json')
+    );
+    expect(ipWrite).toBeDefined();
+    expect(speakerRightsHolders(ipWrite![1] as string)).toEqual(
+      expect.arrayContaining([...JAMES_SPEAKER_HOLDERS])
+    );
+
+    const mediaJsonWrite = write.mock.calls.find((c) =>
+      String(c[0]).endsWith('intellectualproperty/data/H_mediafiles.json')
+    );
+    expect(mediaJsonWrite).toBeDefined();
+    const mediaData = JSON.parse(mediaJsonWrite![1] as string) as {
+      data: Array<{ id: string }>;
+    };
+    expect(mediaData.data.map((r) => r.id)).toEqual(
+      expect.arrayContaining(fixture.mediafiles.map((m) => m.id))
+    );
+
+    expect(copyFile).toHaveBeenCalledTimes(fixture.mediafiles.length);
+    const dests = releaseMediaDests({ copyFile });
+    expect(dests.some((d) => d.includes('greg-rights'))).toBe(true);
+    expect(dests.some((d) => d.includes('fred-release'))).toBe(true);
+
+    const ipIngredient =
+      updated!.ingredients[
+        '/burrito/TST/intellectualproperty/data/I_intellectualpropertys.json'
+      ];
+    expect(ipIngredient).toMatchObject({
+      checksum: { md5: 'deadbeef' },
+      mimeType: 'application/json',
+    });
+    expect(ipIngredient.scope).toBeUndefined();
+
+    expect(updated!.type!.flavorType!.name).toBe('x-intellectualproperty');
+    expect(updated!.type!.flavorType!.flavor.name).toBe(
+      'x-intellectualproperty'
+    );
+  });
+});

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
@@ -178,5 +178,18 @@ describe('useBurritoIntellectualProperty', () => {
     expect(updated!.type!.flavorType!.flavor.name).toBe(
       'x-intellectualproperty'
     );
+
+    const ingredientMime = (filename: string) => {
+      const key = Object.keys(updated!.ingredients).find((k) =>
+        k.includes(filename)
+      );
+      expect(key).toBeDefined();
+      return updated!.ingredients[key!]!.mimeType;
+    };
+    expect(ingredientMime('greg-rights')).toBe('audio/mpeg');
+    expect(ingredientMime('fred-release')).toBe('application/pdf');
+    expect(ingredientMime('alex-consent')).toBe('image/png');
+    expect(ingredientMime('sam-statement')).toBe('audio/mpeg');
+    expect(ingredientMime('jane-rights')).toBe('application/pdf');
   });
 });

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
@@ -80,10 +80,14 @@ export const useBurritoIntellectualProperty = (
       const stat = JSON.parse(await ipc?.stat(destPath)) as Stats;
       const size = stat?.size ?? 0;
       const outputExt = path.extname(destPath).toLowerCase();
+      const declaredMime = (attr.contentType ?? '').trim();
       const mimeType =
         outputExt === '.mp3'
           ? 'audio/mpeg'
-          : inferAudioContentType(destPath, attr.contentType);
+          : declaredMime &&
+              !declaredMime.toLowerCase().startsWith('audio/')
+            ? declaredMime
+            : inferAudioContentType(destPath, attr.contentType);
       ingredients[relPath] = {
         checksum: { md5: await ipc?.md5File(destPath) },
         mimeType,

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
@@ -38,11 +38,7 @@ export const useBurritoIntellectualProperty = (
   memory: Memory,
   organizationId: string
 ) => {
-  return async ({
-    metadata,
-    partPath,
-    preLen,
-  }: Props): Promise<Burrito> => {
+  return async ({ metadata, partPath, preLen }: Props): Promise<Burrito> => {
     const { dataFiles, releaseMediafiles } =
       getOrganizationIntellectualPropertyFiles(memory, organizationId);
     const ingredients: BurritoIngredients = {};
@@ -84,8 +80,7 @@ export const useBurritoIntellectualProperty = (
       const mimeType =
         outputExt === '.mp3'
           ? 'audio/mpeg'
-          : declaredMime &&
-              !declaredMime.toLowerCase().startsWith('audio/')
+          : declaredMime && !declaredMime.toLowerCase().startsWith('audio/')
             ? declaredMime
             : inferAudioContentType(destPath, attr.contentType);
       ingredients[relPath] = {

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
@@ -1,0 +1,106 @@
+import path from 'path-browserify';
+import { Burrito, BurritoIngredients } from './data/types';
+import { MainAPI } from '@model/main-api';
+import { getOrganizationIntellectualPropertyFiles } from '../store/importexport/projectDataExport';
+import Memory from '@orbit/memory';
+import { MediaFileD } from '../model';
+import dataPath, { PathType } from '../utils/dataPath';
+import getMediaExt from '../utils/getMediaExt';
+import getBurritoMediaExportStem from '../utils/burritoMediaFileStem';
+import cleanFileName from '../utils/cleanFileName';
+import { inferAudioContentType } from '../utils/mimeTypes';
+import { Stats } from 'fs';
+
+const ipc = window?.api as MainAPI;
+
+interface Props {
+  metadata: Burrito;
+  partPath: string;
+  preLen: number;
+}
+
+const stemForMedia = (
+  m: MediaFileD,
+  usedStems: Map<string, number>
+): string => {
+  let stem = getBurritoMediaExportStem(m);
+  const count = usedStems.get(stem) ?? 0;
+  usedStems.set(stem, count + 1);
+  if (count > 0) stem = `${stem}-${count}`;
+  return cleanFileName(stem);
+};
+
+/**
+ * Exports team-level speaker intellectual property: PTF-style data JSON plus
+ * release media files at the burrito intellectualproperty part root.
+ */
+export const useBurritoIntellectualProperty = (
+  memory: Memory,
+  organizationId: string
+) => {
+  return async ({
+    metadata,
+    partPath,
+    preLen,
+  }: Props): Promise<Burrito> => {
+    const { dataFiles, releaseMediafiles } =
+      getOrganizationIntellectualPropertyFiles(memory, organizationId);
+    const ingredients: BurritoIngredients = {};
+    const dataDir = path.join(partPath, 'data');
+    await ipc?.createFolder(dataDir);
+
+    for (const [filename, content] of Object.entries(dataFiles)) {
+      const filePath = path.join(partPath, filename);
+      await ipc?.write(filePath, content);
+      const relPath = filePath.substring(preLen);
+      const md5 = await ipc?.md5File(filePath);
+      ingredients[relPath] = {
+        checksum: { md5 },
+        mimeType: 'application/json',
+        size: content.length,
+      };
+    }
+
+    const usedStems = new Map<string, number>();
+    for (const m of releaseMediafiles) {
+      const attr = m.attributes;
+      if (!attr.audioUrl) continue;
+      const local = { localname: '' };
+      await dataPath(attr.audioUrl, PathType.MEDIA, local);
+      const mediaName = local.localname;
+      if (!(await ipc?.exists(mediaName))) continue;
+
+      const ext = getMediaExt(m);
+      const stem = stemForMedia(m, usedStems);
+      const destPath = path.join(partPath, `${stem}.${ext}`);
+      await ipc?.createFolder(path.dirname(destPath));
+      await ipc?.copyFile(mediaName, destPath);
+
+      const relPath = destPath.substring(preLen);
+      const stat = JSON.parse(await ipc?.stat(destPath)) as Stats;
+      const size = stat?.size ?? 0;
+      const outputExt = path.extname(destPath).toLowerCase();
+      const mimeType =
+        outputExt === '.mp3'
+          ? 'audio/mpeg'
+          : inferAudioContentType(destPath, attr.contentType);
+      ingredients[relPath] = {
+        checksum: { md5: await ipc?.md5File(destPath) },
+        mimeType,
+        size,
+        properties: {
+          'x-apmId': m.keys?.remoteId || m.id,
+        },
+      };
+    }
+
+    metadata.ingredients = { ...metadata.ingredients, ...ingredients };
+    if (metadata.type?.flavorType?.flavor) {
+      metadata.type.flavorType.flavor.name = 'x-intellectualproperty';
+    }
+    if (metadata.type?.flavorType) {
+      metadata.type.flavorType.name = 'x-intellectualproperty';
+    }
+    return metadata;
+  };
+};

--- a/src/renderer/src/burrito/useCreateBurrito.test.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.test.ts
@@ -34,8 +34,14 @@ jest.mock('../hoc/useOrbitData', () => ({
 
 jest.mock('../utils/dataPath', () => ({
   __esModule: true,
-  default: jest.fn(async (p: string) => `/abs/${p}`),
-  PathType: { BURRITO: 'burrito' },
+  default: jest.fn(async (p: string, _pathType?: unknown, local?: any) => {
+    if (local) {
+      local.localname = `/local/${p}`;
+      return local.localname;
+    }
+    return `/abs/${p}`;
+  }),
+  PathType: { BURRITO: 'burrito', MEDIA: 'MEDIA' },
 }));
 
 jest.mock('../utils/cleanFileName', () => ({
@@ -125,6 +131,11 @@ jest.mock('./useBurritoApmData', () => ({
     jest.fn(async ({ metadata }: any) => metadata)
   ),
 }));
+jest.mock('./useBurritoIntellectualProperty', () => ({
+  useBurritoIntellectualProperty: jest.fn(() =>
+    jest.fn(async ({ metadata }: any) => metadata)
+  ),
+}));
 
 jest.mock('../crud', () => {
   const related = (rec: any, key: string) =>
@@ -157,6 +168,10 @@ function makeIpc() {
     createFolder: jest.fn().mockResolvedValue(undefined),
     deleteFolder: jest.fn().mockResolvedValue(undefined),
     write: jest.fn().mockResolvedValue(undefined),
+    copyFile: jest.fn().mockResolvedValue(undefined),
+    md5File: jest.fn().mockResolvedValue('deadbeef'),
+    exists: jest.fn().mockResolvedValue(true),
+    stat: jest.fn().mockResolvedValue(JSON.stringify({ size: 1024 })),
   };
 }
 
@@ -173,6 +188,7 @@ type LoadOpts = {
   /** Akuo book slot per project id for projDefBook resolution in tests */
   projBookById?: Record<string, string>;
   num2BookCodeImpl?: (bookNum: number) => string | undefined;
+  memoryStub?: Record<string, unknown>;
 };
 
 function loadCreateBurrito(api: typeof window.api, opts: LoadOpts = {}) {
@@ -212,7 +228,8 @@ function loadCreateBurrito(api: typeof window.api, opts: LoadOpts = {}) {
 
   const { useGlobal } = require('../context/useGlobal');
   useGlobal.mockImplementation((key: string) => {
-    if (key === 'memory') return [{ keyMap: {} }, jest.fn()];
+    if (key === 'memory')
+      return [opts.memoryStub ?? { keyMap: {} }, jest.fn()];
     if (key === 'user') return ['user-1', jest.fn()];
     return [undefined, jest.fn()];
   });
@@ -632,5 +649,138 @@ describe('useCreateBurrito', () => {
     expect(textCall[0].sections.map((s: { id: string }) => s.id)).toContain(
       'sec-g2'
     );
+  });
+
+  it('creates team-level intellectual property from org speaker rights (TT-7187)', async () => {
+    const {
+      buildJamesSpeakerRightsFixture,
+      buildSpeakerRightsMemoryStub,
+      JAMES_SPEAKER_TEAM_ID,
+    } = require('./jamesSpeakerRightsFixture');
+
+    const ipc = makeIpc();
+    const speakerFixture = buildJamesSpeakerRightsFixture();
+    const memoryStub = buildSpeakerRightsMemoryStub(speakerFixture);
+    const { user, team, bible, teamBible } = fixtures(JAMES_SPEAKER_TEAM_ID);
+
+    const ipJson = JSON.stringify({
+      data: speakerFixture.intellectualproperties.map(
+        (ip: { id: string; attributes: { rightsHolder: string }; relationships: unknown }) => ({
+          type: 'intellectualproperties',
+          id: ip.id,
+          attributes: { rightsHolder: ip.attributes.rightsHolder },
+          relationships: ip.relationships,
+        })
+      ),
+    });
+
+    const { renderHook, act, useCreateBurrito } = loadCreateBurrito(
+      ipc as never,
+      {
+        orgDefaults: {
+          burritoBooks: ['JAS'],
+          burritoContents: [BurritoType.IntellectualProperty],
+          burritoWrapper: { wrapper: true },
+          burritoProjects: [speakerFixture.project.id],
+          burritoFormat: { convertToMp3: false },
+          burritoRevision: '1',
+        },
+        bookData: [
+          { code: 'JAS', abbr: 'Jas', short: 'James', long: 'James' },
+        ],
+        memoryStub,
+        orbit: {
+          user: [user],
+          organization: [team],
+          organizationbible: [teamBible],
+          bible: [bible],
+          project: [speakerFixture.project],
+          plan: [],
+          section: [],
+          passage: [],
+          intellectualproperty: speakerFixture.intellectualproperties,
+          mediafile: speakerFixture.mediafiles,
+        },
+      }
+    );
+
+    const { useBurritoIntellectualProperty } = require('./useBurritoIntellectualProperty');
+    useBurritoIntellectualProperty.mockImplementation(() =>
+      jest.fn(async ({ metadata, partPath, preLen }: any) => {
+        const dataDir = `${partPath}/data`;
+        await ipc.createFolder(dataDir);
+        const ipPath = `${dataDir}/I_intellectualpropertys.json`;
+        await ipc.write(ipPath, ipJson);
+        for (const m of speakerFixture.mediafiles) {
+          const dest = `${partPath}/${m.attributes.originalFile}`;
+          await ipc.copyFile('/local/source', dest);
+        }
+        const relIp = ipPath.substring(preLen);
+        const relMedia = `${partPath}/greg-rights.mp3`.substring(preLen);
+        return {
+          ...metadata,
+          ingredients: {
+            ...metadata.ingredients,
+            [relIp]: {
+              checksum: { md5: 'deadbeef' },
+              mimeType: 'application/json',
+              size: ipJson.length,
+            },
+            [relMedia]: {
+              checksum: { md5: 'deadbeef' },
+              mimeType: 'audio/mpeg',
+              size: 1024,
+            },
+          },
+          type: {
+            ...metadata.type,
+            flavorType: {
+              ...metadata.type?.flavorType,
+              name: 'x-intellectualproperty',
+              flavor: { name: 'x-intellectualproperty' },
+            },
+          },
+        };
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useCreateBurrito(JAMES_SPEAKER_TEAM_ID)
+    );
+
+    await act(async () => {
+      await result.current.createBurrito();
+    });
+
+    const folderPaths = ipc.createFolder.mock.calls.map((c) => String(c[0]));
+    expect(
+      folderPaths.some((p) => /intellectualproperty[/\\]59JAS/i.test(p))
+    ).toBe(false);
+    expect(
+      folderPaths.some((p) => /intellectualproperty[/\\]JAS/i.test(p))
+    ).toBe(false);
+
+    const writePaths = ipc.write.mock.calls.map((c) => String(c[0]));
+    expect(
+      writePaths.some((p) =>
+        p.includes('intellectualproperty/data/I_intellectualpropertys.json')
+      )
+    ).toBe(true);
+    expect(ipc.copyFile.mock.calls.length).toBeGreaterThanOrEqual(5);
+
+    const ipMetaWrite = ipc.write.mock.calls.find(
+      (c) =>
+        String(c[0]).includes('intellectualproperty/metadata.json') &&
+        String(c[1]).includes('x-intellectualproperty')
+    );
+    expect(ipMetaWrite).toBeDefined();
+    const metadata = JSON.parse(ipMetaWrite![1] as string);
+    const ingredientKeys = Object.keys(metadata.ingredients ?? {});
+    expect(
+      ingredientKeys.some((k) => k.includes('I_intellectualpropertys.json'))
+    ).toBe(true);
+    expect(ingredientKeys.some((k) => k.includes('greg-rights'))).toBe(true);
+
+    expect(result.current.result).toBe('success');
   });
 });

--- a/src/renderer/src/burrito/useCreateBurrito.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.ts
@@ -42,6 +42,7 @@ import CodeNum from '../assets/code-num.json';
 import { useBurritoAudio } from './useBurritoAudio';
 import { useBurritoNavigation } from './useBurritoNavigation';
 import { useBurritoApmData } from './useBurritoApmData';
+import { useBurritoIntellectualProperty } from './useBurritoIntellectualProperty';
 import { PassageTypeEnum } from '../model/passageType';
 import { ArtifactTypeSlug } from '../crud/artifactTypeSlug';
 import packageJson from '../../package.json';
@@ -102,6 +103,10 @@ export const useCreateBurrito = (teamId: string) => {
   const burritoText = useBurritoText(teamId);
   const burritoNavigation = useBurritoNavigation(teamId);
   const burritoApmData = useBurritoApmData(memory);
+  const burritoIntellectualProperty = useBurritoIntellectualProperty(
+    memory,
+    teamId
+  );
   const t: IBurritoStrings = useSelector(burritoSelector, shallowEqual);
 
   const bookData = (book: string) => allBookData.find((b) => b.code === book);
@@ -365,6 +370,16 @@ export const useCreateBurrito = (teamId: string) => {
           apmDataProjects.length
         );
       }
+    } else if (part === BurritoType.IntellectualProperty) {
+      if (cancelRef.current) return;
+      const partPath = path.dirname(metaName);
+      metaData = await burritoIntellectualProperty({
+        metadata: metaData,
+        partPath,
+        preLen,
+      });
+      if (cancelRef.current) return;
+      onBookComplete(partIndex, 1, '', 1);
     } else {
       let bookIndex = 0;
       for (const book of books) {
@@ -420,20 +435,6 @@ export const useCreateBurrito = (teamId: string) => {
               ArtifactTypeSlug.ProjectResource,
               ArtifactTypeSlug.AIResource,
             ],
-            convertToMp3,
-          });
-        }
-        if (part === BurritoType.IntellectualProperty) {
-          metaData = await burritoAudio({
-            metadata: metaData,
-            bible: bible as BibleD,
-            book,
-            bookPath,
-            preLen,
-            sections: bookSecs,
-            passageTypeFilter: null,
-            flavorTypeName: 'x-intellectualproperty',
-            artifactTypeFilter: [ArtifactTypeSlug.IntellectualProperty],
             convertToMp3,
           });
         }
@@ -499,7 +500,9 @@ export const useCreateBurrito = (teamId: string) => {
           sum +
           (part === BurritoType.ApmData
             ? apmDataProjects.length
-            : books.length),
+            : part === BurritoType.IntellectualProperty
+              ? 1
+              : books.length),
         0
       );
       let completedUnits = 0;

--- a/src/renderer/src/store/importexport/projectDataExport.ts
+++ b/src/renderer/src/store/importexport/projectDataExport.ts
@@ -636,9 +636,9 @@ export function getOrganizationIntellectualPropertyFiles(
 
   const serializeForExport = (rec: InitializedRecord) => {
     if (needsRemoteIds) {
-      return ser.serialize(rec) as Record<string, unknown>;
+      return ser.serialize(rec) as unknown as Record<string, unknown>;
     }
-    const ri = ser.serialize(rec) as Record<string, unknown>;
+    const ri = ser.serialize(rec) as unknown as Record<string, unknown>;
     ri.id = rec.id;
     ri.relationships = rec.relationships;
     return ri;

--- a/src/renderer/src/store/importexport/projectDataExport.ts
+++ b/src/renderer/src/store/importexport/projectDataExport.ts
@@ -568,3 +568,93 @@ export async function getProjectDataFiles(
 
   return files;
 }
+
+export interface OrganizationIntellectualPropertyExport {
+  dataFiles: ProjectDataFiles;
+  releaseMediafiles: MediaFileD[];
+}
+
+/**
+ * PTF-style speaker rights JSON for a team (organization), plus release media rows
+ * referenced by those intellectualproperty records.
+ */
+export function getOrganizationIntellectualPropertyFiles(
+  memory: Memory,
+  organizationId: string
+): OrganizationIntellectualPropertyExport {
+  const ser = getSerializer(memory);
+  const keyMap = memory?.keyMap as RecordKeyMap;
+  const orgs = memory.cache.query((q) =>
+    q.findRecords('organization')
+  ) as OrganizationD[];
+  const org = orgs.find((o) => o.id === organizationId);
+  const needsRemoteIds = Boolean(org?.keys?.remoteId);
+
+  let ips = memory.cache.query((q) =>
+    q.findRecords('intellectualproperty')
+  ) as IntellectualPropertyD[];
+  ips = ips.filter((rec) => related(rec, 'organization') === organizationId);
+
+  if (needsRemoteIds) {
+    ips.forEach((ip) => {
+      if (!remoteId('intellectualproperty', ip.id, keyMap) && ip.attributes)
+        ip.attributes.offlineId = ip.id;
+      if (
+        !remoteId('mediafile', related(ip, 'releaseMediafile'), keyMap) &&
+        ip.attributes
+      )
+        ip.attributes.offlineMediafileId = related(ip, 'releaseMediafile');
+    });
+  }
+
+  const releaseIds = ips
+    .map((ip) => related(ip, 'releaseMediafile'))
+    .filter((id): id is string => Boolean(id));
+  const allMedia = memory.cache.query((q) =>
+    q.findRecords('mediafile')
+  ) as MediaFileD[];
+  let releaseMediafiles = allMedia.filter((m) => releaseIds.includes(m.id));
+  releaseMediafiles = releaseMediafiles.map((m) => ({ ...m }));
+  if (needsRemoteIds) {
+    releaseMediafiles.forEach((m) => {
+      if (!remoteId('mediafile', m.id, keyMap) && m.attributes) {
+        m.attributes.offlineId = m.id;
+      }
+      const src = related(m, 'sourceMedia');
+      if (src && !remoteId('mediafile', src, keyMap) && m.attributes) {
+        m.attributes.sourceMediaOfflineId = src;
+      }
+      delete m.attributes.planId;
+      delete m.attributes.artifactTypeId;
+      delete m.attributes.passageId;
+      delete m.attributes.userId;
+      delete m.attributes.recordedbyUserId;
+      delete m.attributes.recordedByUserId;
+      delete m.attributes.sourceMediaId;
+    });
+  }
+
+  const serializeForExport = (rec: InitializedRecord) => {
+    if (needsRemoteIds) {
+      return ser.serialize(rec) as Record<string, unknown>;
+    }
+    const ri = ser.serialize(rec) as Record<string, unknown>;
+    ri.id = rec.id;
+    ri.relationships = rec.relationships;
+    return ri;
+  };
+
+  const files: ProjectDataFiles = {};
+  if (ips.length > 0) {
+    files['data/I_intellectualpropertys.json'] =
+      '{"data":' + JSON.stringify(ips.map((r) => serializeForExport(r))) + '}';
+  }
+  if (releaseMediafiles.length > 0) {
+    files['data/H_mediafiles.json'] =
+      '{"data":' +
+      JSON.stringify(releaseMediafiles.map((r) => serializeForExport(r))) +
+      '}';
+  }
+
+  return { dataFiles: files, releaseMediafiles };
+}


### PR DESCRIPTION
- Introduced `jamesSpeakerRightsFixture.ts` to define speaker rights data structure and media files for the James project.
- Implemented `buildJamesSpeakerRightsFixture` function to create a fixture for testing.
- Added `useBurritoIntellectualProperty.ts` to handle the export of team-level speaker intellectual property, including JSON and media files.
- Created tests for the new functionality in `useBurritoIntellectualProperty.test.ts`, ensuring correct export behavior and integration with the existing system.
- Updated `useCreateBurrito.ts` to incorporate the new intellectual property handling logic.

This commit enhances the burrito export process by integrating speaker rights management, facilitating better organization and retrieval of intellectual property data.