### PR TITLE
TT-7193,7194 use APM data when available to reconstruct secs n psgs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,5 +55,11 @@ export default tseslint.config(
       'react-hooks/globals': 'off',
     },
   },
+  {
+    files: ['migration/**/*.{js,mjs}'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off',
+    },
+  },
   eslintConfigPrettier
 );

--- a/migration/05-burrito-to-ptf.js
+++ b/migration/05-burrito-to-ptf.js
@@ -2107,16 +2107,26 @@ async function transformBurritoToPTF(cli) {
         sections = remapped.sections;
         passages = remapped.passages;
         plan.attributes.sectionCount = sections.length;
+        const passagesBySectionId = new Map();
+        for (const passage of passages) {
+          const sectionId = passage.relationships?.section?.data?.id;
+          if (sectionId == null) {
+            continue;
+          }
+          const sectionPassages = passagesBySectionId.get(sectionId);
+          if (sectionPassages) {
+            sectionPassages.push(passage);
+          } else {
+            passagesBySectionId.set(sectionId, [passage]);
+          }
+        }
         sections.forEach((section, index) => {
           plan.relationships.sections.data.push(
             relationshipIdentifier('section', section)
           );
           passageBySection.set(
             index,
-            passages.filter(
-              (passage) =>
-                passage.relationships?.section?.data?.id === section.id
-            )
+            passagesBySectionId.get(section.id) ?? []
           );
         });
         passageSeq =

--- a/migration/05-burrito-to-ptf.js
+++ b/migration/05-burrito-to-ptf.js
@@ -1473,6 +1473,18 @@ async function transformBurritoToPTF(cli) {
   let lastPtfPath = null;
   const usedTeamNames = new Set();
   const usedOrganizationSlugs = new Set();
+  const apmdataSister = await findBurritoPackageByFlavorName(
+    INPUT_DIR,
+    'x-apmdata'
+  );
+  const apmDataHelpers = await import(
+    pathToFileURL(path.join(__dirname, 'burrito-apmdata.mjs')).href
+  );
+  if (apmdataSister) {
+    console.log(
+      `  Using ApmData burrito for plan structure: ${apmdataSister.pkg.label}`
+    );
+  }
 
   for (const pkg of packages) {
     const packageLabel = pkg.label;
@@ -1962,7 +1974,7 @@ async function transformBurritoToPTF(cli) {
         relationshipIdentifier('organizationmembership', organizationMembership)
       );
 
-      const orgWorkflowSteps = SAMPLE_ORG_WORKFLOW_STEPS.data.map((step) => {
+      let orgWorkflowSteps = SAMPLE_ORG_WORKFLOW_STEPS.data.map((step) => {
         const attributes = {
           ...step.attributes,
           dateCreated: createdAt,
@@ -2069,37 +2081,82 @@ async function transformBurritoToPTF(cli) {
         }
       });
 
-      const sections = normalizedSections.map((sectionInfo, index) => {
-        const section = createJsonApiRecord(
-          'sections',
-          {
-            sequencenum: index + 1,
-            name: sectionInfo.name || `Section ${index + 1}`,
-            state: '',
-            level: sectionInfo.level ?? 3,
-            published: false,
-            publishTo: '{}',
-            dateCreated: createdAt,
-            dateUpdated: createdAt,
-          },
-          {
-            plan: createRelationship('plan', plan),
-            passages: createRelationship('passage', []),
-          }
-        );
-        plan.relationships.sections.data.push(
-          relationshipIdentifier('section', section)
-        );
-        return section;
-      });
+      const apmSnapshot = apmdataSister
+        ? apmDataHelpers.loadApmDataSnapshot(
+            apmdataSister.pkg.entries,
+            apmdataSister.metadata,
+            bookGroupCode
+          )
+        : null;
 
-      const passages = [];
+      let sections;
+      let passages;
       const mediafiles = [];
       const passageBySection = new Map();
-      sections.forEach((section, index) => {
-        passageBySection.set(index, []);
-      });
       let passageSeq = 1;
+
+      if (apmSnapshot) {
+        const remapped = apmDataHelpers.remapApmDataSnapshot(apmSnapshot, {
+          generateId,
+          createdAt,
+          user,
+          organization,
+          plan,
+        });
+        orgWorkflowSteps = remapped.orgWorkflowSteps;
+        sections = remapped.sections;
+        passages = remapped.passages;
+        plan.attributes.sectionCount = sections.length;
+        sections.forEach((section, index) => {
+          plan.relationships.sections.data.push(
+            relationshipIdentifier('section', section)
+          );
+          passageBySection.set(
+            index,
+            passages.filter(
+              (passage) =>
+                passage.relationships?.section?.data?.id === section.id
+            )
+          );
+        });
+        passageSeq =
+          passages.reduce((max, passage) => {
+            const seq = Number(passage.attributes?.sequencenum ?? 0);
+            return Number.isFinite(seq) ? Math.max(max, seq) : max;
+          }, 0) + 1;
+        console.log(
+          `  Imported ${sections.length} section(s), ${passages.length} passage(s), and ${orgWorkflowSteps.length} org workflow step(s) from ApmData`
+        );
+      } else {
+        sections = normalizedSections.map((sectionInfo, index) => {
+          const section = createJsonApiRecord(
+            'sections',
+            {
+              sequencenum: index + 1,
+              name: sectionInfo.name || `Section ${index + 1}`,
+              state: '',
+              level: sectionInfo.level ?? 3,
+              published: false,
+              publishTo: '{}',
+              dateCreated: createdAt,
+              dateUpdated: createdAt,
+            },
+            {
+              plan: createRelationship('plan', plan),
+              passages: createRelationship('passage', []),
+            }
+          );
+          plan.relationships.sections.data.push(
+            relationshipIdentifier('section', section)
+          );
+          return section;
+        });
+
+        passages = [];
+        sections.forEach((section, index) => {
+          passageBySection.set(index, []);
+        });
+      }
 
       function createPassageFromSpan(sectionIndex, span, fallbackTitle) {
         const section = sections[sectionIndex] ?? sections[0];
@@ -2141,6 +2198,7 @@ async function transformBurritoToPTF(cli) {
       }
 
       if (
+        !apmSnapshot &&
         textEntry &&
         paragraphSpans.length > 0 &&
         chaptersCoveredByAudio.size > 0
@@ -2177,29 +2235,42 @@ async function transformBurritoToPTF(cli) {
           referenceLabel,
           audioEntry.reference.bookCode
         );
-        const targetSectionIndex = findBestSectionIndexForSpan(
-          normalizedSections,
-          span
-        );
-        const candidatePassages =
-          passageBySection.get(targetSectionIndex) ?? [];
-        let passage = candidatePassages.find((candidate) => {
-          if (!span) {
-            return false;
-          }
-          return (
-            candidate.attributes['start-chapter'] === span.startChapter &&
-            candidate.attributes['start-verse'] === span.startVerse &&
-            candidate.attributes['end-chapter'] === span.endChapter &&
-            candidate.attributes['end-verse'] === span.endVerse
-          );
-        });
+        let passage;
+        if (apmSnapshot && span) {
+          passage = passages.find((candidate) => {
+            return (
+              candidate.attributes['start-chapter'] === span.startChapter &&
+              candidate.attributes['start-verse'] === span.startVerse &&
+              candidate.attributes['end-chapter'] === span.endChapter &&
+              candidate.attributes['end-verse'] === span.endVerse
+            );
+          });
+        }
         if (!passage) {
-          passage = createPassageFromSpan(
-            targetSectionIndex,
-            span,
-            referenceTitle
+          const targetSectionIndex = findBestSectionIndexForSpan(
+            normalizedSections,
+            span
           );
+          const candidatePassages =
+            passageBySection.get(targetSectionIndex) ?? [];
+          passage = candidatePassages.find((candidate) => {
+            if (!span) {
+              return false;
+            }
+            return (
+              candidate.attributes['start-chapter'] === span.startChapter &&
+              candidate.attributes['start-verse'] === span.startVerse &&
+              candidate.attributes['end-chapter'] === span.endChapter &&
+              candidate.attributes['end-verse'] === span.endVerse
+            );
+          });
+          if (!passage) {
+            passage = createPassageFromSpan(
+              targetSectionIndex,
+              span,
+              referenceTitle
+            );
+          }
         }
         passage.attributes.reference = referenceLabel;
         passage.attributes.title = referenceTitle;
@@ -2348,14 +2419,18 @@ async function transformBurritoToPTF(cli) {
   }
 }
 
-const cliArgs = parseCliArgs();
-transformBurritoToPTF(cliArgs).catch((err) => {
-  console.error('Failed to transform Scripture Burrito to PTF:', err);
-  if (cliArgs.jsonResult) {
-    console.log(
-      'JSON_RESULT:' +
-        JSON.stringify({ ok: false, error: err?.message ?? String(err) })
-    );
-  }
-  process.exitCode = 1;
-});
+module.exports = { transformBurritoToPTF };
+
+if (require.main === module) {
+  const cliArgs = parseCliArgs();
+  transformBurritoToPTF(cliArgs).catch((err) => {
+    console.error('Failed to transform Scripture Burrito to PTF:', err);
+    if (cliArgs.jsonResult) {
+      console.log(
+        'JSON_RESULT:' +
+          JSON.stringify({ ok: false, error: err?.message ?? String(err) })
+      );
+    }
+    process.exitCode = 1;
+  });
+}

--- a/migration/05-burrito-to-ptf.js
+++ b/migration/05-burrito-to-ptf.js
@@ -1481,9 +1481,7 @@ async function transformBurritoToPTF(cli) {
     pathToFileURL(path.join(__dirname, 'burrito-apmdata.mjs')).href
   );
   if (apmdataSister) {
-    console.log(
-      `  Using ApmData burrito for plan structure: ${apmdataSister.pkg.label}`
-    );
+    console.log(`  Found ApmData burrito: ${apmdataSister.pkg.label}`);
   }
 
   for (const pkg of packages) {

--- a/migration/05-burrito-to-ptf.test.mjs
+++ b/migration/05-burrito-to-ptf.test.mjs
@@ -4,11 +4,9 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { fileURLToPath } from 'node:url';
 import AdmZip from 'adm-zip';
 import { createRequire } from 'node:module';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const { transformBurritoToPTF } = require('./05-burrito-to-ptf.js');
 
@@ -240,6 +238,8 @@ function buildPlanStructure() {
 
 /**
  * @param {string} rootDir
+ * @param {number} orgWorkflowStepCount
+ * @returns {Promise<void>}
  */
 async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
   const apmRoot = path.join(rootDir, 'apmdata');
@@ -251,6 +251,11 @@ async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
   const orgWorkflowSteps = buildOrgWorkflowSteps(orgWorkflowStepCount);
   const scope = { [BOOK]: [] };
 
+  /**
+   * @param {string} fileName
+   * @param {unknown} data
+   * @returns {Promise<void>}
+   */
   const writeTable = async (fileName, data) => {
     await fs.writeFile(
       path.join(dataDir, fileName),
@@ -311,7 +316,11 @@ async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
         meta: {
           version: '0.3',
           category: 'scripture',
-          generator: { softwareName: 'apm', softwareVersion: '1', userName: 't' },
+          generator: {
+            softwareName: 'apm',
+            softwareVersion: '1',
+            userName: 't',
+          },
           defaultLocale: 'en',
           dateCreated: '2025-01-01T00:00:00.000Z',
         },
@@ -334,6 +343,7 @@ async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
 
 /**
  * @param {string} rootDir
+ * @returns {Promise<void>}
  */
 async function writeAudioBurrito(rootDir) {
   const audioRoot = path.join(rootDir, 'audio');
@@ -360,11 +370,18 @@ async function writeAudioBurrito(rootDir) {
         meta: {
           version: '0.3',
           category: 'scripture',
-          generator: { softwareName: 'apm', softwareVersion: '1', userName: 't' },
+          generator: {
+            softwareName: 'apm',
+            softwareVersion: '1',
+            userName: 't',
+          },
           defaultLocale: 'en',
           dateCreated: '2025-01-01T00:00:00.000Z',
         },
-        identification: { name: { en: 'Audio Fixture' }, abbreviation: { en: 'RUT' } },
+        identification: {
+          name: { en: 'Audio Fixture' },
+          abbreviation: { en: 'RUT' },
+        },
         languages: [{ tag: 'und', name: { en: 'Unknown' } }],
         localizedNames: {
           'book-rut': { long: { en: 'Ruth' }, short: { en: 'Rut' } },
@@ -387,6 +404,7 @@ async function writeAudioBurrito(rootDir) {
 /**
  * @param {string} ptfPath
  * @param {string} tableFile
+ * @returns {unknown}
  */
 function readPtfTable(ptfPath, tableFile) {
   const zip = new AdmZip(ptfPath);
@@ -397,6 +415,8 @@ function readPtfTable(ptfPath, tableFile) {
 
 /**
  * @param {number} orgWorkflowStepCount
+ * @param {(ptfPath: string) => void | Promise<void>} run
+ * @returns {Promise<void>}
  */
 async function withFixture(orgWorkflowStepCount, run) {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'burrito-ptf-'));
@@ -413,7 +433,10 @@ async function withFixture(orgWorkflowStepCount, run) {
       jsonResult: true,
     });
     const files = await fs.readdir(outputDir);
-    const ptfPath = path.join(outputDir, files.find((f) => f.endsWith('.ptf')));
+    const ptfPath = path.join(
+      outputDir,
+      files.find((f) => f.endsWith('.ptf'))
+    );
     assert.ok(ptfPath, 'expected a .ptf file');
     await run(ptfPath);
   } finally {
@@ -456,7 +479,9 @@ test('burrito import preserves empty sections from ApmData', async () => {
 test('burrito import preserves publishing rows from ApmData', async () => {
   await withFixture(12, (ptfPath) => {
     const table = readPtfTable(ptfPath, 'G_passages.json');
-    const references = table.data.map((passage) => passage.attributes?.reference);
+    const references = table.data.map(
+      (passage) => passage.attributes?.reference
+    );
     assert.ok(references.includes('Movement 01'), 'movement publishing row');
     assert.ok(references.includes('1'), 'chapter number publishing row');
     assert.ok(references.includes('Note 1'), 'note publishing row');

--- a/migration/05-burrito-to-ptf.test.mjs
+++ b/migration/05-burrito-to-ptf.test.mjs
@@ -1,0 +1,465 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import AdmZip from 'adm-zip';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { transformBurritoToPTF } = require('./05-burrito-to-ptf.js');
+
+const BOOK = 'RUT';
+const PROJECT_FOLDER = 'TestProject';
+const USER_ID = 'user-export-1';
+const ORG_ID = 'org-export-1';
+const PLAN_ID = 'plan-export-1';
+
+/**
+ * @returns {Buffer}
+ */
+function tinyWavBytes() {
+  const sampleRate = 8000;
+  const numChannels = 1;
+  const bitsPerSample = 8;
+  const dataSize = 8;
+  const byteRate = (sampleRate * numChannels * bitsPerSample) / 8;
+  const blockAlign = (numChannels * bitsPerSample) / 8;
+  const buffer = Buffer.alloc(44 + dataSize);
+  buffer.write('RIFF', 0);
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write('WAVE', 8);
+  buffer.write('fmt ', 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(numChannels, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(byteRate, 28);
+  buffer.writeUInt16LE(blockAlign, 32);
+  buffer.writeUInt16LE(bitsPerSample, 34);
+  buffer.write('data', 36);
+  buffer.writeUInt32LE(dataSize, 40);
+  return buffer;
+}
+
+/**
+ * @param {number} count
+ * @returns {unknown[]}
+ */
+function buildOrgWorkflowSteps(count) {
+  return Array.from({ length: count }, (_, index) => {
+    const seq = index + 1;
+    return {
+      type: 'orgworkflowsteps',
+      id: `wf-export-${seq}`,
+      attributes: {
+        process: 'draft',
+        name: `APMImportWF_${String(seq).padStart(2, '0')}`,
+        sequencenum: seq,
+        tool: '{"tool":"transcribe"}',
+        permissions: '{}',
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        organization: { data: { type: 'organization', id: ORG_ID } },
+      },
+    };
+  });
+}
+
+/**
+ * @returns {{ sections: unknown[]; passages: unknown[] }}
+ */
+function buildPlanStructure() {
+  const sectionEmptyA = 'section-empty-a';
+  const sectionAudio = 'section-audio';
+  const sectionEmptyB = 'section-empty-b';
+  const passageAudio = 'passage-audio';
+  const passageMovement = 'passage-movement';
+  const passageChapter = 'passage-chapter';
+  const passageNote = 'passage-note';
+
+  const sections = [
+    {
+      type: 'sections',
+      id: sectionEmptyA,
+      attributes: {
+        sequencenum: 1,
+        name: 'Empty Publishing Row A',
+        state: '',
+        level: 3,
+        published: false,
+        'publish-to': '{}',
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        plan: { data: { type: 'plan', id: PLAN_ID } },
+        passages: { data: [{ type: 'passage', id: passageMovement }] },
+      },
+    },
+    {
+      type: 'sections',
+      id: sectionAudio,
+      attributes: {
+        sequencenum: 2,
+        name: 'Audio Section',
+        state: '',
+        level: 3,
+        published: false,
+        'publish-to': '{}',
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        plan: { data: { type: 'plan', id: PLAN_ID } },
+        passages: { data: [{ type: 'passage', id: passageAudio }] },
+      },
+    },
+    {
+      type: 'sections',
+      id: sectionEmptyB,
+      attributes: {
+        sequencenum: 3,
+        name: 'Empty Publishing Row B',
+        state: '',
+        level: 3,
+        published: false,
+        'publish-to': '{}',
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        plan: { data: { type: 'plan', id: PLAN_ID } },
+        passages: { data: [] },
+      },
+    },
+  ];
+
+  const passages = [
+    {
+      type: 'passages',
+      id: passageMovement,
+      attributes: {
+        sequencenum: 1,
+        book: BOOK,
+        reference: 'Movement 01',
+        title: 'Movement 01',
+        state: 'noMedia',
+        'start-chapter': 0,
+        'end-chapter': 0,
+        'start-verse': 0,
+        'end-verse': 0,
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        section: { data: { type: 'section', id: sectionEmptyA } },
+        mediafiles: { data: [] },
+      },
+    },
+    {
+      type: 'passages',
+      id: passageChapter,
+      attributes: {
+        sequencenum: 2,
+        book: BOOK,
+        reference: '1',
+        title: '1',
+        state: 'noMedia',
+        'start-chapter': 1,
+        'end-chapter': 1,
+        'start-verse': 0,
+        'end-verse': 0,
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        section: { data: { type: 'section', id: sectionEmptyA } },
+        mediafiles: { data: [] },
+      },
+    },
+    {
+      type: 'passages',
+      id: passageNote,
+      attributes: {
+        sequencenum: 3,
+        book: BOOK,
+        reference: 'Note 1',
+        title: 'Note 1',
+        state: 'noMedia',
+        'start-chapter': 0,
+        'end-chapter': 0,
+        'start-verse': 0,
+        'end-verse': 0,
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        section: { data: { type: 'section', id: sectionEmptyA } },
+        mediafiles: { data: [] },
+      },
+    },
+    {
+      type: 'passages',
+      id: passageAudio,
+      attributes: {
+        sequencenum: 4,
+        book: BOOK,
+        reference: '1:1-5',
+        title: '1:1-5',
+        state: 'noMedia',
+        'start-chapter': 1,
+        'end-chapter': 1,
+        'start-verse': 1,
+        'end-verse': 5,
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        lastModifiedByUser: { data: { type: 'user', id: USER_ID } },
+        section: { data: { type: 'section', id: sectionAudio } },
+        mediafiles: { data: [] },
+      },
+    },
+  ];
+
+  return { sections, passages };
+}
+
+/**
+ * @param {string} rootDir
+ */
+async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
+  const apmRoot = path.join(rootDir, 'apmdata');
+  const projectRoot = path.join(apmRoot, PROJECT_FOLDER);
+  const dataDir = path.join(projectRoot, 'data');
+  await fs.mkdir(dataDir, { recursive: true });
+
+  const { sections, passages } = buildPlanStructure();
+  const orgWorkflowSteps = buildOrgWorkflowSteps(orgWorkflowStepCount);
+  const scope = { [BOOK]: [] };
+
+  const writeTable = async (fileName, data) => {
+    await fs.writeFile(
+      path.join(dataDir, fileName),
+      JSON.stringify({ data }, null, 2)
+    );
+  };
+
+  await writeTable('F_sections.json', sections);
+  await writeTable('G_passages.json', passages);
+  await writeTable('C_orgworkflowsteps.json', orgWorkflowSteps);
+  await writeTable('E_plans.json', [
+    {
+      type: 'plans',
+      id: PLAN_ID,
+      attributes: {
+        name: 'Ruth Audio',
+        slug: 'ruth-audio',
+        flat: false,
+        sectionCount: sections.length,
+        'date-created': '2025-01-01T00:00:00.000Z',
+        'date-updated': '2025-01-01T00:00:00.000Z',
+      },
+      relationships: {
+        project: { data: { type: 'project', id: 'project-export-1' } },
+        sections: {
+          data: sections.map((section) => ({
+            type: 'section',
+            id: section.id,
+          })),
+        },
+      },
+    },
+  ]);
+
+  const ingredients = {};
+  for (const fileName of [
+    'F_sections.json',
+    'G_passages.json',
+    'C_orgworkflowsteps.json',
+    'E_plans.json',
+  ]) {
+    const rel = `${PROJECT_FOLDER}/data/${fileName}`;
+    const abs = path.join(projectRoot, 'data', fileName);
+    const size = fsSync.statSync(abs).size;
+    ingredients[rel] = {
+      checksum: { md5: '0'.repeat(32) },
+      mimeType: 'application/json',
+      size,
+      scope,
+    };
+  }
+
+  await fs.writeFile(
+    path.join(apmRoot, 'metadata.json'),
+    JSON.stringify(
+      {
+        format: 'burrito',
+        meta: {
+          version: '0.3',
+          category: 'scripture',
+          generator: { softwareName: 'apm', softwareVersion: '1', userName: 't' },
+          defaultLocale: 'en',
+          dateCreated: '2025-01-01T00:00:00.000Z',
+        },
+        identification: { name: { en: 'ApmData Fixture' } },
+        languages: [{ tag: 'und', name: { en: 'Unknown' } }],
+        type: {
+          flavorType: {
+            name: 'x-apmdata',
+            flavor: { name: 'x-apmdata' },
+            currentScope: scope,
+          },
+        },
+        ingredients,
+      },
+      null,
+      2
+    )
+  );
+}
+
+/**
+ * @param {string} rootDir
+ */
+async function writeAudioBurrito(rootDir) {
+  const audioRoot = path.join(rootDir, 'audio');
+  const ingredientsDir = path.join(audioRoot, 'ingredients');
+  await fs.mkdir(ingredientsDir, { recursive: true });
+  const audioName = 'rut-1-5.wav';
+  const audioPath = path.join(ingredientsDir, audioName);
+  await fs.writeFile(audioPath, tinyWavBytes());
+
+  const ingredients = {
+    [`ingredients/${audioName}`]: {
+      checksum: { md5: '0'.repeat(32) },
+      mimeType: 'audio/wav',
+      size: tinyWavBytes().length,
+      scope: { [BOOK]: ['1:1-5'] },
+    },
+  };
+
+  await fs.writeFile(
+    path.join(audioRoot, 'metadata.json'),
+    JSON.stringify(
+      {
+        format: 'burrito',
+        meta: {
+          version: '0.3',
+          category: 'scripture',
+          generator: { softwareName: 'apm', softwareVersion: '1', userName: 't' },
+          defaultLocale: 'en',
+          dateCreated: '2025-01-01T00:00:00.000Z',
+        },
+        identification: { name: { en: 'Audio Fixture' }, abbreviation: { en: 'RUT' } },
+        languages: [{ tag: 'und', name: { en: 'Unknown' } }],
+        localizedNames: {
+          'book-rut': { long: { en: 'Ruth' }, short: { en: 'Rut' } },
+        },
+        type: {
+          flavorType: {
+            name: 'scripture',
+            flavor: { name: 'audioTranslation' },
+            currentScope: { [BOOK]: [] },
+          },
+        },
+        ingredients,
+      },
+      null,
+      2
+    )
+  );
+}
+
+/**
+ * @param {string} ptfPath
+ * @param {string} tableFile
+ */
+function readPtfTable(ptfPath, tableFile) {
+  const zip = new AdmZip(ptfPath);
+  const entry = zip.getEntry(`data/${tableFile}`);
+  assert.ok(entry, `missing data/${tableFile} in ${ptfPath}`);
+  return JSON.parse(entry.getData().toString('utf-8'));
+}
+
+/**
+ * @param {number} orgWorkflowStepCount
+ */
+async function withFixture(orgWorkflowStepCount, run) {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'burrito-ptf-'));
+  const outputDir = path.join(rootDir, 'out');
+  await fs.mkdir(outputDir, { recursive: true });
+  try {
+    await writeAudioBurrito(rootDir);
+    await writeApmDataBurrito(rootDir, orgWorkflowStepCount);
+    await transformBurritoToPTF({
+      input: rootDir,
+      output: outputDir,
+      book: BOOK,
+      optionsJson: '{}',
+      jsonResult: true,
+    });
+    const files = await fs.readdir(outputDir);
+    const ptfPath = path.join(outputDir, files.find((f) => f.endsWith('.ptf')));
+    assert.ok(ptfPath, 'expected a .ptf file');
+    await run(ptfPath);
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+test('burrito import uses org workflow steps from ApmData instead of the migration sample', async () => {
+  const exportedStepCount = 12;
+  await withFixture(exportedStepCount, (ptfPath) => {
+    const table = readPtfTable(ptfPath, 'C_orgworkflowsteps.json');
+    assert.equal(
+      table.data.length,
+      exportedStepCount,
+      'org workflow step count should match ApmData export'
+    );
+    const names = table.data.map((step) => step.attributes?.name);
+    assert.ok(
+      names.includes('APMImportWF_01'),
+      'expected exported workflow step names in PTF'
+    );
+    assert.ok(
+      !names.includes('MarkVerses'),
+      'should not use hardcoded sample org workflow steps when ApmData is present'
+    );
+  });
+});
+
+test('burrito import preserves empty sections from ApmData', async () => {
+  await withFixture(12, (ptfPath) => {
+    const table = readPtfTable(ptfPath, 'F_sections.json');
+    assert.equal(table.data.length, 3, 'all exported sections should import');
+    const names = table.data.map((section) => section.attributes?.name);
+    assert.ok(names.includes('Empty Publishing Row A'));
+    assert.ok(names.includes('Empty Publishing Row B'));
+    assert.ok(names.includes('Audio Section'));
+  });
+});
+
+test('burrito import preserves publishing rows from ApmData', async () => {
+  await withFixture(12, (ptfPath) => {
+    const table = readPtfTable(ptfPath, 'G_passages.json');
+    const references = table.data.map((passage) => passage.attributes?.reference);
+    assert.ok(references.includes('Movement 01'), 'movement publishing row');
+    assert.ok(references.includes('1'), 'chapter number publishing row');
+    assert.ok(references.includes('Note 1'), 'note publishing row');
+    assert.ok(references.includes('1:1-5'), 'audio passage row');
+  });
+});

--- a/migration/05-burrito-to-ptf.test.mjs
+++ b/migration/05-burrito-to-ptf.test.mjs
@@ -342,6 +342,75 @@ async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
 }
 
 /**
+ * ApmData burrito whose table files are not valid JSON (conversion should fall back).
+ * @param {string} rootDir
+ * @returns {Promise<void>}
+ */
+async function writeMalformedApmDataBurrito(rootDir) {
+  const apmRoot = path.join(rootDir, 'apmdata');
+  const projectRoot = path.join(apmRoot, PROJECT_FOLDER);
+  const dataDir = path.join(projectRoot, 'data');
+  await fs.mkdir(dataDir, { recursive: true });
+
+  const scope = { [BOOK]: [] };
+  const tableFiles = [
+    'F_sections.json',
+    'G_passages.json',
+    'C_orgworkflowsteps.json',
+    'E_plans.json',
+  ];
+
+  for (const fileName of tableFiles) {
+    await fs.writeFile(path.join(dataDir, fileName), '{not valid json');
+  }
+
+  const ingredients = {};
+  for (const fileName of tableFiles) {
+    const rel = `${PROJECT_FOLDER}/data/${fileName}`;
+    const abs = path.join(projectRoot, 'data', fileName);
+    const size = fsSync.statSync(abs).size;
+    ingredients[rel] = {
+      checksum: { md5: '0'.repeat(32) },
+      mimeType: 'application/json',
+      size,
+      scope,
+    };
+  }
+
+  await fs.writeFile(
+    path.join(apmRoot, 'metadata.json'),
+    JSON.stringify(
+      {
+        format: 'burrito',
+        meta: {
+          version: '0.3',
+          category: 'scripture',
+          generator: {
+            softwareName: 'apm',
+            softwareVersion: '1',
+            userName: 't',
+          },
+          defaultLocale: 'en',
+          dateCreated: '2025-01-01T00:00:00.000Z',
+        },
+        identification: { name: { en: 'Malformed ApmData Fixture' } },
+        languages: [{ tag: 'und', name: { en: 'Unknown' } }],
+        type: {
+          flavorType: {
+            name: 'x-apmdata',
+            flavor: { name: 'x-apmdata' },
+            currentScope: scope,
+          },
+        },
+        ingredients,
+      },
+      null,
+      2
+    )
+  );
+}
+
+/**
  * @param {string} rootDir
  * @returns {Promise<void>}
  */
@@ -485,4 +554,32 @@ test('burrito import preserves publishing rows from ApmData', async () => {
     assert.ok(references.includes('Note 1'), 'note publishing row');
     assert.ok(references.includes('1:1-5'), 'audio passage row');
   });
+});
+
+test('burrito import falls back when ApmData tables contain malformed JSON', async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'burrito-ptf-'));
+  const outputDir = path.join(rootDir, 'out');
+  await fs.mkdir(outputDir, { recursive: true });
+  try {
+    await writeAudioBurrito(rootDir);
+    await writeMalformedApmDataBurrito(rootDir);
+    await transformBurritoToPTF({
+      input: rootDir,
+      output: outputDir,
+      book: BOOK,
+      optionsJson: '{}',
+      jsonResult: true,
+    });
+    const files = await fs.readdir(outputDir);
+    const ptfFile = files.find((f) => f.endsWith('.ptf'));
+    assert.ok(ptfFile, 'expected a .ptf file');
+    const table = readPtfTable(path.join(outputDir, ptfFile), 'C_orgworkflowsteps.json');
+    const names = table.data.map((step) => step.attributes?.name);
+    assert.ok(
+      names.includes('MarkVerses'),
+      'malformed ApmData should fall back to migration sample workflow steps'
+    );
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
 });

--- a/migration/05-burrito-to-ptf.test.mjs
+++ b/migration/05-burrito-to-ptf.test.mjs
@@ -433,11 +433,9 @@ async function withFixture(orgWorkflowStepCount, run) {
       jsonResult: true,
     });
     const files = await fs.readdir(outputDir);
-    const ptfPath = path.join(
-      outputDir,
-      files.find((f) => f.endsWith('.ptf'))
-    );
-    assert.ok(ptfPath, 'expected a .ptf file');
+    const ptfFile = files.find((f) => f.endsWith('.ptf'));
+    assert.ok(ptfFile, 'expected a .ptf file');
+    const ptfPath = path.join(outputDir, ptfFile);
     await run(ptfPath);
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });

--- a/migration/burrito-apmdata.mjs
+++ b/migration/burrito-apmdata.mjs
@@ -106,8 +106,15 @@ function readApmDataTable(entries, projectFolder, fileName) {
   if (!bytes) {
     return [];
   }
-  const parsed = JSON.parse(bytes.toString('utf-8'));
-  return Array.isArray(parsed?.data) ? parsed.data : [];
+  try {
+    const parsed = JSON.parse(bytes.toString('utf-8'));
+    return Array.isArray(parsed?.data) ? parsed.data : [];
+  } catch (err) {
+    console.warn(
+      `  Unable to parse ApmData table ${fileName}: ${err?.message ?? String(err)}`
+    );
+    return [];
+  }
 }
 
 /**

--- a/migration/burrito-apmdata.mjs
+++ b/migration/burrito-apmdata.mjs
@@ -1,0 +1,281 @@
+/**
+ * Load and remap ApmData burrito PTF JSON for burrito-to-ptf import.
+ */
+
+const APM_DATA_TABLE_FILES = {
+  sections: 'F_sections.json',
+  passages: 'G_passages.json',
+  orgWorkflowSteps: 'C_orgworkflowsteps.json',
+  plans: 'E_plans.json',
+};
+
+/**
+ * @param {string} entryName
+ * @returns {string}
+ */
+function normalizeEntryPath(entryName) {
+  return String(entryName ?? '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '');
+}
+
+/**
+ * @param {import('./05-burrito-to-ptf.js').BurritoVirtualEntry[]} entries
+ * @param {string} relativePath
+ * @returns {Buffer | null}
+ */
+function readEntryBytes(entries, relativePath) {
+  const target = normalizeEntryPath(relativePath);
+  const direct = entries.find(
+    (entry) =>
+      !entry.isDirectory && normalizeEntryPath(entry.entryName) === target
+  );
+  if (direct) {
+    return direct.getData();
+  }
+  const suffix = entries.find(
+    (entry) =>
+      !entry.isDirectory &&
+      normalizeEntryPath(entry.entryName).endsWith(`/${target}`)
+  );
+  return suffix ? suffix.getData() : null;
+}
+
+/**
+ * @param {Record<string, unknown>} metadata
+ * @returns {string[]}
+ */
+export function listApmDataProjectFolders(metadata) {
+  /** @type {Set<string>} */
+  const folders = new Set();
+  for (const key of Object.keys(metadata?.ingredients ?? {})) {
+    const normalized = normalizeEntryPath(key);
+    const match = normalized.match(/^([^/]+)\/data\/[A-Z]_/);
+    if (match) {
+      folders.add(match[1]);
+    }
+  }
+  return [...folders];
+}
+
+/**
+ * @param {Record<string, unknown>} metadata
+ * @param {string | null | undefined} bookCode
+ * @returns {string | null}
+ */
+export function selectApmDataProjectFolder(metadata, bookCode) {
+  const folders = listApmDataProjectFolders(metadata);
+  if (folders.length === 0) {
+    return null;
+  }
+  if (folders.length === 1) {
+    return folders[0];
+  }
+  const book = String(bookCode ?? '')
+    .trim()
+    .toUpperCase();
+  if (!book) {
+    return folders[0];
+  }
+  for (const folder of folders) {
+    for (const [key, ingredient] of Object.entries(
+      metadata?.ingredients ?? {}
+    )) {
+      if (!normalizeEntryPath(key).startsWith(`${folder}/`)) {
+        continue;
+      }
+      const scope = /** @type {{ scope?: Record<string, unknown> }} */ (
+        ingredient
+      ).scope;
+      if (scope && Object.prototype.hasOwnProperty.call(scope, book)) {
+        return folder;
+      }
+    }
+  }
+  return folders[0];
+}
+
+/**
+ * @param {import('./05-burrito-to-ptf.js').BurritoVirtualEntry[]} entries
+ * @param {string} projectFolder
+ * @param {string} fileName
+ * @returns {unknown[]}
+ */
+function readApmDataTable(entries, projectFolder, fileName) {
+  const bytes = readEntryBytes(
+    entries,
+    `${projectFolder}/data/${fileName}`
+  );
+  if (!bytes) {
+    return [];
+  }
+  const parsed = JSON.parse(bytes.toString('utf-8'));
+  return Array.isArray(parsed?.data) ? parsed.data : [];
+}
+
+/**
+ * @param {import('./05-burrito-to-ptf.js').BurritoVirtualEntry[]} entries
+ * @param {Record<string, unknown>} metadata
+ * @param {string | null | undefined} bookCode
+ * @returns {{
+ *   projectFolder: string;
+ *   sections: unknown[];
+ *   passages: unknown[];
+ *   orgWorkflowSteps: unknown[];
+ * } | null}
+ */
+export function loadApmDataSnapshot(entries, metadata, bookCode) {
+  const projectFolder = selectApmDataProjectFolder(metadata, bookCode);
+  if (!projectFolder) {
+    return null;
+  }
+  const sections = readApmDataTable(
+    entries,
+    projectFolder,
+    APM_DATA_TABLE_FILES.sections
+  );
+  const passages = readApmDataTable(
+    entries,
+    projectFolder,
+    APM_DATA_TABLE_FILES.passages
+  );
+  const orgWorkflowSteps = readApmDataTable(
+    entries,
+    projectFolder,
+    APM_DATA_TABLE_FILES.orgWorkflowSteps
+  );
+  if (
+    sections.length === 0 &&
+    passages.length === 0 &&
+    orgWorkflowSteps.length === 0
+  ) {
+    return null;
+  }
+  return { projectFolder, sections, passages, orgWorkflowSteps };
+}
+
+/**
+ * @param {unknown} record
+ * @param {string} relName
+ * @returns {string | null}
+ */
+function relIdNamed(record, relName) {
+  const rel = /** @type {{ data?: { id?: string } }} */ (
+    record?.relationships?.[relName]
+  );
+  return typeof rel?.data?.id === 'string' ? rel.data.id : null;
+}
+
+/**
+ * @param {unknown} record
+ * @param {string} relName
+ * @param {{ type: string; id: string } | null} target
+ */
+function setRel(record, relName, target) {
+  if (!record || typeof record !== 'object') {
+    return;
+  }
+  const rels = /** @type {Record<string, unknown>} */ (record);
+  if (!rels.relationships || typeof rels.relationships !== 'object') {
+    rels.relationships = {};
+  }
+  const relationships = /** @type {Record<string, unknown>} */ (
+    rels.relationships
+  );
+  relationships[relName] = target
+    ? { data: { type: target.type, id: target.id } }
+    : { data: null };
+}
+
+/**
+ * @param {{
+ *   sections: unknown[];
+ *   passages: unknown[];
+ *   orgWorkflowSteps: unknown[];
+ * }} snapshot
+ * @param {{
+ *   generateId: () => string;
+ *   createdAt: string;
+ *   user: { id: string };
+ *   organization: { id: string };
+ *   plan: { id: string };
+ * }} context
+ * @returns {{
+ *   sections: unknown[];
+ *   passages: unknown[];
+ *   orgWorkflowSteps: unknown[];
+ * }}
+ */
+export function remapApmDataSnapshot(snapshot, context) {
+  const { generateId, createdAt, user, organization, plan } = context;
+  /** @type {Map<string, string>} */
+  const idMap = new Map();
+
+  const cloneWithNewIds = (records) =>
+    records.map((record) => {
+      const source = /** @type {{ id?: string }} */ (record);
+      const oldId = source.id;
+      const nextId = generateId();
+      if (oldId) {
+        idMap.set(oldId, nextId);
+      }
+      return {
+        ...source,
+        id: nextId,
+        attributes: {
+          ...(source.attributes ?? {}),
+          dateCreated: createdAt,
+          dateUpdated: createdAt,
+          'date-created': createdAt,
+          'date-updated': createdAt,
+        },
+        relationships: { ...(source.relationships ?? {}) },
+      };
+    });
+
+  const orgWorkflowSteps = cloneWithNewIds(snapshot.orgWorkflowSteps).map(
+    (step) => {
+      setRel(step, 'lastModifiedByUser', { type: 'user', id: user.id });
+      setRel(step, 'organization', {
+        type: 'organization',
+        id: organization.id,
+      });
+      return step;
+    }
+  );
+
+  const sections = cloneWithNewIds(snapshot.sections).map((section) => {
+    setRel(section, 'lastModifiedByUser', { type: 'user', id: user.id });
+    setRel(section, 'plan', { type: 'plan', id: plan.id });
+    const passageRels =
+      /** @type {{ data?: Array<{ id?: string; type?: string }> }} */ (
+        section.relationships?.passages
+      )?.data ?? [];
+    section.relationships.passages = {
+      data: passageRels
+        .map((item) => {
+          const mapped = item?.id ? idMap.get(item.id) : null;
+          return mapped ? { type: 'passage', id: mapped } : null;
+        })
+        .filter(Boolean),
+    };
+    return section;
+  });
+
+  const passages = cloneWithNewIds(snapshot.passages).map((passage) => {
+    setRel(passage, 'lastModifiedByUser', { type: 'user', id: user.id });
+    const sectionId = relIdNamed(passage, 'section');
+    if (sectionId && idMap.has(sectionId)) {
+      setRel(passage, 'section', {
+        type: 'section',
+        id: idMap.get(sectionId),
+      });
+    }
+    passage.relationships.mediafiles = { data: [] };
+    return passage;
+  });
+
+  return { sections, passages, orgWorkflowSteps };
+}
+
+export { APM_DATA_TABLE_FILES };

--- a/migration/burrito-apmdata.mjs
+++ b/migration/burrito-apmdata.mjs
@@ -102,10 +102,7 @@ export function selectApmDataProjectFolder(metadata, bookCode) {
  * @returns {unknown[]}
  */
 function readApmDataTable(entries, projectFolder, fileName) {
-  const bytes = readEntryBytes(
-    entries,
-    `${projectFolder}/data/${fileName}`
-  );
+  const bytes = readEntryBytes(entries, `${projectFolder}/data/${fileName}`);
   if (!bytes) {
     return [];
   }

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "test:ci": "CI=true jest --verbose --maxWorkers=1 --no-cache",
     "test:migration-usj": "cd ../.. && node --test migration/usj-structure.test.mjs",
+    "test:migration-burrito-to-ptf": "cd ../.. && node --test migration/05-burrito-to-ptf.test.mjs",
     "test:coverage": "npm run test --watchAll=false --collectCoverageFrom=src/**/*.ts* --coverage",
     "format": "prettier --config ../../.prettierrc.yaml --ignore-path ../../.prettierignore --write \"**/*.{js,ts,tsx,json,css,md,mdx,html}\"",
     "lint": "eslint . --cache-location node_modules/.cache/eslint --quiet",


### PR DESCRIPTION
- Added a new ESLint rule configuration to disable the '@typescript-eslint/explicit-function-return-type' rule for all files in the 'migration' directory.
- Updated the `05-burrito-to-ptf.test.mjs` file to improve code formatting and add JSDoc comments for better type documentation.
- Refactored the `burrito-apmdata.mjs` file to streamline the reading of entry bytes by consolidating the function call into a single line.

This commit enhances the ESLint configuration for migration files and improves code clarity and documentation in the affected files.