### PR TITLE
TT-7481 refactor(burrito): standardize flavorType naming in burrito transformation

### DIFF
--- a/migration/05-burrito-to-ptf.js
+++ b/migration/05-burrito-to-ptf.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 /**
  * Scripture Burrito to APM PTF Transformer
  *
@@ -189,9 +188,15 @@ const BURRITO_PTF_FLAVOR_NAME = 'audioTranslation';
 
 function getBurritoFlavor(metadata) {
   const ft = metadata?.type?.flavorType;
+  const rawTypeName = ft?.name ?? null;
+  const flavorName = ft?.flavor?.name ?? null;
+  // Legacy exports stored the custom flavor in flavorType.name instead of flavor.name.
+  const legacyFlavorInTypeName = rawTypeName?.startsWith('x-')
+    ? rawTypeName
+    : null;
   return {
-    flavorTypeName: ft?.name ?? null,
-    flavorName: ft?.flavor?.name ?? null,
+    flavorTypeName: legacyFlavorInTypeName ? 'scripture' : rawTypeName,
+    flavorName: flavorName ?? legacyFlavorInTypeName,
   };
 }
 

--- a/migration/05-burrito-to-ptf.test.mjs
+++ b/migration/05-burrito-to-ptf.test.mjs
@@ -328,7 +328,7 @@ async function writeApmDataBurrito(rootDir, orgWorkflowStepCount) {
         languages: [{ tag: 'und', name: { en: 'Unknown' } }],
         type: {
           flavorType: {
-            name: 'x-apmdata',
+            name: 'scripture',
             flavor: { name: 'x-apmdata' },
             currentScope: scope,
           },
@@ -397,7 +397,7 @@ async function writeMalformedApmDataBurrito(rootDir) {
         languages: [{ tag: 'und', name: { en: 'Unknown' } }],
         type: {
           flavorType: {
-            name: 'x-apmdata',
+            name: 'scripture',
             flavor: { name: 'x-apmdata' },
             currentScope: scope,
           },
@@ -573,7 +573,10 @@ test('burrito import falls back when ApmData tables contain malformed JSON', asy
     const files = await fs.readdir(outputDir);
     const ptfFile = files.find((f) => f.endsWith('.ptf'));
     assert.ok(ptfFile, 'expected a .ptf file');
-    const table = readPtfTable(path.join(outputDir, ptfFile), 'C_orgworkflowsteps.json');
+    const table = readPtfTable(
+      path.join(outputDir, ptfFile),
+      'C_orgworkflowsteps.json'
+    );
     const names = table.data.map((step) => step.attributes?.name);
     assert.ok(
       names.includes('MarkVerses'),

--- a/src/renderer/src/burrito/akuoBookToUsfm.ts
+++ b/src/renderer/src/burrito/akuoBookToUsfm.ts
@@ -2,6 +2,10 @@
  * Maps an Akuo-style project book slot (e.g. A01, B02 from project `book` default)
  * to a Paratext/USFM 3-letter book code using the same numbering as ApmData export.
  */
+import type { ProjectD } from '../model';
+import { projDefBook } from '../crud/useProjectDefaults';
+import type { BurritoScopes } from './data/types';
+
 export function akuoBookToUsfm(
   akuoBook: string,
   num2BookCode: (bookNum: number) => string | undefined
@@ -31,4 +35,36 @@ export function projectDefaultToBurritoBookKey(
   if (mapped) return mapped;
   if (/^\d{3}$/.test(def)) return def;
   return undefined;
+}
+
+/** `currentScope` entry for one ApmData / intellectualproperty burrito project. */
+export function burritoCurrentScopeForProject(
+  project: ProjectD,
+  getProjectDefault: (key: string, project: ProjectD) => unknown,
+  num2BookCode: (bookNum: number) => string | undefined
+): BurritoScopes {
+  const bookCode = projectDefaultToBurritoBookKey(
+    (getProjectDefault(projDefBook, project) as string) ?? 'B01',
+    num2BookCode
+  );
+  return bookCode ? { [bookCode]: [] } : {};
+}
+
+/** Union of per-project scopes for the ApmData and intellectualproperty burritos. */
+export function burritoCurrentScopeForProjects(
+  projects: ProjectD[],
+  getProjectDefault: (key: string, project: ProjectD) => unknown,
+  num2BookCode: (bookNum: number) => string | undefined
+): BurritoScopes {
+  return projects.reduce<BurritoScopes>(
+    (scope, project) => ({
+      ...scope,
+      ...burritoCurrentScopeForProject(
+        project,
+        getProjectDefault,
+        num2BookCode
+      ),
+    }),
+    {}
+  );
 }

--- a/src/renderer/src/burrito/useBurritoApmData.test.ts
+++ b/src/renderer/src/burrito/useBurritoApmData.test.ts
@@ -137,7 +137,7 @@ describe('useBurritoApmData', () => {
       scope: { GEN: [] },
     });
 
-    expect(updated!.type!.flavorType!.name).toBe('x-apmdata');
+    expect(updated!.type!.flavorType!.name).toBe('scripture');
     expect(updated!.type!.flavorType!.flavor.name).toBe('x-apmdata');
     expect(updated!.type!.flavorType!.currentScope).toMatchObject({
       GEN: [],

--- a/src/renderer/src/burrito/useBurritoApmData.ts
+++ b/src/renderer/src/burrito/useBurritoApmData.ts
@@ -6,7 +6,10 @@ import { getProjectDataFiles } from '../store/importexport/projectDataExport';
 import Memory from '@orbit/memory';
 import { projDefBook, useProjectDefaults } from '../crud/useProjectDefaults';
 import { useNum2BookCode } from '../utils/useNum2BookCode';
-import { projectDefaultToBurritoBookKey } from './akuoBookToUsfm';
+import {
+  projectDefaultToBurritoBookKey,
+  burritoCurrentScopeForProject,
+} from './akuoBookToUsfm';
 
 const ipc = window?.api as MainAPI;
 
@@ -58,18 +61,22 @@ export const useBurritoApmData = (memory: Memory) => {
     }
 
     metadata.ingredients = { ...metadata.ingredients, ...ingredients };
-    if (bookCode && metadata.type?.flavorType) {
-      const currentScope = metadata.type.flavorType.currentScope ?? {};
+    const bookScope = burritoCurrentScopeForProject(
+      project,
+      getProjectDefault,
+      num2BookCode
+    );
+    if (Object.keys(bookScope).length && metadata.type?.flavorType) {
       metadata.type.flavorType.currentScope = {
-        ...currentScope,
-        [bookCode]: [],
+        ...metadata.type.flavorType.currentScope,
+        ...bookScope,
       };
     }
-    if (metadata.type?.flavorType?.flavor) {
-      metadata.type.flavorType.flavor.name = 'x-apmdata';
-    }
     if (metadata.type?.flavorType) {
-      metadata.type.flavorType.name = 'x-apmdata';
+      metadata.type.flavorType.name = 'scripture';
+      if (metadata.type.flavorType.flavor) {
+        metadata.type.flavorType.flavor.name = 'x-apmdata';
+      }
     }
     return metadata;
   };

--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -94,20 +94,15 @@ function loadAudioForApi(api: unknown) {
   return { renderHook, act, useBurritoAudio };
 }
 
-function loadAudioForJames(
-  api: unknown,
-  fixture: JamesPublishingFixture
-) {
+function loadAudioForJames(api: unknown, fixture: JamesPublishingFixture) {
   /* eslint-disable @typescript-eslint/no-require-imports */
   jest.resetModules();
   (window as unknown as { api?: unknown }).api = api;
 
-  jest.doMock(
-    '../components/PassageDetail/Internalization/useComputeRef',
-    () =>
-      jest.requireActual(
-        '../components/PassageDetail/Internalization/useComputeRef'
-      )
+  jest.doMock('../components/PassageDetail/Internalization/useComputeRef', () =>
+    jest.requireActual(
+      '../components/PassageDetail/Internalization/useComputeRef'
+    )
   );
 
   jest.doMock('../utils/dataPath', () => ({
@@ -238,7 +233,8 @@ describe('useBurritoAudio', () => {
       });
     });
 
-    expect(metadata.type?.flavorType?.name).toBe('x-notes');
+    expect(metadata.type?.flavorType?.name).toBe('scripture');
+    expect(metadata.type?.flavorType?.flavor?.name).toBe('x-notes');
     expect(ipc.write).toHaveBeenCalled();
     const writePaths = (ipc.write as jest.Mock).mock.calls.map((c) => c[0]);
     expect(writePaths.some((p: string) => p.includes('alignment.json'))).toBe(

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -73,7 +73,7 @@ interface Props {
   sections: SectionD[];
   /** When set, only include passages of this type. When null, accept any passage type. Defaults to PASSAGE. */
   passageTypeFilter?: PassageTypeEnum | null;
-  /** When set, overrides type.flavorType.name in metadata (e.g. 'x-notes' for Notes export). */
+  /** When set, sets type.flavorType.flavor.name for custom burritos (e.g. 'x-notes'). */
   flavorTypeName?: string;
   /** When set, only include media files whose artifact type slug is in this list (e.g. Resource, SharedResource, ProjectResource). */
   artifactTypeFilter?: ArtifactTypeSlug[];
@@ -106,7 +106,10 @@ export const useBurritoAudio = (teamId: string) => {
     convertToMp3 = false,
   }: Props) => {
     if (flavorTypeName && metadata.type?.flavorType) {
-      metadata.type.flavorType.name = flavorTypeName;
+      metadata.type.flavorType.name = 'scripture';
+      if (metadata.type.flavorType.flavor) {
+        metadata.type.flavorType.flavor.name = flavorTypeName;
+      }
     }
     const bibleId = bible?.attributes?.bibleId || teamId || '';
     const scopes: Map<string, string[]> = new Map();

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.test.ts
@@ -13,6 +13,15 @@ jest.mock('../store/importexport/projectDataExport', () => ({
   getOrganizationIntellectualPropertyFiles: jest.fn(),
 }));
 
+jest.mock('../crud/useProjectDefaults', () => ({
+  projDefBook: 'book',
+  useProjectDefaults: jest.fn(),
+}));
+
+jest.mock('../utils/useNum2BookCode', () => ({
+  useNum2BookCode: () => () => 'JAS',
+}));
+
 jest.mock('../utils/dataPath', () => ({
   __esModule: true,
   PathType: { MEDIA: 'MEDIA' },
@@ -64,6 +73,14 @@ async function loadIpHookForApi(
   (getOrganizationIntellectualPropertyFiles as jest.Mock).mockReturnValue(
     exportPayload
   );
+  const { useProjectDefaults } = await import('../crud/useProjectDefaults');
+  (useProjectDefaults as jest.Mock).mockReturnValue({
+    getProjectDefault: jest.fn(() => 'B59'),
+    setProjectDefault: jest.fn(),
+    canSetProjectDefault: true,
+    getLocalDefault: jest.fn(),
+    setLocalDefault: jest.fn(),
+  });
   const memoryStub = buildSpeakerRightsMemoryStub(
     buildJamesSpeakerRightsFixture()
   ) as unknown as Memory;
@@ -118,6 +135,7 @@ describe('useBurritoIntellectualProperty', () => {
     const stat = jest.fn().mockResolvedValue(JSON.stringify({ size: 1024 }));
 
     const fixture = buildJamesSpeakerRightsFixture();
+    const apmDataProjects = [fixture.project];
     const {
       renderHook,
       act,
@@ -139,6 +157,7 @@ describe('useBurritoIntellectualProperty', () => {
         metadata: burritoFixture(),
         partPath: '/burrito/TST/intellectualproperty',
         preLen: 0,
+        apmDataProjects,
       });
     });
 
@@ -183,10 +202,11 @@ describe('useBurritoIntellectualProperty', () => {
     });
     expect(ipIngredient.scope).toBeUndefined();
 
-    expect(updated!.type!.flavorType!.name).toBe('x-intellectualproperty');
+    expect(updated!.type!.flavorType!.name).toBe('scripture');
     expect(updated!.type!.flavorType!.flavor.name).toBe(
       'x-intellectualproperty'
     );
+    expect(updated!.type!.flavorType!.currentScope).toEqual({ JAS: [] });
 
     const ingredientMime = (filename: string) => {
       const key = Object.keys(updated!.ingredients).find((k) =>

--- a/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
+++ b/src/renderer/src/burrito/useBurritoIntellectualProperty.ts
@@ -3,13 +3,16 @@ import { Burrito, BurritoIngredients } from './data/types';
 import { MainAPI } from '@model/main-api';
 import { getOrganizationIntellectualPropertyFiles } from '../store/importexport/projectDataExport';
 import Memory from '@orbit/memory';
-import { MediaFileD } from '../model';
+import { MediaFileD, ProjectD } from '../model';
 import dataPath, { PathType } from '../utils/dataPath';
 import getMediaExt from '../utils/getMediaExt';
 import getBurritoMediaExportStem from '../utils/burritoMediaFileStem';
 import cleanFileName from '../utils/cleanFileName';
 import { inferAudioContentType } from '../utils/mimeTypes';
 import { Stats } from 'fs';
+import { useProjectDefaults } from '../crud/useProjectDefaults';
+import { useNum2BookCode } from '../utils/useNum2BookCode';
+import { burritoCurrentScopeForProjects } from './akuoBookToUsfm';
 
 const ipc = window?.api as MainAPI;
 
@@ -17,6 +20,8 @@ interface Props {
   metadata: Burrito;
   partPath: string;
   preLen: number;
+  /** Selected burrito projects; scope matches the ApmData burrito `currentScope`. */
+  apmDataProjects: ProjectD[];
 }
 
 const stemForMedia = (
@@ -38,7 +43,15 @@ export const useBurritoIntellectualProperty = (
   memory: Memory,
   organizationId: string
 ) => {
-  return async ({ metadata, partPath, preLen }: Props): Promise<Burrito> => {
+  const { getProjectDefault } = useProjectDefaults();
+  const num2BookCode = useNum2BookCode();
+
+  return async ({
+    metadata,
+    partPath,
+    preLen,
+    apmDataProjects,
+  }: Props): Promise<Burrito> => {
     const { dataFiles, releaseMediafiles } =
       getOrganizationIntellectualPropertyFiles(memory, organizationId);
     const ingredients: BurritoIngredients = {};
@@ -94,11 +107,22 @@ export const useBurritoIntellectualProperty = (
     }
 
     metadata.ingredients = { ...metadata.ingredients, ...ingredients };
-    if (metadata.type?.flavorType?.flavor) {
-      metadata.type.flavorType.flavor.name = 'x-intellectualproperty';
+    const currentScope = burritoCurrentScopeForProjects(
+      apmDataProjects,
+      getProjectDefault,
+      num2BookCode
+    );
+    if (Object.keys(currentScope).length && metadata.type?.flavorType) {
+      metadata.type.flavorType.currentScope = {
+        ...metadata.type.flavorType.currentScope,
+        ...currentScope,
+      };
     }
     if (metadata.type?.flavorType) {
-      metadata.type.flavorType.name = 'x-intellectualproperty';
+      metadata.type.flavorType.name = 'scripture';
+      if (metadata.type.flavorType.flavor) {
+        metadata.type.flavorType.flavor.name = 'x-intellectualproperty';
+      }
     }
     return metadata;
   };

--- a/src/renderer/src/burrito/useBurritoNavigation.test.ts
+++ b/src/renderer/src/burrito/useBurritoNavigation.test.ts
@@ -165,55 +165,46 @@ function makeIpc() {
 /**
  * `useBurritoNavigation` reads `window.api` at module load. `jest.isolateModules`
  * would give the hook a second React copy and break hooks; `resetModules` +
- * requiring RTL before the hook keeps a single React for `renderHook`.
+ * dynamic `import()` before the hook keeps a single React for `renderHook`.
  */
-function loadNavigationForApi(api: MainAPI | undefined) {
+async function loadNavigationForApi(api: MainAPI | undefined) {
   jest.resetModules();
   (window as unknown as { api?: typeof api }).api = api;
-  // `react` entry registers Jest hooks; `pure` does not (invalid inside `it`).
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { renderHook, act } = require('@testing-library/react/pure');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useProjectDefaults } = require('../crud/useProjectDefaults');
-  useProjectDefaults.mockReturnValue({
+  const { renderHook, act } = await import('@testing-library/react/pure');
+  const { useProjectDefaults } = await import('../crud/useProjectDefaults');
+  (useProjectDefaults as jest.Mock).mockReturnValue({
     getProjectDefault: jest.fn(),
     setProjectDefault: jest.fn(),
     canSetProjectDefault: true,
     getLocalDefault: jest.fn(),
     setLocalDefault: jest.fn(),
   });
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useBurritoNavigation } = require('./useBurritoNavigation');
+  const { useBurritoNavigation } = await import('./useBurritoNavigation');
   return { renderHook, act, useBurritoNavigation };
 }
 
-function loadNavigationForJames(
+async function loadNavigationForJames(
   api: MainAPI | undefined,
   fixture: JamesPublishingFixture
 ) {
   jest.resetModules();
   (window as unknown as { api?: typeof api }).api = api;
 
-  jest.doMock(
-    '../components/PassageDetail/Internalization/useComputeRef',
-    () =>
-      jest.requireActual(
-        '../components/PassageDetail/Internalization/useComputeRef'
-      )
+  jest.doMock('../components/PassageDetail/Internalization/useComputeRef', () =>
+    jest.requireActual(
+      '../components/PassageDetail/Internalization/useComputeRef'
+    )
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { renderHook, act } = require('@testing-library/react/pure');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useProjectDefaults, projDefSectionMap } = require('../crud/useProjectDefaults');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { findRecord, remoteId, remoteIdGuid, remoteIdNum } = require('../crud');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useGlobal } = require('../context/useGlobal');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useOrbitData } = require('../hoc/useOrbitData');
+  const { renderHook, act } = await import('@testing-library/react/pure');
+  const { useProjectDefaults, projDefSectionMap } =
+    await import('../crud/useProjectDefaults');
+  const { findRecord, remoteId, remoteIdGuid, remoteIdNum } =
+    await import('../crud');
+  const { useGlobal } = await import('../context/useGlobal');
+  const { useOrbitData } = await import('../hoc/useOrbitData');
 
-  useProjectDefaults.mockReturnValue({
+  (useProjectDefaults as jest.Mock).mockReturnValue({
     getProjectDefault: jest.fn((key: string) =>
       key === projDefSectionMap ? fixture.sectionMap : undefined
     ),
@@ -230,7 +221,7 @@ function loadNavigationForJames(
   };
   const projectRec = { id: fixture.projectId, type: 'project' };
 
-  findRecord.mockImplementation(
+  (findRecord as jest.Mock).mockImplementation(
     (_memory: unknown, type: string, id: string) => {
       if (type === 'plan') return planRec;
       if (type === 'project') return projectRec;
@@ -241,32 +232,38 @@ function loadNavigationForJames(
     }
   );
 
-  remoteId.mockImplementation((_type: string, localId: string) => localId);
-  remoteIdNum.mockImplementation((type: string, localId: string) => {
-    if (type === 'section') {
-      return JAMES_SECTION_REMOTE_NUM[localId] ?? 0;
+  (remoteId as jest.Mock).mockImplementation(
+    (_type: string, localId: string) => localId
+  );
+  (remoteIdNum as jest.Mock).mockImplementation(
+    (type: string, localId: string) => {
+      if (type === 'section') {
+        return JAMES_SECTION_REMOTE_NUM[localId] ?? 0;
+      }
+      return 1;
     }
-    return 1;
-  });
-  remoteIdGuid.mockImplementation((type: string, numStr: string) => {
-    if (type === 'section') {
-      const num = parseInt(numStr, 10);
-      const entry = Object.entries(JAMES_SECTION_REMOTE_NUM).find(
-        ([, v]) => v === num
-      );
-      return entry?.[0];
+  );
+  (remoteIdGuid as jest.Mock).mockImplementation(
+    (type: string, numStr: string) => {
+      if (type === 'section') {
+        const num = parseInt(numStr, 10);
+        const entry = Object.entries(JAMES_SECTION_REMOTE_NUM).find(
+          ([, v]) => v === num
+        );
+        return entry?.[0];
+      }
+      return undefined;
     }
-    return undefined;
-  });
+  );
 
-  useGlobal.mockImplementation((key: string) => {
+  (useGlobal as jest.Mock).mockImplementation((key: string) => {
     if (key === 'memory') {
       return [{ keyMap: {} }, jest.fn()];
     }
     return [undefined, jest.fn()];
   });
 
-  useOrbitData.mockImplementation((model: string) => {
+  (useOrbitData as jest.Mock).mockImplementation((model: string) => {
     switch (model) {
       case 'mediafile':
         return fixture.mediafiles;
@@ -285,8 +282,7 @@ function loadNavigationForJames(
     }
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { useBurritoNavigation } = require('./useBurritoNavigation');
+  const { useBurritoNavigation } = await import('./useBurritoNavigation');
   return { renderHook, act, useBurritoNavigation };
 }
 
@@ -294,10 +290,8 @@ async function runJamesNavigationExport(
   ipc: ReturnType<typeof makeIpc>,
   fixture: JamesPublishingFixture
 ) {
-  const { renderHook, act, useBurritoNavigation } = loadNavigationForJames(
-    ipc as never,
-    fixture
-  );
+  const { renderHook, act, useBurritoNavigation } =
+    await loadNavigationForJames(ipc as never, fixture);
   const { result } = renderHook(() => useBurritoNavigation('team-1'));
   const metadata = burritoFixture();
   await act(async () => {
@@ -328,9 +322,8 @@ describe('useBurritoNavigation', () => {
 
   it('sets x-nav flavor, writes navigation.json, graphics folder, and merges manifest ingredient', async () => {
     const ipc = makeIpc();
-    const { renderHook, act, useBurritoNavigation } = loadNavigationForApi(
-      ipc as never
-    );
+    const { renderHook, act, useBurritoNavigation } =
+      await loadNavigationForApi(ipc as never);
 
     const { result } = renderHook(() => useBurritoNavigation(teamId));
     const metadata = burritoFixture();
@@ -346,7 +339,8 @@ describe('useBurritoNavigation', () => {
       });
     });
 
-    expect(metadata.type?.flavorType?.name).toBe('x-nav');
+    expect(metadata.type?.flavorType?.name).toBe('scripture');
+    expect(metadata.type?.flavorType?.flavor?.name).toBe('x-nav');
     expect(
       ipc.createFolder.mock.calls.some((c) => c[0].includes('graphics'))
     ).toBe(false);
@@ -374,7 +368,7 @@ describe('useBurritoNavigation', () => {
 
   it('does not throw when window.api is missing (empty sections)', async () => {
     const { renderHook, act, useBurritoNavigation } =
-      loadNavigationForApi(undefined);
+      await loadNavigationForApi(undefined);
 
     const { result } = renderHook(() => useBurritoNavigation(teamId));
     const metadata = burritoFixture();
@@ -390,7 +384,8 @@ describe('useBurritoNavigation', () => {
       });
     });
 
-    expect(metadata.type?.flavorType?.name).toBe('x-nav');
+    expect(metadata.type?.flavorType?.name).toBe('scripture');
+    expect(metadata.type?.flavorType?.flavor?.name).toBe('x-nav');
     const manifestIngredient = Object.values(metadata.ingredients).find(
       (i) => i.mimeType === 'application/json' && !i.role
     );
@@ -400,9 +395,8 @@ describe('useBurritoNavigation', () => {
 
   it('includes special book sections (BookSeq/AltBkSeq encded in the sequence number for each plan), even with no passages', async () => {
     const ipc = makeIpc();
-    const { renderHook, act, useBurritoNavigation } = loadNavigationForApi(
-      ipc as never
-    );
+    const { renderHook, act, useBurritoNavigation } =
+      await loadNavigationForApi(ipc as never);
 
     // normal section list passed into the hook: determines planIdsForBook
     const normalSection = {

--- a/src/renderer/src/burrito/useBurritoNavigation.ts
+++ b/src/renderer/src/burrito/useBurritoNavigation.ts
@@ -208,7 +208,10 @@ export const useBurritoNavigation = (teamId: string) => {
     sections,
   }: Props) => {
     if (metadata.type?.flavorType) {
-      metadata.type.flavorType.name = 'x-nav';
+      metadata.type.flavorType.name = 'scripture';
+      if (metadata.type.flavorType.flavor) {
+        metadata.type.flavorType.flavor.name = 'x-nav';
+      }
     }
     const bibleId = bible?.attributes?.bibleId || teamId || '';
     const scopes: Map<string, string[]> = new Map();
@@ -506,42 +509,42 @@ export const useBurritoNavigation = (teamId: string) => {
       await ipc?.createFolder(categoryGraphicsPath);
 
       for (const cat of categoriesForExport) {
-      const catRemId = remoteId('artifactcategory', cat.id, keyMap);
-      if (!catRemId) continue;
+        const catRemId = remoteId('artifactcategory', cat.id, keyMap);
+        if (!catRemId) continue;
 
-      const titleMediaId = related(cat, 'titleMediafile');
-      if (titleMediaId) {
-        const m = mediafiles.find((mf) => mf.id === titleMediaId);
-        if (m) {
-          const ext = getMediaExt(m);
-          const destName = `${bibleId}-${book}-category-title-${cleanFileName(cat.attributes.categoryname)}-${catRemId}.${ext}`;
-          const destPath = path.join(categoryGraphicsPath, destName);
-          const ok = await processMediaFile(m, destPath, '');
-          if (ok) {
-            titleMediaManifest.push({
-              resourceType: 'category',
-              remoteId: catRemId,
-              path: destPath.substring(preLen),
-            });
+        const titleMediaId = related(cat, 'titleMediafile');
+        if (titleMediaId) {
+          const m = mediafiles.find((mf) => mf.id === titleMediaId);
+          if (m) {
+            const ext = getMediaExt(m);
+            const destName = `${bibleId}-${book}-category-title-${cleanFileName(cat.attributes.categoryname)}-${catRemId}.${ext}`;
+            const destPath = path.join(categoryGraphicsPath, destName);
+            const ok = await processMediaFile(m, destPath, '');
+            if (ok) {
+              titleMediaManifest.push({
+                resourceType: 'category',
+                remoteId: catRemId,
+                path: destPath.substring(preLen),
+              });
+            }
           }
         }
-      }
 
-      const categoryGraphic = graphics.find(
-        (g) =>
-          g.attributes.resourceType === 'category' &&
-          g.attributes.resourceId ===
-            remoteIdNum('artifactcategory', cat.id, keyMap)
-      );
-      if (categoryGraphic) {
-        await processGraphic(
-          categoryGraphic,
-          categoryGraphicsPath,
-          '',
-          'category',
-          catRemId
+        const categoryGraphic = graphics.find(
+          (g) =>
+            g.attributes.resourceType === 'category' &&
+            g.attributes.resourceId ===
+              remoteIdNum('artifactcategory', cat.id, keyMap)
         );
-      }
+        if (categoryGraphic) {
+          await processGraphic(
+            categoryGraphic,
+            categoryGraphicsPath,
+            '',
+            'category',
+            catRemId
+          );
+        }
       }
     }
 
@@ -593,7 +596,7 @@ export const useBurritoNavigation = (teamId: string) => {
           const ext = getMediaExt(m);
           const chSuffix =
             passageType === PassageTypeEnum.CHAPTERNUMBER
-              ? exportFolder.chapter ?? '1'
+              ? (exportFolder.chapter ?? '1')
               : cleanFileName(sectionRef);
           const destName = `${bibleId}-${book}-chapter-${chSuffix}-title-${passRemId}.${ext}`;
           const destPath = path.join(chapterPath, destName);

--- a/src/renderer/src/burrito/useCreateBurrito.test.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.test.ts
@@ -228,8 +228,7 @@ function loadCreateBurrito(api: typeof window.api, opts: LoadOpts = {}) {
 
   const { useGlobal } = require('../context/useGlobal');
   useGlobal.mockImplementation((key: string) => {
-    if (key === 'memory')
-      return [opts.memoryStub ?? { keyMap: {} }, jest.fn()];
+    if (key === 'memory') return [opts.memoryStub ?? { keyMap: {} }, jest.fn()];
     if (key === 'user') return ['user-1', jest.fn()];
     return [undefined, jest.fn()];
   });
@@ -665,7 +664,11 @@ describe('useCreateBurrito', () => {
 
     const ipJson = JSON.stringify({
       data: speakerFixture.intellectualproperties.map(
-        (ip: { id: string; attributes: { rightsHolder: string }; relationships: unknown }) => ({
+        (ip: {
+          id: string;
+          attributes: { rightsHolder: string };
+          relationships: unknown;
+        }) => ({
           type: 'intellectualproperties',
           id: ip.id,
           attributes: { rightsHolder: ip.attributes.rightsHolder },
@@ -685,9 +688,7 @@ describe('useCreateBurrito', () => {
           burritoFormat: { convertToMp3: false },
           burritoRevision: '1',
         },
-        bookData: [
-          { code: 'JAS', abbr: 'Jas', short: 'James', long: 'James' },
-        ],
+        bookData: [{ code: 'JAS', abbr: 'Jas', short: 'James', long: 'James' }],
         memoryStub,
         orbit: {
           user: [user],
@@ -704,7 +705,9 @@ describe('useCreateBurrito', () => {
       }
     );
 
-    const { useBurritoIntellectualProperty } = require('./useBurritoIntellectualProperty');
+    const {
+      useBurritoIntellectualProperty,
+    } = require('./useBurritoIntellectualProperty');
     useBurritoIntellectualProperty.mockImplementation(() =>
       jest.fn(async ({ metadata, partPath, preLen }: any) => {
         const dataDir = `${partPath}/data`;
@@ -736,7 +739,7 @@ describe('useCreateBurrito', () => {
             ...metadata.type,
             flavorType: {
               ...metadata.type?.flavorType,
-              name: 'x-intellectualproperty',
+              name: 'scripture',
               flavor: { name: 'x-intellectualproperty' },
             },
           },

--- a/src/renderer/src/burrito/useCreateBurrito.ts
+++ b/src/renderer/src/burrito/useCreateBurrito.ts
@@ -377,6 +377,7 @@ export const useCreateBurrito = (teamId: string) => {
         metadata: metaData,
         partPath,
         preLen,
+        apmDataProjects,
       });
       if (cancelRef.current) return;
       onBookComplete(partIndex, 1, '', 1);


### PR DESCRIPTION
- Updated the `flavorType.name` to 'scripture' across various components to ensure consistency in the burrito transformation process.
- Adjusted related tests to reflect the new naming convention, enhancing clarity and maintainability.
- Improved handling of legacy flavor names to accommodate existing data structures.
- Add currentScope to the intellectualproperty custom burrito

This commit improves compliance with the custom burrito standard