### PR TITLE
TT-7191 feat(burrito): add Philippians publishing fixture and related functionality

### DIFF
--- a/src/renderer/src/burrito/philippiansPublishingFixture.ts
+++ b/src/renderer/src/burrito/philippiansPublishingFixture.ts
@@ -1,0 +1,182 @@
+import { AltBkSeq, BookSeq } from '../model/section';
+import type { BibleD } from '../model';
+import type { MediaFileD } from '../model';
+import type { PassageD } from '../model';
+import type { SectionD } from '../model';
+
+export const PHP_BOOK = 'PHP';
+export const PHP_BOOK_PATH = '/burrito/PHP';
+
+export const phpBibleFixture = {
+  id: 'bib-php',
+  type: 'bible',
+  attributes: {
+    bibleId: 'SEHGEO',
+    bibleName: 'Philippians',
+    iso: 'seh',
+  },
+} as BibleD;
+
+export interface PhilippiansPublishingFixture {
+  planId: string;
+  sectionsAll: SectionD[];
+  passages: PassageD[];
+  mediafiles: MediaFileD[];
+}
+
+function sectionRow(
+  id: string,
+  sequencenum: number,
+  planId: string
+): SectionD {
+  return {
+    id,
+    type: 'section',
+    attributes: { sequencenum, state: '' },
+    relationships: { plan: { data: { id: planId } } },
+  } as unknown as SectionD;
+}
+
+function noteMedia(
+  id: string,
+  passageId: string,
+  planId: string,
+  filename: string
+): MediaFileD {
+  return {
+    id,
+    type: 'mediafile',
+    attributes: {
+      audioUrl: `/tmp/${filename}`,
+      originalFile: filename,
+      contentType: 'audio/mpeg',
+      versionNumber: 1,
+      segments: '{}',
+    },
+    relationships: {
+      plan: { data: { id: planId } },
+      passage: { data: { id: passageId } },
+      artifactType: { data: null },
+    },
+  } as unknown as MediaFileD;
+}
+
+function notePassage(
+  id: string,
+  sectionId: string,
+  sequencenum: number
+): PassageD {
+  return {
+    id,
+    type: 'passage',
+    attributes: {
+      book: PHP_BOOK,
+      reference: 'NOTE',
+      sequencenum,
+      startChapter: 0,
+      startVerse: 0,
+      endChapter: 0,
+      endVerse: 0,
+    },
+    relationships: {
+      section: { data: { id: sectionId } },
+      sharedResource: { data: null },
+    },
+  } as unknown as PassageD;
+}
+
+function chnumPassage(
+  id: string,
+  sectionId: string,
+  chapter: number,
+  sequencenum: number
+): PassageD {
+  return {
+    id,
+    type: 'passage',
+    attributes: {
+      book: PHP_BOOK,
+      reference: `CHNUM ${chapter}`,
+      sequencenum,
+      startChapter: 0,
+      startVerse: 0,
+      endChapter: 0,
+      endVerse: 0,
+    },
+    relationships: {
+      section: { data: { id: sectionId } },
+      sharedResource: { data: null },
+    },
+  } as unknown as PassageD;
+}
+
+function scripturePassage(
+  id: string,
+  sectionId: string,
+  reference: string,
+  sequencenum: number,
+  startChapter: number,
+  endChapter: number
+): PassageD {
+  return {
+    id,
+    type: 'passage',
+    attributes: {
+      book: PHP_BOOK,
+      reference,
+      sequencenum,
+      startChapter,
+      startVerse: 1,
+      endChapter,
+      endVerse: 30,
+    },
+    relationships: {
+      section: { data: { id: sectionId } },
+      sharedResource: { data: null },
+    },
+  } as unknown as PassageD;
+}
+
+/** Philippians-style plan: book rows + chapter-as-section with `CHNUM N` references. */
+export function buildPhilippiansPublishingFixture(): PhilippiansPublishingFixture {
+  const planId = 'plan-php';
+
+  const secBook = sectionRow('sec-book', BookSeq, planId);
+  const secAlt = sectionRow('sec-alt', AltBkSeq, planId);
+  const secCh1 = sectionRow('sec-ch1', 1, planId);
+  const secCh2 = sectionRow('sec-ch2', 2, planId);
+
+  const sectionsAll = [secBook, secAlt, secCh1, secCh2];
+
+  const passages: PassageD[] = [
+    notePassage('p-note-book', 'sec-book', 0.01),
+    notePassage('p-note-alt', 'sec-alt', 0.01),
+    notePassage('p-note-ch1-section', 'sec-ch1', 0.01),
+    chnumPassage('p-chnum-1', 'sec-ch1', 1, 0.02),
+    notePassage('p-note-ch1-chapter', 'sec-ch1', 0.03),
+    scripturePassage('p-php-1', 'sec-ch1', '1:1-30', 1, 1, 1),
+    notePassage('p-note-ch2-section', 'sec-ch2', 0.01),
+    chnumPassage('p-chnum-2', 'sec-ch2', 2, 0.02),
+    notePassage('p-note-ch2-chapter', 'sec-ch2', 0.03),
+    scripturePassage('p-php-2', 'sec-ch2', '2:1-30', 1, 2, 2),
+  ];
+
+  const mediafiles: MediaFileD[] = [
+    noteMedia('med-book-note', 'p-note-book', planId, 'book-note.mp3'),
+    noteMedia('med-alt-note', 'p-note-alt', planId, 'alt-note.mp3'),
+    noteMedia('med-ch1-section-note', 'p-note-ch1-section', planId, 'ch1-section-note.mp3'),
+    noteMedia('med-ch1-chapter-note', 'p-note-ch1-chapter', planId, 'ch1-chapter-note.mp3'),
+    noteMedia('med-ch2-section-note', 'p-note-ch2-section', planId, 'ch2-section-note.mp3'),
+    noteMedia('med-ch2-chapter-note', 'p-note-ch2-chapter', planId, 'ch2-chapter-note.mp3'),
+  ];
+
+  return { planId, sectionsAll, passages, mediafiles };
+}
+
+export function phpNoteSections(
+  fixture: PhilippiansPublishingFixture
+): SectionD[] {
+  return [...fixture.sectionsAll].sort(
+    (a, b) => a.attributes.sequencenum - b.attributes.sequencenum
+  );
+}

--- a/src/renderer/src/burrito/resolveBurritoExportFolder.test.ts
+++ b/src/renderer/src/burrito/resolveBurritoExportFolder.test.ts
@@ -1,0 +1,98 @@
+import { AltBkSeq, BookSeq } from '../model/section';
+import type { PassageD, SectionD } from '../model';
+import {
+  chnumChapterFromRef,
+  resolveBurritoExportFolder,
+  resolveChnumExportFolder,
+} from './resolveBurritoExportFolder';
+
+const bookPath = '/burrito/PHP';
+
+function section(id: string, sequencenum: number): SectionD {
+  return {
+    id,
+    type: 'section',
+    attributes: { sequencenum },
+    relationships: { plan: { data: { id: 'plan-1' } } },
+  } as unknown as SectionD;
+}
+
+function passage(
+  id: string,
+  sectionId: string,
+  reference: string,
+  sequencenum: number,
+  startChapter?: number
+): PassageD {
+  return {
+    id,
+    type: 'passage',
+    attributes: {
+      reference,
+      sequencenum,
+      startChapter: startChapter ?? 0,
+      startVerse: 1,
+      endChapter: startChapter ?? 0,
+      endVerse: 1,
+    },
+    relationships: { section: { data: { id: sectionId } } },
+  } as unknown as PassageD;
+}
+
+describe('chnumChapterFromRef', () => {
+  it('parses pipe and space CHNUM reference formats', () => {
+    expect(chnumChapterFromRef('CHNUM|3')).toBe(3);
+    expect(chnumChapterFromRef('CHNUM 4')).toBe(4);
+  });
+});
+
+describe('resolveBurritoExportFolder — book rows', () => {
+  it('uses distinct scope refs for Book and Alt Book rows', () => {
+    const book = section('book', BookSeq);
+    const alt = section('alt', AltBkSeq);
+    const passages: PassageD[] = [];
+    const input = {
+      bookPath,
+      sections: [book, alt],
+      passages,
+      computeSectionRef: () => '',
+      computeMovementRef: () => '',
+    };
+    expect(resolveBurritoExportFolder({ ...input, section: book }).scopeRef).toBe(
+      'BOOK'
+    );
+    expect(resolveBurritoExportFolder({ ...input, section: alt }).scopeRef).toBe(
+      'ALTBK'
+    );
+  });
+});
+
+describe('resolveChnumExportFolder', () => {
+  it('places CHNUM space-format rows in the matching chapter folder', () => {
+    const p = passage('p1', 's1', 'CHNUM 2', 0.02);
+    const folder = resolveChnumExportFolder(p, bookPath);
+    expect(folder.folderPath).toBe(`${bookPath}/002`);
+    expect(folder.chapter).toBe('2');
+  });
+});
+
+describe('resolveBurritoExportFolder — CHNUM space format', () => {
+  it('derives chapter folder from CHNUM N when section has no scripture ref prefix', () => {
+    const ch2 = section('ch2', 2);
+    const passages = [
+      passage('n1', 'ch2', 'NOTE', 0.01),
+      passage('cn', 'ch2', 'CHNUM 2', 0.02),
+      passage('n2', 'ch2', 'NOTE', 0.03),
+      passage('scr', 'ch2', '2:1-30', 1, 2),
+    ];
+    const folder = resolveBurritoExportFolder({
+      section: ch2,
+      bookPath,
+      sections: [ch2],
+      passages,
+      computeSectionRef: () => '2:1-30',
+      computeMovementRef: () => '',
+    });
+    expect(folder.folderPath).toBe(`${bookPath}/002`);
+  });
+});

--- a/src/renderer/src/burrito/resolveBurritoExportFolder.ts
+++ b/src/renderer/src/burrito/resolveBurritoExportFolder.ts
@@ -39,6 +39,29 @@ const sortAscend = (a: PassageD, b: PassageD) =>
 const findScripturePassage = (p: PassageD) =>
   passageTypeFromRef(p.attributes.reference, false) === PassageTypeEnum.PASSAGE;
 
+/** Parses chapter from `CHNUM|12` (sheet) or `CHNUM 12` (PTF / online save). */
+export function chnumChapterFromRef(ref?: string): number | undefined {
+  if (!ref) return undefined;
+  const pipe = ref.split('|');
+  if (pipe.length > 1) {
+    const ch = parseInt(pipe[1] ?? '', 10);
+    if (ch) return ch;
+  }
+  const space = /^CHNUM\s+(\d+)/i.exec(ref);
+  if (space) {
+    const ch = parseInt(space[1], 10);
+    if (ch) return ch;
+  }
+  return undefined;
+}
+
+function bookLevelScopeRef(section: SectionD): string {
+  const seq = section.attributes?.sequencenum ?? 0;
+  if (seq === BookSeq) return 'BOOK';
+  if (seq === AltBkSeq) return 'ALTBK';
+  return '';
+}
+
 function chapterFromSectionPassages(
   sectionId: string,
   passages: PassageD[]
@@ -52,8 +75,7 @@ function chapterFromSectionPassages(
       PassageTypeEnum.CHAPTERNUMBER
   );
   if (chnum) {
-    const pipe = chnum.attributes.reference.split('|');
-    const ch = parseInt(pipe[1] ?? '', 10);
+    const ch = chnumChapterFromRef(chnum.attributes.reference);
     if (ch) return ch;
   }
   const firstPassage = sectPass.find(findScripturePassage);
@@ -98,7 +120,11 @@ export function resolveBurritoExportFolder({
   computeMovementRef,
 }: ResolveBurritoExportFolderInput): BurritoExportFolder {
   if (isBookLevelSection(section)) {
-    return { folderPath: bookPath, chapter: null, scopeRef: '' };
+    return {
+      folderPath: bookPath,
+      chapter: null,
+      scopeRef: bookLevelScopeRef(section),
+    };
   }
   if (isMovementSection(section)) {
     const chapterNum = movementChapterStart(section, sections, passages);
@@ -125,8 +151,7 @@ export function resolveChnumExportFolder(
   passage: PassageD,
   bookPath: string
 ): BurritoExportFolder {
-  const pipe = passage.attributes.reference.split('|');
-  const chapterNum = parseInt(pipe[1] ?? '', 10) || 1;
+  const chapterNum = chnumChapterFromRef(passage.attributes.reference) ?? 1;
   return {
     folderPath: path.join(bookPath, pad3(chapterNum)),
     chapter: chapterNum.toString(),

--- a/src/renderer/src/burrito/useBurritoAudio.test.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.test.ts
@@ -11,6 +11,15 @@ import {
   jamesNoteSections,
   type JamesPublishingFixture,
 } from './jamesPublishingFixture';
+import {
+  PHP_BOOK,
+  PHP_BOOK_PATH,
+  buildPhilippiansPublishingFixture,
+  phpBibleFixture,
+  phpNoteSections,
+  type PhilippiansPublishingFixture,
+} from './philippiansPublishingFixture';
+import { isBookRootPath } from './jamesPublishingFixture';
 
 jest.mock('../crud/related', () => ({
   __esModule: true,
@@ -156,6 +165,78 @@ async function runJamesNotesExport(
       bookPath: JAMES_BOOK_PATH,
       preLen: 0,
       sections: jamesNoteSections(fixture),
+      passageTypeFilter: PassageTypeEnum.NOTE,
+      flavorTypeName: 'x-notes',
+    });
+  });
+  return metadata;
+}
+
+function loadAudioForPhilippians(
+  api: unknown,
+  fixture: PhilippiansPublishingFixture
+) {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  jest.resetModules();
+  (window as unknown as { api?: unknown }).api = api;
+
+  jest.doMock(
+    '../components/PassageDetail/Internalization/useComputeRef',
+    () =>
+      jest.requireActual(
+        '../components/PassageDetail/Internalization/useComputeRef'
+      )
+  );
+
+  jest.doMock('../utils/dataPath', () => ({
+    __esModule: true,
+    PathType: { MEDIA: 'MEDIA' },
+    default: jest.fn(
+      async (url: string, _pathType: unknown, local: { localname: string }) => {
+        local.localname = url;
+        return url;
+      }
+    ),
+  }));
+
+  const { renderHook, act } = require('@testing-library/react/pure');
+  const { useOrgDefaults } = require('../crud/useOrgDefaults');
+  const { useOrbitData } = require('../hoc/useOrbitData');
+
+  useOrgDefaults.mockReturnValue(defaultOrgDefaults());
+
+  useOrbitData.mockImplementation((type: string) => {
+    if (type === 'mediafile') return fixture.mediafiles;
+    if (type === 'passage') return fixture.passages;
+    if (type === 'sectionresource') return [];
+    if (type === 'sharedresource') return [];
+    if (type === 'section') return fixture.sectionsAll;
+    return [];
+  });
+
+  const { useBurritoAudio } = require('./useBurritoAudio');
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  return { renderHook, act, useBurritoAudio };
+}
+
+async function runPhilippiansNotesExport(
+  ipc: ReturnType<typeof makeIpc>,
+  fixture: PhilippiansPublishingFixture
+) {
+  const { renderHook, act, useBurritoAudio } = loadAudioForPhilippians(
+    ipc,
+    fixture
+  );
+  const { result } = renderHook(() => useBurritoAudio('team-1'));
+  const metadata = burritoFixture();
+  await act(async () => {
+    await result.current({
+      metadata,
+      bible: phpBibleFixture,
+      book: PHP_BOOK,
+      bookPath: PHP_BOOK_PATH,
+      preLen: 0,
+      sections: phpNoteSections(fixture),
       passageTypeFilter: PassageTypeEnum.NOTE,
       flavorTypeName: 'x-notes',
     });
@@ -897,5 +978,35 @@ describe('James publishing hierarchy — note folder placement (TT-7191)', () =>
       .map((name) => destForMediaSrc(ipc, name))
       .filter((dest): dest is string => dest != null && dest.includes('/001/'));
     expect(misplaced).toHaveLength(0);
+  });
+});
+
+describe('Philippians publishing hierarchy — note export (TT-7191)', () => {
+  let ipc: ReturnType<typeof makeIpc>;
+
+  beforeEach(async () => {
+    ipc = makeIpc();
+    await runPhilippiansNotesExport(ipc, buildPhilippiansPublishingFixture());
+  });
+
+  it('exports Book and Alt Book note recordings to distinct book-root files', () => {
+    const bookDest = destForMediaSrc(ipc, 'book-note.mp3');
+    const altDest = destForMediaSrc(ipc, 'alt-note.mp3');
+    expect(bookDest).toBeDefined();
+    expect(altDest).toBeDefined();
+    expect(isBookRootPath(bookDest!, PHP_BOOK_PATH)).toBe(true);
+    expect(isBookRootPath(altDest!, PHP_BOOK_PATH)).toBe(true);
+    expect(bookDest).not.toBe(altDest);
+  });
+
+  it('places chapter 2 note recordings in chapter 002, not 001', () => {
+    const sectionDest = destForMediaSrc(ipc, 'ch2-section-note.mp3');
+    const chapterDest = destForMediaSrc(ipc, 'ch2-chapter-note.mp3');
+    expect(sectionDest).toBeDefined();
+    expect(chapterDest).toBeDefined();
+    expect(sectionDest).toContain('/002/');
+    expect(chapterDest).toContain('/002/');
+    expect(sectionDest).not.toContain('/001/');
+    expect(chapterDest).not.toContain('/001/');
   });
 });

--- a/src/renderer/src/burrito/useBurritoAudio.ts
+++ b/src/renderer/src/burrito/useBurritoAudio.ts
@@ -32,6 +32,7 @@ import { IRegion } from '../crud/useWavesurferRegions';
 import { timeFmt } from '../utils/timeFmt';
 import { useComputeRef } from '../components/PassageDetail/Internalization/useComputeRef';
 import {
+  chnumChapterFromRef,
   isBookLevelSection,
   resolveBurritoExportFolder,
 } from './resolveBurritoExportFolder';
@@ -400,8 +401,7 @@ export const useBurritoAudio = (teamId: string) => {
         parseRef(firstP);
         const pt = passageTypeFromRef(firstP.attributes.reference, false);
         if (pt === PassageTypeEnum.CHAPTERNUMBER) {
-          const pipe = firstP.attributes.reference.split('|');
-          sectionChapter = parseInt(pipe[1] ?? '', 10) || 1;
+          sectionChapter = chnumChapterFromRef(firstP.attributes.reference) ?? 1;
         } else {
           sectionChapter = firstP.attributes.startChapter || 1;
         }
@@ -466,8 +466,7 @@ export const useBurritoAudio = (teamId: string) => {
           startChapter = 1;
         }
         if (passageType === PassageTypeEnum.CHAPTERNUMBER) {
-          const pipe = p.attributes.reference.split('|');
-          startChapter = parseInt(pipe[1] ?? '', 10) || 1;
+          startChapter = chnumChapterFromRef(p.attributes.reference) ?? 1;
         }
 
         // new chapter number create a new chapter folder and usfm chapter header if necessary


### PR DESCRIPTION
- Introduced `philippiansPublishingFixture.ts` to define the structure for Philippians publishing, including sections, passages, and media files.
- Implemented functions to create sections and passages, enhancing the fixture's usability for testing.
- Added tests for the Philippians publishing hierarchy, ensuring correct export behavior for notes and media files.
- Updated `resolveBurritoExportFolder` to support chapter parsing from CHNUM references, improving folder resolution logic.

This commit enhances the burrito export process by integrating a comprehensive fixture for Philippians, facilitating better organization and retrieval of publishing data.