### PR TITLE
Auth: dev callback follows served origin instead of hardcoded VITE_CALLBACK

### DIFF
--- a/src/renderer/src/auth/AuthApp.tsx
+++ b/src/renderer/src/auth/AuthApp.tsx
@@ -14,7 +14,13 @@ export const AuthApp: React.FC = () => {
       }
       authorizationParams={{
         audience: apiIdentifier,
-        redirect_uri: import.meta.env.VITE_CALLBACK,
+        // In the dev server, return to whatever origin (and port) the app is
+        // actually being served from, so `npm start -- --port N` round-trips
+        // through Auth0 without hardcoding VITE_CALLBACK. Production builds keep
+        // the configured callback. Both must be in Auth0's Allowed Callback URLs.
+        redirect_uri: import.meta.env.DEV
+          ? window.location.origin
+          : import.meta.env.VITE_CALLBACK,
         useRefreshTokens: true,
       }}
     >


### PR DESCRIPTION
## What
In the Vite dev server, derive the Auth0 `redirect_uri` from `window.location.origin` instead of the hardcoded `VITE_CALLBACK`, so `npm start -- --port N` round-trips through Auth0 back to whatever port the app is actually served on. Production builds are unchanged — they still use the configured `VITE_CALLBACK`.

Only `src/auth/AuthApp.tsx` changes:

```ts
redirect_uri: import.meta.env.DEV
  ? window.location.origin
  : import.meta.env.VITE_CALLBACK,
```

`import.meta.env.DEV` is a Vite built-in: `true` under the dev server, `false` in a production build. `window.location.origin` must still be in Auth0's Allowed Callback URLs (localhost:3000 and :3001 already are on the dev tenant).

## Why
Running the dev app on a non-3000 port previously bounced you back to :3000 after login, because the callback was hardcoded. This lets you run on any port (e.g. alongside another worktree already on :3000) without editing env files.

## Test plan
- `npm start -- --port 3001 --strictPort`, log in via Auth0 → returns to `http://localhost:3001` and lands on the authenticated dashboard (verified end-to-end).
- `npm run typecheck` passes.
- Production build behavior unchanged (still uses `VITE_CALLBACK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)