### PR TITLE
fix: move useRefreshTokens to top-level Auth0Provider prop

### DIFF
--- a/src/renderer/src/auth/AuthApp.tsx
+++ b/src/renderer/src/auth/AuthApp.tsx
@@ -8,6 +8,11 @@ export const AuthApp: React.FC = () => {
     <Auth0Provider
       domain={auth0Domain}
       clientId={webClientId}
+      // useRefreshTokens is a top-level Auth0Provider option (from
+      // @auth0/auth0-spa-js Auth0ClientOptions), not an authorization param.
+      // Nested inside authorizationParams it is sent to /authorize as an
+      // unrecognized query param and refresh-token rotation stays disabled.
+      useRefreshTokens={true}
       cacheLocation={
         (import.meta.env.VITE_AUTH_CACHE as 'localstorage' | 'memory') ||
         'memory'
@@ -15,7 +20,6 @@ export const AuthApp: React.FC = () => {
       authorizationParams={{
         audience: apiIdentifier,
         redirect_uri: import.meta.env.VITE_CALLBACK,
-        useRefreshTokens: true,
       }}
     >
       <TokenChecked />

--- a/src/renderer/src/auth/AuthApp.tsx
+++ b/src/renderer/src/auth/AuthApp.tsx
@@ -8,10 +8,6 @@ export const AuthApp: React.FC = () => {
     <Auth0Provider
       domain={auth0Domain}
       clientId={webClientId}
-      // useRefreshTokens is a top-level Auth0Provider option (from
-      // @auth0/auth0-spa-js Auth0ClientOptions), not an authorization param.
-      // Nested inside authorizationParams it is sent to /authorize as an
-      // unrecognized query param and refresh-token rotation stays disabled.
       useRefreshTokens={true}
       cacheLocation={
         (import.meta.env.VITE_AUTH_CACHE as 'localstorage' | 'memory') ||


### PR DESCRIPTION
## What
Move `useRefreshTokens` from inside `authorizationParams` to a top-level `<Auth0Provider>` prop.

```diff
      clientId={webClientId}
+     useRefreshTokens={true}
      cacheLocation={ ... }
      authorizationParams={{
        audience: apiIdentifier,
        redirect_uri: import.meta.env.VITE_CALLBACK,
-       useRefreshTokens: true,
      }}
```

## Why
`useRefreshTokens` is a top-level option in the `@auth0/auth0-react` / `@auth0/auth0-spa-js` client options (`Auth0ClientOptions`), **not** an authorization parameter. `authorizationParams` maps to query parameters on the `/authorize` endpoint. Nested there, `useRefreshTokens: true` was sent as an unrecognized query param and the SDK's client-side refresh-token rotation stayed at its default (disabled). It type-checked only because `AuthorizationParams` permits arbitrary custom params.

Flagged by automated review on #393; this is a pre-existing issue, fixed here in isolation.

## Scope
- Only `useRefreshTokens` placement changes. `cacheLocation` (env-driven `VITE_AUTH_CACHE`) and `redirect_uri` are untouched.
- Independent of #393 (the dev-callback-origin change); whichever merges second may need a trivial rebase since both edit the `Auth0Provider` block.

## Test plan
- `npm run typecheck`: no new errors from this change (the only failures are pre-existing `cypress/support/commands.ts` issues present on `develop` already).
- Verified in a live login that a top-level `useRefreshTokens` results in `offline_access` being requested at `/authorize` (the SDK adds it only when the option is recognized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)