### PR TITLE
TT-7527 fix: show Delete Region button in Mobile view

### DIFF
--- a/src/renderer/src/components/WSAudioPlayer.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.tsx
@@ -2067,8 +2067,7 @@ function WSAudioPlayer(props: IProps) {
 
   const deleteRegionNode = !hideWaveformEditTools &&
     hasRegion !== 0 &&
-    !oneShotUsed &&
-    !isMobileView && (
+    !oneShotUsed && (
       <LightTooltip id="wsAudioDeleteRegionTip" title={t.deleteRegion}>
         <span>
           <IconButton


### PR DESCRIPTION
## Summary

Fixes TT-7527 — the **Delete Region** button was missing in Mobile view of the audio player, so mobile users could not remove an incorrect recording region and had to clear and re-record the entire audio.

The button was gated behind a `!isMobileView` condition in `WSAudioPlayer`. This PR removes that condition so the Delete Region control renders in Mobile view just as it already does in Desktop view.

## Test plan

- On a mobile / narrow viewport, open the audio player with a selected region and confirm the Delete Region button now appears and deletes the region.
- Confirm Desktop view behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)