### PR TITLE
TT-7524 feat: hide Versions button and use trash-can icon to clear on BOLD record step

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailRecord.tsx
@@ -380,7 +380,7 @@ export function PassageDetailRecord(props: IProps) {
           </>
         }
         onVersions={
-          hasExistingVersion && vernacularVersionCount > 1
+          !isBoldWorkflow && hasExistingVersion && vernacularVersionCount > 1
             ? handleVersions
             : undefined
         }

--- a/src/renderer/src/components/WSAudioPlayer.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.tsx
@@ -30,6 +30,7 @@ import MicIcon from '@mui/icons-material/SettingsVoice';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import SettingsIcon from '@mui/icons-material/Settings';
 import VersionsIcon from '@mui/icons-material/List';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
 import NormalizeIcon from '../control/NormalizeIcon';
 import UploadIcon from '@mui/icons-material/CloudUpload';
 import { Button } from '@mui/material';
@@ -2178,8 +2179,9 @@ function WSAudioPlayer(props: IProps) {
     !dockRecordButton && (
       <LightTooltip id="wsAudioClearTip" title={t.clearRecordingTip}>
         <span>
-          <AltButton
+          <IconButton
             id="wsAudioClear"
+            aria-label={t.clearRecordingTip}
             onClick={() => handleClear()}
             disabled={
               recording ||
@@ -2187,10 +2189,9 @@ function WSAudioPlayer(props: IProps) {
               waitingForAI ||
               Boolean(mediaSaveInProgress)
             }
-            sx={smallButtonProps}
           >
-            {t.reset}
-          </AltButton>
+            <DeleteIcon />
+          </IconButton>
         </span>
       </LightTooltip>
     );


### PR DESCRIPTION
## Summary

Polish for the BOLD record step (TT-7524):

1. **No Versions button** — the Versions button is now suppressed on the BOLD workflow record step (gated on `!isBoldWorkflow` in `PassageDetailRecord`). It still shows for non-BOLD workflows with multiple vernacular versions.
2. **Clear → trash can** — the text "Clear" button in the `WSAudioPlayer` record controls is replaced with a trash-can icon button (`DeleteOutline`), matching the delete affordance used in other wavesurfer contexts (e.g. Careful Speech). Functionality is unchanged (still opens the "Clear Recording?" confirmation).

## Test plan

- `npm run typecheck` passes.
- Verified live in the dev web app on a record step with existing audio: the clear control now renders as a trash-can icon (aria-label "Clear Recording") and clicking it opens the "Clear Recording?" confirmation, then No/Yes behaves as before.
- The Versions-button change is a boolean guard added to the existing render condition; a BOLD-workflow team wasn't set up in the dev DB to exercise it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)