### PR TITLE
TT-7521 no offline sheet change

### DIFF
--- a/src/renderer/src/components/AudioTab/AudioTab.tsx
+++ b/src/renderer/src/components/AudioTab/AudioTab.tsx
@@ -71,7 +71,7 @@ export function AudioTab() {
   const { showMessage } = useSnackBar();
   const [data, setData] = useState(Array<IRow>());
   const [pdata, setPData] = useState(Array<IPRow>());
-  const { sectionArr, shared, publishingOn, canEditSheet, canPublish } =
+  const { sectionArr, shared, publishingOn, canEditAudio, canPublish } =
     useContext(PlanContext).state;
   const sectionMap = new Map<number, string>(sectionArr);
   const [attachVisible, setAttachVisible] = useState(false);
@@ -341,7 +341,7 @@ export function AudioTab() {
       <Box width="100%">
         <TabAppBar position="fixed" color="default">
           <TabActions>
-            {canEditSheet && (
+            {canEditAudio && (
               <>
                 <AltButton
                   id="audUpload"
@@ -394,7 +394,7 @@ export function AudioTab() {
               playItem={playItem}
               setPlayItem={setPlayItem}
               onAttach={onAttach}
-              readonly={!canEditSheet}
+              readonly={!canEditAudio}
               sectionArr={sectionArr}
               shared={shared}
               canSetDestination={!isOffline && canPublish}

--- a/src/renderer/src/components/Sheet/PassageCard.cy.tsx
+++ b/src/renderer/src/components/Sheet/PassageCard.cy.tsx
@@ -146,6 +146,7 @@ describe('PassageCard', () => {
     publishingOn: true,
     hidePublishing: true,
     canEditSheet: false,
+    canEditAudio: false,
     canPublish: false,
     sectionArr: [],
     setSectionArr: () => {},

--- a/src/renderer/src/components/Sheet/PassageRef.cy.tsx
+++ b/src/renderer/src/components/Sheet/PassageRef.cy.tsx
@@ -121,6 +121,7 @@ describe('PassageRef', () => {
     publishingOn: true,
     hidePublishing: true,
     canEditSheet: false,
+    canEditAudio: false,
     canPublish: false,
     sectionArr: [],
     setSectionArr: () => {},

--- a/src/renderer/src/components/Sheet/PlanBar.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanBar.cy.tsx
@@ -245,6 +245,7 @@ describe('PlanBar', () => {
     publishingOn: true,
     hidePublishing: true,
     canEditSheet: false,
+    canEditAudio: false,
     canPublish: false,
     sectionArr: [],
     setSectionArr: cy.stub(),

--- a/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
@@ -176,6 +176,7 @@ describe('PlanTabSelect', () => {
     publishingOn: true,
     hidePublishing: true,
     canEditSheet: false,
+    canEditAudio: false,
     canPublish: false,
     sectionArr: [],
     setSectionArr: cy.stub(),

--- a/src/renderer/src/components/Sheet/PlanView.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanView.cy.tsx
@@ -186,6 +186,7 @@ describe('PlanView', () => {
     publishingOn: true,
     hidePublishing: true,
     canEditSheet: false,
+    canEditAudio: false,
     canPublish: false,
     sectionArr: [],
     setSectionArr: cy.stub(),

--- a/src/renderer/src/context/PlanContext.tsx
+++ b/src/renderer/src/context/PlanContext.tsx
@@ -30,6 +30,7 @@ const initState = {
   publishingOn: true,
   hidePublishing: true,
   canEditSheet: false,
+  canEditAudio: false,
   canPublish: false,
   sectionArr: [] as SectionArray,
   setSectionArr: (_sectionArr: SectionArray) => {},
@@ -64,6 +65,7 @@ const PlanProvider = (props: IProps) => {
   const [project] = useGlobal('project'); //will be constant here
   const [connected] = useGlobal('connected'); //verified this is not used in a function 2/18/25
   const [isOffline] = useGlobal('offline'); //verified this is not used in a function 2/18/25
+  const [offlineOnly] = useGlobal('offlineOnly');
   const [isDeveloper] = useGlobal('developer');
   const getPlanType = usePlanType();
   const { setProjectDefault, getProjectDefault } = useProjectDefaults();
@@ -73,7 +75,14 @@ const PlanProvider = (props: IProps) => {
   // Bold-workflow members can add sections/passages when the session-only
   // "Add {Story} or Passage" flag is set (see UserMenu). The flag can only be
   // set in a bold context, so no extra workflow guard is needed here.
-  const canEditSheet = canEditSheetPerm || addStoryOrPassage;
+  // Structural sheet edits (adding/moving sections & passages) still require
+  // connectivity to the server, same as admins/sheet-editors -- see TT-7521.
+  // Audio upload/delete is safe to allow offline (it queues for later sync),
+  // so canEditAudio intentionally does not apply that restriction.
+  const structuralOffline = isOffline && !offlineOnly;
+  const canEditSheet =
+    canEditSheetPerm || (addStoryOrPassage && !structuralOffline);
+  const canEditAudio = canEditSheetPerm || addStoryOrPassage;
   const [state, setState] = useState({
     ...initState,
     mediafiles,
@@ -162,6 +171,7 @@ const PlanProvider = (props: IProps) => {
           setSectionArr,
           connected,
           canEditSheet,
+          canEditAudio,
           canPublish,
           togglePublishing,
           setCanAddPublishing,

--- a/src/renderer/src/context/PlanContext.tsx
+++ b/src/renderer/src/context/PlanContext.tsx
@@ -69,8 +69,11 @@ const PlanProvider = (props: IProps) => {
   const [isDeveloper] = useGlobal('developer');
   const getPlanType = usePlanType();
   const { setProjectDefault, getProjectDefault } = useProjectDefaults();
-  const { canEditSheet: canEditSheetPerm, canPublish } =
-    useProjectPermissions();
+  const {
+    canEditSheet: canEditSheetPerm,
+    canEditSheetBase,
+    canPublish,
+  } = useProjectPermissions();
   const [addStoryOrPassage] = useGlobal('addStoryOrPassage');
   // Bold-workflow members can add sections/passages when the session-only
   // "Add {Story} or Passage" flag is set (see UserMenu). The flag can only be
@@ -82,7 +85,7 @@ const PlanProvider = (props: IProps) => {
   const structuralOffline = isOffline && !offlineOnly;
   const canEditSheet =
     canEditSheetPerm || (addStoryOrPassage && !structuralOffline);
-  const canEditAudio = canEditSheetPerm || addStoryOrPassage;
+  const canEditAudio = canEditSheetBase || addStoryOrPassage;
   const [state, setState] = useState({
     ...initState,
     mediafiles,

--- a/src/renderer/src/utils/useProjectPermissions.ts
+++ b/src/renderer/src/utils/useProjectPermissions.ts
@@ -9,8 +9,13 @@ import { useOrbitData } from '../hoc/useOrbitData';
 export const useProjectPermissions = (
   team?: string,
   proj?: string
-): { canEditSheet: boolean; canPublish: boolean } => {
+): {
+  canEditSheet: boolean;
+  canEditSheetBase: boolean;
+  canPublish: boolean;
+} => {
   const [canEditSheet, setCanEditSheet] = useState(false);
+  const [canEditSheetBase, setCanEditSheetBase] = useState(false);
   const [canPublish, setCanPublish] = useState(false);
   const [isOffline] = useGlobal('offline'); //verified this is not used in a function 2/18/25
   const [offlineOnly] = useGlobal('offlineOnly');
@@ -39,14 +44,14 @@ export const useProjectPermissions = (
     const editgroup = related(projectRec, 'editsheetgroup');
     const edituser = related(projectRec, 'editsheetuser');
 
-    setCanEditSheet(
-      (!(isOffline && !offlineOnly) &&
-        (isAdmin ||
-          (Boolean(editgroup) &&
-            myGroups.findIndex((g) => g.id === editgroup) > -1) ||
-          (Boolean(edituser) && edituser === user))) ??
-        false
-    );
+    const editSheetBase =
+      isAdmin ||
+      (Boolean(editgroup) &&
+        myGroups.findIndex((g) => g.id === editgroup) > -1) ||
+      (Boolean(edituser) && edituser === user);
+
+    setCanEditSheetBase(editSheetBase ?? false);
+    setCanEditSheet((!(isOffline && !offlineOnly) && editSheetBase) ?? false);
 
     const publishgroup = related(projectRec, 'publishgroup');
     const publishuser = related(projectRec, 'publishuser');
@@ -60,5 +65,5 @@ export const useProjectPermissions = (
     );
   }, [projectRec, myGroups, isAdmin, user, isOffline, offlineOnly]);
 
-  return { canEditSheet, canPublish };
+  return { canEditSheet, canEditSheetBase, canPublish };
 };


### PR DESCRIPTION
This PR introduces a separate canEditAudio permission that remains available offline, while restricting structural sheet edits (canEditSheet) when the user is offline and not in offline-only mode.

The key insight (ref TT-7521): structural edits (add/move sections & passages) require server connectivity, but audio upload/delete can safely queue for later sync. Previously both used canEditSheet, so going offline blocked audio operations unnecessarily.