### PR TITLE
TT- 7040 workflow add fail

### DIFF
--- a/src/renderer/src/components/App/OrgHead.tsx
+++ b/src/renderer/src/components/App/OrgHead.tsx
@@ -1,7 +1,8 @@
 import { useContext, useMemo, useState } from 'react';
 import { LocalKey, localUserKey } from '../../utils/localUserKey';
 import { useMobile } from '../../utils';
-import { useGlobal } from '../../context/useGlobal';
+import { useGetGlobal, useGlobal } from '../../context/useGlobal';
+import { UnsavedContext } from '../../context/UnsavedContext';
 import { IconButton, Menu, MenuItem, Stack, Typography } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import UsersIcon from '@mui/icons-material/People';
@@ -39,6 +40,8 @@ export const OrgHead = () => {
   const [workflowVisible, setWorkflowVisible] = useState(false);
   const { isMobile, isMobileView } = useMobile();
   const commitTeamSettings = useCommitTeamSettings();
+  const { startSave, waitForSave } = useContext(UnsavedContext).state;
+  const getGlobal = useGetGlobal();
   const { pathname } = useLocation();
   const isTeamScreen = pathname.includes('/team');
   const isSwitchTeamsScreen = pathname.includes('/switch-teams');
@@ -111,6 +114,13 @@ export const OrgHead = () => {
   const handleWorkflow = () => {
     setWorkflowVisible(true);
     handleSettingsMenuClose();
+  };
+
+  const handleWorkflowClose = (isOpen: boolean) => {
+    if (getGlobal('changed')) {
+      startSave();
+      waitForSave(() => setWorkflowVisible(isOpen), 500);
+    } else setWorkflowVisible(isOpen);
   };
 
   const handleCommitSettings = async (
@@ -248,7 +258,7 @@ export const OrgHead = () => {
                 )
           }
           isOpen={workflowVisible}
-          onOpen={setWorkflowVisible}
+          onOpen={handleWorkflowClose}
           bp={isMobile ? BigDialogBp.mobile : BigDialogBp.md}
         >
           <StepEditor


### PR DESCRIPTION
TT-7040 feat: integrate UnsavedContext for workflow handling in OrgHead component

OrgHead.tsx closed the mobile Edit Workflow dialog by calling setWorkflowVisible(false) directly, which unmounted StepEditor before the startSave()/saveRecs() flow ever ran — so newly added steps (only in local component state) were discarded instead of persisted to Orbit.

The desktop entry points (TeamItem.tsx, PersonalItem.tsx) already wrap their close handler with startSave() + waitForSave() to flush pending changes first. I mirrored that same pattern in OrgHead.tsx:

- Added UnsavedContext (startSave/waitForSave) and useGetGlobal.
- Added handleWorkflowClose, which checks getGlobal('changed'); if there are unsaved changes it triggers startSave() and only flips workflowVisible to false once waitForSave resolves.
- Wired the dialog's onOpen to this new handler instead of the raw setWorkflowVisible