### PR TITLE
improve layout of edit reference dialog

### DIFF
--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -227,7 +227,31 @@ export default function EditReferenceDropdown({
     }));
   };
 
-  /*
+  const renderSuffixSelect = (side: 'start' | 'end') => {
+    const isStart = side === 'start';
+    const suffix = isStart ? draft.startSuffix : draft.endSuffix;
+    const suffixLabel = `${side} verse suffix`;
+    return (
+      <NativeSelect
+        value={suffix}
+        onChange={handleSuffixChange(isStart ? 'startSuffix' : 'endSuffix')}
+        inputProps={{ 'aria-label': suffixLabel, title: suffixLabel }}
+        sx={selectSx}
+      >
+        {suffixOptions.map((option) => (
+          <option
+            key={option || `none-${side}`}
+            value={option}
+            style={suffixOptionStyle}
+          >
+            {option || ' '}
+          </option>
+        ))}
+      </NativeSelect>
+    );
+  };
+
+  /**
    * An editable `chapter:verse` endpoint (`unrestricted` mode). The chapter is a
    * dropdown only when the passage spans multiple chapters; the verse is always
    * a dropdown scoped to the chosen chapter.
@@ -236,11 +260,9 @@ export default function EditReferenceDropdown({
     const isStart = side === 'start';
     const chapter = isStart ? draft.startChapter : draft.endChapter;
     const verse = isStart ? draft.startVerse : draft.endVerse;
-    const suffix = isStart ? draft.startSuffix : draft.endSuffix;
     const verseOptions = versesForChapter(chapter);
     const chapterLabel = `${side} chapter number`;
     const verseLabel = `${side} verse number`;
-    const suffixLabel = `${side} verse suffix`;
     return (
       <Box sx={{ textAlign: 'center', minWidth: 96 }}>
         <Box
@@ -294,25 +316,8 @@ export default function EditReferenceDropdown({
               </option>
             ))}
           </NativeSelect>
+          {draft.splitVerse ? renderSuffixSelect(side) : null}
         </Box>
-        {draft.splitVerse ? (
-          <NativeSelect
-            value={suffix}
-            onChange={handleSuffixChange(isStart ? 'startSuffix' : 'endSuffix')}
-            inputProps={{ 'aria-label': suffixLabel, title: suffixLabel }}
-            sx={{ ...selectSx, mt: 0.5 }}
-          >
-            {suffixOptions.map((option) => (
-              <option
-                key={option || `none-${side}`}
-                value={option}
-                style={suffixOptionStyle}
-              >
-                {option || ' '}
-              </option>
-            ))}
-          </NativeSelect>
-        ) : null}
       </Box>
     );
   };
@@ -333,8 +338,8 @@ export default function EditReferenceDropdown({
           sx={{
             display: 'flex',
             justifyContent: 'center',
-            alignItems: 'flex-start',
-            gap: 3,
+            alignItems: 'center',
+            gap: 2,
             mb: 2,
             fontVariantNumeric: 'tabular-nums',
           }}
@@ -343,39 +348,26 @@ export default function EditReferenceDropdown({
             renderEditableEndpoint('start')
           ) : (
             <Box sx={{ textAlign: 'center', minWidth: 96 }}>
-              <Typography
-                component="div"
-                aria-label="start verse reference"
-                sx={{ fontSize: 28, lineHeight: 1.2, py: 0.5 }}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.5,
+                }}
               >
-                {`${draft.startChapter}:${draft.startVerse}`}
-              </Typography>
-              {draft.splitVerse ? (
-                <NativeSelect
-                  value={draft.startSuffix}
-                  onChange={handleSuffixChange('startSuffix')}
-                  inputProps={{
-                    'aria-label': 'start verse suffix',
-                    title: 'start verse suffix',
-                  }}
-                  sx={{ ...selectSx, mt: 0.5 }}
+                <Typography
+                  component="div"
+                  aria-label="start verse reference"
+                  sx={{ fontSize: 28, lineHeight: 1.2, py: 0.5 }}
                 >
-                  {suffixOptions.map((option) => (
-                    <option
-                      key={option || 'none-start'}
-                      value={option}
-                      style={suffixOptionStyle}
-                    >
-                      {option || ' '}
-                    </option>
-                  ))}
-                </NativeSelect>
-              ) : null}
+                  {`${draft.startChapter}:${draft.startVerse}`}
+                </Typography>
+                {draft.splitVerse ? renderSuffixSelect('start') : null}
+              </Box>
             </Box>
           )}
-          <Typography variant="h6" sx={{ mt: 0.75 }}>
-            -
-          </Typography>
+          <Typography variant="h6">-</Typography>
           {unrestricted ? (
             renderEditableEndpoint('end')
           ) : (
@@ -412,28 +404,8 @@ export default function EditReferenceDropdown({
                     </option>
                   ))}
                 </NativeSelect>
+                {draft.splitVerse ? renderSuffixSelect('end') : null}
               </Box>
-              {draft.splitVerse ? (
-                <NativeSelect
-                  value={draft.endSuffix}
-                  onChange={handleSuffixChange('endSuffix')}
-                  inputProps={{
-                    'aria-label': 'end verse suffix',
-                    title: 'end verse suffix',
-                  }}
-                  sx={{ ...selectSx, mt: 0.5 }}
-                >
-                  {suffixOptions.map((option) => (
-                    <option
-                      key={option || 'none-end'}
-                      value={option}
-                      style={suffixOptionStyle}
-                    >
-                      {option || ' '}
-                    </option>
-                  ))}
-                </NativeSelect>
-              ) : null}
             </Box>
           )}
         </Box>

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -21,12 +21,11 @@ import {
 
 const suffixOptions = ['', 'a', 'b', 'c', 'd', 'e'];
 const selectSx = {
-  minWidth: 56,
+  width: 'auto',
   '& .MuiNativeSelect-select': {
     fontSize: '1.25rem',
     lineHeight: 1.2,
     textAlign: 'center',
-    pr: 2.5,
     py: 0.5,
   },
   '& .MuiNativeSelect-icon': {

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -338,7 +338,7 @@ export default function EditReferenceDropdown({
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
-            gap: 2,
+            gap: 0.5,
             mb: 2,
             fontVariantNumeric: 'tabular-nums',
           }}


### PR DESCRIPTION
## Summary

Layout improvements for the Mark Verses **edit reference** dropdown (`EditReferenceDropdown.tsx`, mobile view):

- Place the verse **suffix** next to the verse.
- Let the native select **size to its content** (`width: 'auto'`) instead of a fixed `minWidth: 56` with extra right padding (`pr: 2.5`), tightening the dropdown spacing.

No functional/behavior change — purely visual layout of the edit reference UI.

## Test plan

- In mobile Mark Verses, open the edit reference dropdown and confirm the verse + suffix read naturally and the select width fits its content without excess padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)