### PR TITLE
TT-7019,feat: enhance AlertDialog responsiveness and add publishing control in PlanView

### DIFF
--- a/src/renderer/src/components/AlertDialog.tsx
+++ b/src/renderer/src/components/AlertDialog.tsx
@@ -6,11 +6,13 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  useTheme,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import DialogActions, { DialogActionsProps } from '@mui/material/DialogActions';
 import { shallowEqual, useSelector } from 'react-redux';
 import { alertSelector } from '../selector';
+import { useMobile } from '../utils/useMobile';
 
 // see: https://mui.com/material-ui/customization/how-to-customize/
 interface StyledActionsProps extends DialogActionsProps {
@@ -51,6 +53,8 @@ function AlertDialog(props: IProps) {
   } = props;
   const t: IAlertStrings = useSelector(alertSelector, shallowEqual);
   const [open, setOpen] = useState(true);
+  const { isMobile } = useMobile();
+  const theme = useTheme();
 
   const handleClose = () => {
     if (noResponse !== null) {
@@ -78,6 +82,19 @@ function AlertDialog(props: IProps) {
       aria-labelledby="alertDlg"
       aria-describedby="alertDesc"
       disableEnforceFocus
+      sx={
+        isMobile
+          ? {
+              '& .MuiDialog-paper': {
+                maxWidth: `calc(100vw - ${theme.spacing(4)})`,
+                width: '100%',
+                minWidth: 0,
+                maxHeight: `calc(100dvh - ${theme.spacing(4)})`,
+                boxSizing: 'border-box',
+              },
+            }
+          : undefined
+      }
     >
       <DialogTitle id="alertDlg">
         {title || (isDelete ? t.delete : t.confirmation)}

--- a/src/renderer/src/components/Sheet/PlanView.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanView.cy.tsx
@@ -543,7 +543,7 @@ describe('PlanView', () => {
     ).should('not.exist');
   });
 
-  it('should call handlePublish when publish is confirmed', () => {
+  it('should disable the publish button and not call handlePublish when canPublish is false', () => {
     const section = createMockSection({
       passageType: PassageTypeEnum.PASSAGE as any,
     });
@@ -568,9 +568,8 @@ describe('PlanView', () => {
     )
       .first()
       .closest('button')
-      .click();
-    cy.get('button#alertYes', { timeout: 5000 }).click();
-    cy.wrap(mockHandlePublish).should('have.been.calledWith', 0);
+      .should('be.disabled');
+    cy.wrap(mockHandlePublish).should('not.have.been.called');
   });
 
   it('should show PublishOnIcon (PublicOutlinedIcon) when item is not published', () => {
@@ -665,7 +664,7 @@ describe('PlanView', () => {
     cy.get('svg[data-testid="PublicOutlinedIcon"]').should('not.exist');
   });
 
-  it('should call handlePublish with correct index for multiple passages', () => {
+  it('should disable all publish buttons for multiple passages when canPublish is false', () => {
     const passage1 = createMockSection({
       passageType: 'PASS' as any,
       published: [],
@@ -705,25 +704,14 @@ describe('PlanView', () => {
       'svg[data-testid="PublicOutlinedIcon"], svg[data-testid="PublicOffOutlinedIcon"]'
     ).should('have.length', 3);
 
-    // Click the second button (index 1)
+    // Every publish button should be disabled since canPublish is false
     cy.get(
       'svg[data-testid="PublicOutlinedIcon"], svg[data-testid="PublicOffOutlinedIcon"]'
-    )
-      .eq(1)
-      .closest('button')
-      .click();
-    cy.get('button#alertYes', { timeout: 5000 }).click();
-    cy.wrap(mockHandlePublish).should('have.been.calledWith', 1);
+    ).each(($icon) => {
+      cy.wrap($icon).closest('button').should('be.disabled');
+    });
 
-    // Click the third button (index 2)
-    cy.get(
-      'svg[data-testid="PublicOutlinedIcon"], svg[data-testid="PublicOffOutlinedIcon"]'
-    )
-      .eq(2)
-      .closest('button')
-      .click();
-    cy.get('button#alertYes', { timeout: 5000 }).click();
-    cy.wrap(mockHandlePublish).should('have.been.calledWith', 2);
+    cy.wrap(mockHandlePublish).should('not.have.been.called');
   });
 
   it('should not show publish button for non-PASS passage types', () => {

--- a/src/renderer/src/components/Sheet/PlanView.tsx
+++ b/src/renderer/src/components/Sheet/PlanView.tsx
@@ -42,7 +42,7 @@ export function PlanView(props: IProps) {
   const { rowInfo, publishingView, handlePublish, handleGraphic } = props;
   const { prjId } = useParams();
   const ctx = useContext(PlanContext);
-  const { shared, publishingOn } = ctx.state;
+  const { shared, publishingOn, canPublish } = ctx.state;
   const [srcMediaId, setSrcMediaId] = useState<string | undefined>(undefined);
   const [view, setView] = useState('');
   const [confirmPublish, setConfirmPublish] = useState(false);
@@ -141,6 +141,7 @@ export function PlanView(props: IProps) {
                 <Button
                   variant="outlined"
                   onClick={() => onPublish(i)}
+                  disabled={!canPublish}
                   sx={{
                     color: 'primary.light',
                     minWidth: 'auto',

--- a/src/renderer/src/components/Sheet/ScriptureTable.tsx
+++ b/src/renderer/src/components/Sheet/ScriptureTable.tsx
@@ -1860,6 +1860,7 @@ export function ScriptureTable(props: IProps) {
       doForceDataChanges.current = true;
     }
     setUpdate(false);
+    setTimeout(() => startSave(), 1000);
   };
 
   const onPublishing = async (update: boolean) => {

--- a/src/renderer/src/context/UnsavedContext.tsx
+++ b/src/renderer/src/context/UnsavedContext.tsx
@@ -304,7 +304,7 @@ const UnsavedProvider = (props: PropsWithChildren) => {
     setAlertOpen(false);
     startClear();
     forceClearPending();
-    finishConfirmed(savedMethod, 18);
+    finishConfirmed(savedMethod, 200);
   };
 
   const finishConfirmed = (
@@ -322,7 +322,7 @@ const UnsavedProvider = (props: PropsWithChildren) => {
     showMessage(t.saving);
     startSave();
     setAlertOpen(false);
-    finishConfirmed(savedMethod, 18);
+    finishConfirmed(savedMethod, 200);
   };
 
   return (


### PR DESCRIPTION
- PlanView.tsx — mobile Publish button now reads canPublish from PlanContext and is disabled={!canPublish}, matching the desktop PublishButton behavior.
- ScriptureTable.tsx — setSectionPublish now triggers startSave() after 1s, same pattern as updateTitleMedia, so publishing persists immediately instead of waiting for the next navigation.
- UnsavedContext.tsx — the Unsaved-Data-dialog save-confirmation timeout was raised from 18s (an outlier) to 200s, matching the convention used elsewhere in the app.
- AlertDialog.tsx — added mobile-aware Dialog-paper sizing (via useMobile()/useTheme()), fixing the "wrong place" positioning bug for the Unsaved Data dialog and every other confirmation dialog built on this shared component.