### PR TITLE
TT-7549 fix: show Switch Teams button for first-time mobile users

### DIFF
--- a/src/renderer/src/routes/ProjectsScreen.tsx
+++ b/src/renderer/src/routes/ProjectsScreen.tsx
@@ -16,6 +16,7 @@ import { remoteId, defaultWorkflow, useTeamWorkflowProcess } from '../crud';
 import { UnsavedContext } from '../context/UnsavedContext';
 import BigDialog from '../hoc/BigDialog';
 import { StepEditor } from '../components/StepEditor';
+import { useIsPapLike } from '../utils/useIsPapLike';
 
 interface ProjectBoxProps extends BoxProps {
   isMobile?: boolean;
@@ -32,14 +33,8 @@ export const ProjectsScreenInner: React.FC = () => {
   const navigate = useMyNavigate();
   const teamId = localStorage.getItem(localUserKey(LocalKey.team));
   const ctx = React.useContext(TeamContext);
-  const {
-    teamProjects,
-    personalProjects,
-    personalTeam,
-    teams,
-    teamDirectoryReady,
-    isAdmin,
-  } = ctx.state;
+  const { teamProjects, personalProjects, personalTeam, teams, isAdmin } =
+    ctx.state;
   const t: ICardsStrings = useSelector(cardsSelector, shallowEqual);
   const { pathname } = useLocation();
   const [plan] = useGlobal('plan');
@@ -74,11 +69,7 @@ export const ProjectsScreenInner: React.FC = () => {
   }, []);
 
   const isPersonal = teamId === personalTeam;
-  const isPapLike =
-    Boolean(personalTeam) &&
-    isPersonal &&
-    teams.length === 0 &&
-    teamDirectoryReady;
+  const isPapLike = useIsPapLike() && isPersonal;
   const projects = React.useMemo(
     () => (isPersonal ? personalProjects : teamId ? teamProjects(teamId) : []),
     [isPersonal, personalProjects, teamId, teamProjects]

--- a/src/renderer/src/routes/SwitchTeams.tsx
+++ b/src/renderer/src/routes/SwitchTeams.tsx
@@ -26,6 +26,7 @@ import { useGlobal } from '../context/useGlobal';
 import { useTeamActions } from '../components/Team/useTeamActions';
 import { SharedContentCreatorDialog } from '../components/Team/SharedContentCreatorDialog';
 import StickyRedirect from '../components/StickyRedirect';
+import { useIsPapLike } from '../utils/useIsPapLike';
 
 interface ISettingsButtonProps {
   label: string;
@@ -404,16 +405,8 @@ export const SwitchTeamsGuard: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const ctx = React.useContext(TeamContext);
-  const { teams, personalTeam, teamDirectoryReady } = ctx.state;
-  const [isOffline] = useGlobal('offline');
-  const [offlineOnly] = useGlobal('offlineOnly');
-  // When offline && !offlineOnly, getTeams() may be empty because shared teams
-  // without local projects are filtered out — not the same as true PAP-only.
-  const isPapLike =
-    Boolean(personalTeam) &&
-    teams.length === 0 &&
-    teamDirectoryReady &&
-    (!isOffline || offlineOnly);
+  const { personalTeam } = ctx.state;
+  const isPapLike = useIsPapLike();
 
   React.useEffect(() => {
     if (!isPapLike || !personalTeam) return;

--- a/src/renderer/src/utils/useIsPapLike.ts
+++ b/src/renderer/src/utils/useIsPapLike.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TeamContext } from '../context/TeamContext';
+import { useGlobal } from '../context/useGlobal';
+
+/**
+ * True when the signed-in user is Work-Alone-Offline / PAP-like: only a personal
+ * team exists and we can trust that emptiness. Detect "Work Alone Offline" via the
+ * `offlineOnly` global — NOT `teams.length === 0` alone, which is also true for a
+ * normal user who simply hasn't joined a team yet.
+ *
+ * When offline && !offlineOnly, getTeams() may be empty because shared teams
+ * without local projects are filtered out — not the same as true PAP-only.
+ */
+export const useIsPapLike = (): boolean => {
+  const ctx = React.useContext(TeamContext);
+  const { teams, personalTeam, teamDirectoryReady } = ctx.state;
+  const [isOffline] = useGlobal('offline');
+  const [offlineOnly] = useGlobal('offlineOnly');
+  return (
+    Boolean(personalTeam) &&
+    teams.length === 0 &&
+    teamDirectoryReady &&
+    (!isOffline || offlineOnly)
+  );
+};

--- a/src/renderer/src/utils/useIsPapLike.ts
+++ b/src/renderer/src/utils/useIsPapLike.ts
@@ -3,23 +3,19 @@ import { TeamContext } from '../context/TeamContext';
 import { useGlobal } from '../context/useGlobal';
 
 /**
- * True when the signed-in user is Work-Alone-Offline / PAP-like: only a personal
- * team exists and we can trust that emptiness. Detect "Work Alone Offline" via the
- * `offlineOnly` global — NOT `teams.length === 0` alone, which is also true for a
- * normal user who simply hasn't joined a team yet.
+ * True when the signed-in user is Work-Alone-Offline / PAP-like
  *
- * When offline && !offlineOnly, getTeams() may be empty because shared teams
- * without local projects are filtered out — not the same as true PAP-only.
+ * Detect "Work Alone Offline" via the `offlineOnly` global — `teams.length
+ * === 0` alone is not enough as it is also true for a normal user who simply hasn't joined a team yet.
+ * And not `!offline` (an online first-time user is online but still needs Switch
+ * Teams / Add Team). `offlineOnly` is set at login for users with no remoteId
+ * (see Access.tsx) and is the single reliable signal.
  */
 export const useIsPapLike = (): boolean => {
   const ctx = React.useContext(TeamContext);
   const { teams, personalTeam, teamDirectoryReady } = ctx.state;
-  const [isOffline] = useGlobal('offline');
   const [offlineOnly] = useGlobal('offlineOnly');
-  return (
-    Boolean(personalTeam) &&
-    teams.length === 0 &&
-    teamDirectoryReady &&
-    (!isOffline || offlineOnly)
+  return Boolean(
+    personalTeam && teams.length === 0 && teamDirectoryReady && offlineOnly
   );
 };


### PR DESCRIPTION
## Summary

Fixes [TT-7549](https://jira.sil.org/browse/TT-7549) — the **Switch Teams** button was missing for first-time mobile users, leaving them able to create/access only Personal Audio Projects with no path to Add Team or Team projects.

The button was hidden for any user whose only team is their personal team (`teams.length === 0`). That condition is also true for a normal first-time mobile user who simply hasn't joined a team yet — so they lost the button and, with it, the route to **Add Team**.

## Changes

- Detect true Work-Alone-Offline / PAP-like users via the existing `offlineOnly` global (the canonical Work-Alone-Offline signal set at login in `Access.tsx`), not empty-team-list alone.
- Extract the shared check into a new `useIsPapLike` hook (`utils/useIsPapLike.ts`, following the repo's one-hook-per-file convention) so `ProjectsScreen` and the `SwitchTeamsGuard` in `SwitchTeams` share one source of truth.
- `ProjectsScreen` now computes `isPapLike = useIsPapLike() && isPersonal`, replacing the inline `teams.length === 0 && teamDirectoryReady` check that lacked the `offlineOnly` gate.

## Test plan

- [ ] As a first-time mobile user (online, no teams yet): **Switch Teams** button is visible and leads to the picker / Add Team.
- [ ] As a Work-Alone-Offline (`offlineOnly`) user with only a personal team: **Switch Teams** button stays hidden (redirects to team home), preserving TT-6962 behavior.
- [ ] `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
