### PR TITLE
fix performance issues

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,9 +8,11 @@ import { useSelector, shallowEqual } from 'react-redux';
 import { IState } from './model';
 import { createAppTheme } from './theme';
 import { useMemo } from 'react';
+import { useRenderProfiler } from './utils/perf';
 export { HeadHeight } from './layout';
 
 function App(): React.JSX.Element {
+  useRenderProfiler('App');
   const lang = useSelector((state: IState) => state.strings.lang, shallowEqual);
 
   const theme = useMemo(() => createAppTheme(lang), [lang]);

--- a/src/renderer/src/Sources.tsx
+++ b/src/renderer/src/Sources.tsx
@@ -244,7 +244,18 @@ interface SourcesReturn {
   goRemote: boolean;
 }
 
-export const Sources = async (
+// Module-level reentrancy guard: two Sources() runs must never overlap. Each
+// call deactivates/reactivates the coordinator and recreates the remote source;
+// overlapping runs race on coordinator.deactivate() and can close the backup
+// IndexedDB under an in-flight memory->backup sync ("IndexedDB database is not
+// yet open"), which hangs the loading screen. A spurious second call (e.g. a
+// /loading remount firing fetchOrbitData again) now reuses the in-flight
+// promise instead of tearing the coordinator down under the first run. The
+// guard clears on completion so the next sequential login still runs fresh.
+// Mirrors restoreBackup's restorePromise pattern.
+let sourcesPromise: Promise<SourcesReturn> | null = null;
+
+const sourcesImpl = async (
   coordinator: Coordinator,
   tokenCtx: ITokenContext,
   fingerprint: string,
@@ -536,4 +547,14 @@ export const Sources = async (
     await updateConsultantWorkflowStep(token, memory, user);
   }
   return { syncBuffer, syncFile, goRemote };
+};
+
+export const Sources = (
+  ...args: Parameters<typeof sourcesImpl>
+): Promise<SourcesReturn> => {
+  if (sourcesPromise) return sourcesPromise; // dedupe concurrent invocations
+  sourcesPromise = sourcesImpl(...args).finally(() => {
+    sourcesPromise = null; // allow the next (sequential) login to run fresh
+  });
+  return sourcesPromise;
 };

--- a/src/renderer/src/components/PassageDetail/ConsultantCheckReview.tsx
+++ b/src/renderer/src/components/PassageDetail/ConsultantCheckReview.tsx
@@ -6,6 +6,7 @@ import { related } from '../../crud/related';
 import { ArtifactTypeSlug } from '../../crud/artifactTypeSlug';
 import { IRow } from '../../context/PassageDetailContext';
 import usePassageDetailContext from '../../context/usePassageDetailContext';
+import { useRenderProfiler, useWhyRender } from '../../utils/perf';
 import {
   FormControl,
   IconButton,
@@ -71,7 +72,9 @@ export default function ConsultantCheckReview({
   onPlayer,
   playId,
 }: IProps) {
+  useRenderProfiler('ConsultantCheckReview');
   const { rowData, mediafileId } = usePassageDetailContext();
+  useWhyRender('ConsultantCheckReview', { item, playId, rowData, mediafileId });
   const [allMedia, setAllMedia] = useState<MediaFileD[]>([]);
   const [segments, setSegments] = useState('');
   const [selectedLang, setSelectedLang] = useState<string>('');

--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -11,6 +11,7 @@ import { Box, Typography } from '@mui/material';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useGlobal } from '../../context/useGlobal';
 import usePassageDetailContext from '../../context/usePassageDetailContext';
+import { useRenderProfiler, useWhyRender } from '../../utils/perf';
 import PassageDetailPlayer from './PassageDetailPlayer';
 import StepMessage from './boldClause/StepMessage';
 import { remoteIdGuid, useArtifactType, useStepTool } from '../../crud';
@@ -98,6 +99,7 @@ export function PassageDetailGuidedPhraseRecord({
   controlStrings,
   workflowGateMessage,
 }: IProps) {
+  useRenderProfiler('PassageDetailGuidedPhraseRecord');
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
   const [memory] = useGlobal('memory');
   const [user] = useGlobal('user');
@@ -124,6 +126,18 @@ export function PassageDetailGuidedPhraseRecord({
     setStepComplete,
     stepComplete,
   } = usePassageDetailContext();
+  useWhyRender('PassageDetailGuidedPhraseRecord', {
+    passage,
+    playerMediafile,
+    mediafileId,
+    rowData,
+    currentstep,
+    currentSegmentIndex,
+    isBoldWorkflow,
+    stepComplete,
+    carefulSpeechSegParams,
+    mediafiles,
+  });
   const { settings } = useStepTool(currentstep);
   const stepSettings = useMemo((): Record<string, unknown> => {
     if (!settings) return {};

--- a/src/renderer/src/components/PassageDetail/PassageDetailPhraseBackTranslate.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailPhraseBackTranslate.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../crud';
 import { useGlobal } from '../../context/useGlobal';
 import usePassageDetailContext from '../../context/usePassageDetailContext';
+import { useRenderProfiler } from '../../utils/perf';
 import { NamedRegions } from '../../utils/namedSegments';
 import PassageDetailGuidedPhraseRecord from './PassageDetailGuidedPhraseRecord';
 import {
@@ -58,6 +59,7 @@ interface IProps {
 }
 
 export function PassageDetailPhraseBackTranslate({ width }: IProps) {
+  useRenderProfiler('PassageDetailPhraseBackTranslate');
   const [memory] = useGlobal('memory');
   const { currentstep } = usePassageDetailContext();
   const { settings } = useStepTool(currentstep);

--- a/src/renderer/src/components/PassageDetail/PassageDetailTranscribe.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailTranscribe.tsx
@@ -11,6 +11,7 @@ import { Grid, Typography, Box, BoxProps, styled } from '@mui/material';
 import { TranscriberProvider } from '../../context/TranscriberContext';
 import Transcriber from '../../components/Transcriber';
 import usePassageDetailContext from '../../context/usePassageDetailContext';
+import { useRenderProfiler, useWhyRender } from '../../utils/perf';
 import { sharedSelector, transcriberSelector } from '../../selector';
 import { shallowEqual, useSelector } from 'react-redux';
 import TaskList, { TaskTableWidth } from '../TaskList';
@@ -54,6 +55,7 @@ interface IProps {
 }
 
 export function PassageDetailTranscribe({ width, artifactTypeId }: IProps) {
+  useRenderProfiler('PassageDetailTranscribe');
   const {
     mediafileId,
     section,
@@ -66,6 +68,15 @@ export function PassageDetailTranscribe({ width, artifactTypeId }: IProps) {
     psgCompleted,
     passage,
   } = usePassageDetailContext();
+  useWhyRender('PassageDetailTranscribe', {
+    mediafileId,
+    section,
+    currentstep,
+    orgWorkflowSteps,
+    rowData,
+    psgCompleted,
+    passage,
+  });
   const { waitForSave } = useContext(UnsavedContext).state;
   const { setState } = useContext(PassageDetailContext);
   const { canDoSectionStep } = useStepPermissions();

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
@@ -16,6 +16,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { IGuidedPhraseRecordControlStrings } from '../guidedPhraseRecord/types';
+import { useRenderProfiler, useWhyRender } from '../../../utils/perf';
 
 export type CarefulSpeechPhase =
   | 'bootstrapping'
@@ -129,6 +130,20 @@ export default function CarefulSpeechControls({
   canPrevUnit = false,
   canNextUnit = false,
 }: Props) {
+  useRenderProfiler('CarefulSpeechControls');
+  useWhyRender('CarefulSpeechControls', {
+    phase,
+    currentRegion,
+    recordingPassStarted,
+    allClausesHeard,
+    allClausesComplete,
+    highlightSpeaker,
+    allowRecord,
+    savingRecording,
+    resetMedia,
+    recordingMediaId,
+    sourceSegments,
+  });
   const speakerInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {

--- a/src/renderer/src/components/Sheet/PlanBar.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanBar.cy.tsx
@@ -24,18 +24,16 @@ const createMockLiveQuery = () => ({
   query: () => [],
 });
 
-const createMockMemory = (organizations: any[] = []) =>
-  ({
+// useOrbitData reads records via memory.cache.query (not liveQuery.query), so
+// route cache.query through the same findRecords the live query uses.
+const createMockMemory = (organizations: any[] = []) => {
+  const findRecords = (type: string) =>
+    type === 'organization' ? organizations : [];
+  return {
     cache: {
-      query: () => [],
+      query: (queryBuildFn: (q: any) => any) => queryBuildFn({ findRecords }),
       liveQuery: (queryBuildFn: (q: any) => any) => {
-        const q = {
-          findRecords: (type: string) => {
-            if (type === 'organization') return organizations;
-            return [];
-          },
-        };
-        const records = queryBuildFn(q);
+        const records = queryBuildFn({ findRecords });
         return {
           subscribe: () => () => {},
           query: () => records,
@@ -43,7 +41,8 @@ const createMockMemory = (organizations: any[] = []) =>
       },
     },
     update: () => {},
-  }) as unknown as Memory;
+  } as unknown as Memory;
+};
 
 let currentTestMemory: Memory = createMockMemory();
 

--- a/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
+++ b/src/renderer/src/components/Sheet/PlanTabSelect.cy.tsx
@@ -33,19 +33,18 @@ const sectionsPassagesLabel = planTabsFixture.sectionsPassages.replace(
   organizedByDefault
 );
 
-// Mock memory — must match DataProvider so useOrbitData sees organizations (cypress-testing-takeaways: data-driven providers, not import stubs).
-const createMockMemory = (organizations: any[] = []) =>
-  ({
+// Mock memory — must match DataProvider so useOrbitData sees organizations
+// (cypress-testing-takeaways: data-driven providers, not import stubs).
+// useOrbitData reads records via memory.cache.query (not liveQuery.query), so
+// route cache.query through the same findRecords the live query uses.
+const createMockMemory = (organizations: any[] = []) => {
+  const findRecords = (type: string) =>
+    type === 'organization' ? organizations : [];
+  return {
     cache: {
-      query: () => [],
+      query: (queryBuildFn: (q: any) => any) => queryBuildFn({ findRecords }),
       liveQuery: (queryBuildFn: (q: any) => any) => {
-        const q = {
-          findRecords: (type: string) => {
-            if (type === 'organization') return organizations;
-            return [];
-          },
-        };
-        const records = queryBuildFn(q);
+        const records = queryBuildFn({ findRecords });
         return {
           subscribe: () => () => {},
           query: () => records,
@@ -53,7 +52,8 @@ const createMockMemory = (organizations: any[] = []) =>
       },
     },
     update: () => {},
-  }) as unknown as Memory;
+  } as unknown as Memory;
+};
 
 let currentTestMemory: Memory = createMockMemory();
 

--- a/src/renderer/src/components/UserMenu.tsx
+++ b/src/renderer/src/components/UserMenu.tsx
@@ -34,6 +34,7 @@ import {
   useTeamWorkflowProcess,
   BOLD_WORKFLOW_PROCESS,
 } from '../crud/useTeamWorkflowProcess';
+import { useRenderProfiler, useWhyRender } from '../utils/perf';
 
 const TermsItem = styled(StyledMenuItem)<MenuItemProps>(() => ({
   textAlign: 'center',
@@ -54,6 +55,7 @@ interface IProps {
 }
 
 export function UserMenu(props: IProps) {
+  useRenderProfiler('UserMenu');
   const { action } = props;
   const users = useOrbitData<User[]>('user');
   const [orgRole] = useGlobal('orgRole'); //verified this is not used in a function 2/18/25
@@ -74,6 +76,19 @@ export function UserMenu(props: IProps) {
   const { isMobileView, isMobileWidth } = useMobile();
   const t: IMainStrings = useSelector(mainSelector, shallowEqual);
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
+  useWhyRender('UserMenu', {
+    users,
+    user,
+    org,
+    orgRole,
+    isBoldWorkflow,
+    userIsAdmin,
+    addStoryOrPassage,
+    anchorEl,
+    userRec,
+    t,
+    ts,
+  });
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setShift(event.shiftKey);

--- a/src/renderer/src/context/GlobalContext.tsx
+++ b/src/renderer/src/context/GlobalContext.tsx
@@ -1,4 +1,5 @@
 import React, { useState, ReactNode } from 'react';
+import { useRenderProfiler } from '../utils/perf';
 import Coordinator from '@orbit/coordinator';
 import Memory from '@orbit/memory';
 import { AlertSeverity } from '../hoc/SnackBar';
@@ -73,6 +74,7 @@ interface GlobalProps {
 }
 
 const GlobalProvider: React.FC<GlobalProps> = ({ init, children }) => {
+  useRenderProfiler('GlobalProvider');
   const [globalState, setGlobalState] = useState<GlobalState>(init);
 
   return (

--- a/src/renderer/src/context/PassageDetailContext.tsx
+++ b/src/renderer/src/context/PassageDetailContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 // see: https://upmostly.com/tutorials/how-to-use-the-usecontext-hook-in-react
 import { useGetGlobal, useGlobal } from '../context/useGlobal';
+import { useRenderProfiler } from '../utils/perf';
 import { useParams } from 'react-router-dom';
 import { shallowEqual } from 'react-redux';
 import {
@@ -243,6 +244,7 @@ interface IProps {
   children: React.ReactElement;
 }
 const PassageDetailProvider = (props: IProps) => {
+  useRenderProfiler('PassageDetailProvider');
   const passages = useOrbitData<Passage[]>('passage');
   const sections = useOrbitData<Section[]>('section');
   const mediafiles = useOrbitData<MediaFileD[]>('mediafile');

--- a/src/renderer/src/context/TeamContext.tsx
+++ b/src/renderer/src/context/TeamContext.tsx
@@ -70,6 +70,7 @@ import {
   RecordTransformBuilder,
 } from '@orbit/records';
 import { useOrbitData } from '../hoc/useOrbitData';
+import { useRenderProfiler, useWhyRender } from '../utils/perf';
 import { ReplaceRelatedRecord, UpdateLastModifiedBy } from '../model/baseModel';
 import { projDefBook, useProjectDefaults } from '../crud/useProjectDefaults';
 import { pad3 } from '../utils/pad3';
@@ -154,6 +155,7 @@ interface IProps {
 }
 
 const TeamProvider = (props: IProps) => {
+  useRenderProfiler('TeamProvider');
   const projects = useOrbitData<ProjectD[]>('project');
   const plans = useOrbitData<PlanD[]>('plan');
   const planTypes = useOrbitData<PlanTypeD[]>('plantype');
@@ -428,6 +430,23 @@ const TeamProvider = (props: IProps) => {
 
     return projects.filter((p) => grpIds.includes(related(p, 'group')));
   }, [projects, groupMemberships, user]);
+
+  useWhyRender('TeamProvider', {
+    projects,
+    plans,
+    planTypes,
+    organizations,
+    orgMembers,
+    groupMemberships,
+    sections,
+    passages,
+    userProjects,
+    personalTeam: state.personalTeam,
+    personalProjects: state.personalProjects,
+    teams: state.teams,
+    importOpen,
+    importProject,
+  });
 
   // cache plan sort values to avoid recalculating
   const planSortMap = new Map<string, string>();

--- a/src/renderer/src/context/useGlobal.ts
+++ b/src/renderer/src/context/useGlobal.ts
@@ -7,6 +7,7 @@ import {
   GetGlobalType,
 } from './GlobalContext';
 import { debounce } from 'lodash';
+import { perfRecordGlobalSet } from '../utils/perf';
 
 const changes = {} as GlobalState;
 
@@ -28,6 +29,7 @@ export const useGlobal = <K extends GlobalKey>(
 
   const setter = (val: GlobalState[K]) => {
     if (val === (changes[prop] ?? globalState[prop])) return; // ignore set to same value
+    perfRecordGlobalSet(prop as string); // instrumentation: track cascade drivers
     changes[prop] = val; // keep track of all changes
     handleChange(); // post them as react can handle them
   };

--- a/src/renderer/src/hoc/DataChanges.tsx
+++ b/src/renderer/src/hoc/DataChanges.tsx
@@ -25,8 +25,10 @@ import { useBibleMedia } from '../crud/useBibleMedia';
 import { useDispatch } from 'react-redux';
 import { useOrbitData } from './useOrbitData';
 import { doDataChanges } from './doDataChanges';
+import { useRenderProfiler, perfRecordMs } from '../utils/perf';
 
 export function DataChanges(props: PropsWithChildren) {
+  useRenderProfiler('DataChanges');
   const { children } = props;
   const dispatch = useDispatch();
   const setLanguage = (lang: string) =>
@@ -94,6 +96,7 @@ export function DataChanges(props: PropsWithChildren) {
   }, [remote, ctx, loadComplete, connected, firstRun, userDataDelay]);
 
   const updateBusy = useCallback(() => {
+    const t0 = performance.now();
     const checkBusy =
       getGlobal('user') === '' ||
       (remote && remote.requestQueue.length !== 0) ||
@@ -108,10 +111,12 @@ export function DataChanges(props: PropsWithChildren) {
     } else if (checkBusy !== getGlobal('remoteBusy')) {
       setBusy(checkBusy);
     }
+    perfRecordMs('DataChanges.updateBusy', performance.now() - t0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [remote, user]);
 
   const updateData = async () => {
+    const t0 = performance.now();
     if (
       !doingChanges.current &&
       !getGlobal('remoteBusy') &&
@@ -143,6 +148,7 @@ export function DataChanges(props: PropsWithChildren) {
           await doSanityCheck(getGlobal('projectsLoaded')[ix] as string);
       }
       doingChanges.current = false; //attempt to prevent double calls
+      perfRecordMs('DataChanges.updateData', performance.now() - t0);
     }
   };
 

--- a/src/renderer/src/hoc/DataProvider.tsx
+++ b/src/renderer/src/hoc/DataProvider.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useRef } from 'react';
 import MemorySource from '@orbit/memory';
 import { UninitializedRecord } from '@orbit/records';
 import { OrbitContext } from './OrbitContextProvider';
@@ -10,7 +10,9 @@ interface DataProviderProps extends PropsWithChildren {
 type IRecs = UninitializedRecord[] | undefined;
 
 export const DataProvider = ({ dataStore, children }: DataProviderProps) => {
-  const recMap = new Map<string, IRecs>();
+  // Keep the cache stable across DataProvider re-renders. A fresh `new Map()`
+  // per render would silently drop every cached record set.
+  const recMap = useRef(new Map<string, IRecs>()).current;
 
   const getRecs = (type: string) => recMap.get(type);
   const setRecs = (type: string, recs: IRecs) => recMap.set(type, recs);

--- a/src/renderer/src/hoc/useOrbitData.ts
+++ b/src/renderer/src/hoc/useOrbitData.ts
@@ -1,43 +1,65 @@
-import { useLayoutEffect, useContext, useState, useRef, useMemo } from 'react';
+import { useContext, useState, useEffect, useCallback } from 'react';
 import { OrbitContext } from './OrbitContextProvider';
-import { ReactIsInDevelomentMode } from '../utils/ReactIsInDevelopmentMode';
 import { UninitializedRecord } from '@orbit/records';
+import { useRenderProfiler, perfRecordGlobalSet } from '../utils/perf';
 
+// Stable empty result used before the memory source is available, so we don't
+// hand back a fresh array identity on every render.
+const EMPTY: UninitializedRecord[] = [];
+
+/**
+ * Subscribe a component to the live set of Orbit records for `model`.
+ *
+ * Design notes (this hook has been a source of subtle bugs):
+ *
+ * - One subscription per mount, established in a useEffect and cleaned up on
+ *   unmount. The original implementation subscribed *during render* and never
+ *   unsubscribed the prior subscription, so every data change fired an
+ *   ever-growing pile of callbacks — each triggering another render + another
+ *   subscription — a self-amplifying render storm.
+ *
+ * - Data is read with `memory.cache.query` (the canonical synchronous read used
+ *   throughout the codebase), NOT `liveQuery.query()`, which returns the live
+ *   query's own internal snapshot and is stale until re-evaluated. The
+ *   liveQuery is used purely as a change signal.
+ *
+ * - A catch-up read runs immediately after subscribing. Records can finish
+ *   loading (e.g. a backup restore from IndexedDB) in the window between the
+ *   first render and the effect wiring up the subscription; without the
+ *   catch-up the component would keep showing the empty initial snapshot and
+ *   never update (which left teams/projects blank on some loads).
+ *
+ * Reference stability: `records` state only changes when the subscription fires
+ * (an actual data change) or on the one-time mount catch-up, so consumers that
+ * use the result in useMemo/useEffect deps see a stable array between changes.
+ */
 export function useOrbitData<S extends UninitializedRecord[]>(
   model: string
 ): S {
-  const { memory, getRecs, setRecs } = useContext(OrbitContext);
-  const [newValue, setNewValue] = useState(0);
-  const mounted = useRef(0);
+  useRenderProfiler(`useOrbitData:${model}`);
+  const { memory } = useContext(OrbitContext);
 
-  const isDev = useMemo(() => ReactIsInDevelomentMode(), []);
+  const read = useCallback(
+    (): S =>
+      memory
+        ? (memory.cache.query((q) => q.findRecords(model)) as S)
+        : (EMPTY as S),
+    [memory, model]
+  );
 
-  const liveQuery = memory?.cache.liveQuery((q) => q.findRecords(model));
+  const [records, setRecords] = useState<S>(read);
 
-  const unsubscribe = liveQuery.subscribe((update) => {
-    update && update.query();
-    setRecs(model, undefined);
-    setNewValue(newValue + 1);
-  });
+  useEffect(() => {
+    if (!memory) return;
+    const liveQuery = memory.cache.liveQuery((q) => q.findRecords(model));
+    const unsubscribe = liveQuery.subscribe(() => {
+      perfRecordGlobalSet(`orbitUpdate:${model}`); // data-driven refresh
+      setRecords(read());
+    });
+    // Catch up on anything that changed between the initial render and here.
+    setRecords(read());
+    return unsubscribe;
+  }, [memory, model, read]);
 
-  // Only allow unsubscribe if actually unmounting
-  useLayoutEffect(() => {
-    mounted.current += 1;
-    return () => {
-      if (!isDev || mounted.current > 1) {
-        unsubscribe();
-        // setRecs(model, undefined);
-        mounted.current = 0;
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const current = getRecs(model);
-  if (current) {
-    return current as S;
-  }
-  const records = liveQuery.query() as S;
-  setRecs(model, records);
-  return records as S;
+  return records;
 }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -5,6 +5,7 @@ import '../src/index.css';
 import { coordinator, memory } from '../src/schema';
 import Bugsnag from '@bugsnag/js';
 import { LocalKey, localUserKey, Online } from '../src/utils';
+import '../src/utils/perf'; // registers window.aptPerf + long-task observer early
 import { isElectron, OrbitNetworkErrorRetries } from '../api-variable';
 import { GlobalProvider } from '../src/context/GlobalContext';
 import bugsnagClient from '../src/auth/bugsnagClient';

--- a/src/renderer/src/utils/index.ts
+++ b/src/renderer/src/utils/index.ts
@@ -23,6 +23,7 @@ export * from './relMouseCoords';
 export * from './resetData';
 export * from './sort';
 export * from './toCamel';
+export * from './perf';
 export * from './uiLang';
 export * from './updateXml';
 export * from './useInterval';

--- a/src/renderer/src/utils/perf.ts
+++ b/src/renderer/src/utils/perf.ts
@@ -1,0 +1,451 @@
+/**
+ * Lightweight, opt-in performance instrumentation.
+ *
+ * Goal: find out why the app becomes unresponsive — which components re-render
+ * in storms, which effects/memos are slow, which global-state keys churn, and
+ * what long-tasks block the main thread (so clicks/dialogs feel delayed).
+ *
+ * ── Turn it on (in the app's devtools console) ─────────────────────────────
+ *     aptPerf.on()        // enables + reloads
+ *   or set localStorage 'perfDebug' = '1' and reload.
+ *
+ * ── Reproduce the problem, then get a report ───────────────────────────────
+ *     aptPerf.report()    // prints tables + copies a text report to clipboard
+ *     aptPerf.reset()     // zero the counters (e.g. right before a repro step)
+ *     aptPerf.auto(5000)  // print a compact summary every 5s (0 to stop)
+ *     aptPerf.off()       // disable + reload
+ *
+ * Everything is a no-op with near-zero cost when disabled, so it is safe to
+ * leave the instrumentation calls in place.
+ */
+
+/* eslint-disable react-hooks/refs */
+// This is an opt-in debug utility: it intentionally reads refs across renders
+// (to compare previous vs current values) and logs to the console.
+import { useEffect, useMemo, useRef } from 'react';
+
+const FLAG = 'perfDebug';
+
+let enabled = false;
+try {
+  enabled =
+    typeof localStorage !== 'undefined' && localStorage.getItem(FLAG) === '1';
+} catch {
+  enabled = false;
+}
+
+export const perfEnabled = (): boolean => enabled;
+
+const now = (): number =>
+  typeof performance !== 'undefined' ? performance.now() : 0;
+
+type Kind = 'render' | 'effect' | 'memo' | 'global' | 'longtask' | 'fn';
+
+interface Stat {
+  kind: Kind;
+  label: string;
+  count: number;
+  totalMs: number;
+  maxMs: number;
+  lastTs: number;
+  /** recent fire times (perf clock) for burst/storm detection */
+  recent: number[];
+  /** for effects/memos: how many times a given dep index was the one that changed */
+  depChanges?: Record<number, number>;
+}
+
+const registry = new Map<string, Stat>();
+const RECENT_WINDOW_MS = 1000;
+const RECENT_MAX = 200;
+
+const keyFor = (kind: Kind, label: string) => `${kind}::${label}`;
+
+const stat = (kind: Kind, label: string): Stat => {
+  const k = keyFor(kind, label);
+  let s = registry.get(k);
+  if (!s) {
+    s = { kind, label, count: 0, totalMs: 0, maxMs: 0, lastTs: 0, recent: [] };
+    registry.set(k, s);
+  }
+  return s;
+};
+
+const record = (kind: Kind, label: string, ms: number, depIdx?: number) => {
+  const s = stat(kind, label);
+  const t = now();
+  s.count += 1;
+  s.totalMs += ms;
+  if (ms > s.maxMs) s.maxMs = ms;
+  s.lastTs = t;
+  s.recent.push(t);
+  if (s.recent.length > RECENT_MAX) s.recent.shift();
+  if (depIdx !== undefined && depIdx >= 0) {
+    if (!s.depChanges) s.depChanges = {};
+    s.depChanges[depIdx] = (s.depChanges[depIdx] ?? 0) + 1;
+  }
+};
+
+/** peak fires within any RECENT_WINDOW_MS sliding window (storm intensity) */
+const peakBurst = (s: Stat): number => {
+  if (s.recent.length === 0) return 0;
+  let peak = 0;
+  let start = 0;
+  for (let end = 0; end < s.recent.length; end++) {
+    while (s.recent[end] - s.recent[start] > RECENT_WINDOW_MS) start++;
+    peak = Math.max(peak, end - start + 1);
+  }
+  return peak;
+};
+
+// ── Public recording helpers (used by non-hook call sites) ──────────────────
+
+/** Record an explicit global-state key mutation (called from useGlobal setter). */
+export const perfRecordGlobalSet = (prop: string): void => {
+  if (!enabled) return;
+  record('global', prop, 0);
+};
+
+/** Record a pre-measured duration (for async work you time yourself). */
+export const perfRecordMs = (label: string, ms: number): void => {
+  if (!enabled) return;
+  record('fn', label, ms);
+};
+
+/** Time an arbitrary function and record it under `label`. */
+export const perfTime = <T>(label: string, fn: () => T): T => {
+  if (!enabled) return fn();
+  const t = now();
+  try {
+    return fn();
+  } finally {
+    record('fn', label, now() - t);
+  }
+};
+
+// ── Hooks ───────────────────────────────────────────────────────────────────
+
+/**
+ * Count renders of a component and detect render storms.
+ * Drop `useRenderProfiler('MyComponent')` at the top of a component body.
+ */
+export const useRenderProfiler = (label: string): void => {
+  const last = useRef(0);
+  if (!enabled) return;
+  const t = now();
+  const delta = last.current ? t - last.current : 0;
+  last.current = t;
+  // ms field here stores inter-render gap so maxMs = longest gap (not useful);
+  // we mainly want count + burst, so store 0 for time.
+  record('render', label, 0);
+  // stash the tightest gap in depChanges[0] as a proxy (optional)
+  if (delta > 0 && delta < 16) {
+    const s = stat('render', label);
+    s.depChanges = s.depChanges ?? {};
+    s.depChanges[0] = (s.depChanges[0] ?? 0) + 1; // renders <16ms apart (back-to-back)
+  }
+};
+
+const changedDepIndex = (
+  prev: readonly any[] | undefined,
+  next: readonly any[]
+): number => {
+  if (!prev) return -1;
+  const len = Math.max(prev.length, next.length);
+  for (let i = 0; i < len; i++) {
+    if (!Object.is(prev[i], next[i])) return i;
+  }
+  return -1;
+};
+
+/**
+ * Drop-in replacement for useEffect that times the effect body and records
+ * which dependency index changed to trigger it.
+ */
+export const useTimedEffect = (
+  label: string,
+  effect: () => void | (() => void),
+  deps: readonly any[]
+): void => {
+  const prev = useRef<readonly any[] | undefined>(undefined);
+  useEffect(() => {
+    if (!enabled) return effect();
+    const depIdx = changedDepIndex(prev.current, deps);
+    prev.current = deps;
+    const t = now();
+    const cleanup = effect();
+    record('effect', label, now() - t, depIdx);
+    return cleanup;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};
+
+/**
+ * Drop-in replacement for useMemo that times the factory and records which
+ * dependency changed to trigger the recompute.
+ */
+export const useTimedMemo = <T>(
+  label: string,
+  factory: () => T,
+  deps: readonly any[]
+): T => {
+  const prev = useRef<readonly any[] | undefined>(undefined);
+
+  return useMemo(() => {
+    if (!enabled) return factory();
+    const depIdx = changedDepIndex(prev.current, deps);
+    prev.current = deps;
+    const t = now();
+    const value = factory();
+    record('memo', label, now() - t, depIdx);
+    return value;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};
+
+/**
+ * Log which *named* dependency changed between renders — the fastest way to
+ * find "why is this component re-rendering so much". Pass an object of the
+ * props/values you suspect: useWhyRender('UserMenu', { user, users, org }).
+ */
+export const useWhyRender = (
+  label: string,
+  watched: Record<string, any>
+): void => {
+  const prev = useRef<Record<string, any> | undefined>(undefined);
+  if (!enabled) return;
+  const before = prev.current;
+  prev.current = { ...watched };
+  if (!before) return;
+  const changed: string[] = [];
+  for (const k of Object.keys(watched)) {
+    if (!Object.is(before[k], watched[k])) changed.push(k);
+  }
+  if (changed.length) {
+    for (const k of changed) record('render', `${label}⇐${k}`, 0);
+  } else {
+    // re-rendered but none of the watched values changed → parent/context churn
+    record('render', `${label}⇐(context/parent)`, 0);
+  }
+};
+
+// ── Long-task observer (why do clicks/dialogs feel delayed?) ────────────────
+
+let longTaskObserver: PerformanceObserver | undefined;
+const startLongTaskObserver = () => {
+  if (
+    !enabled ||
+    longTaskObserver ||
+    typeof PerformanceObserver === 'undefined'
+  )
+    return;
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        record('longtask', 'main-thread-block', entry.duration);
+        if (entry.duration >= 200) {
+          console.warn(
+            `[aptPerf] LONG TASK ${Math.round(entry.duration)}ms blocked the main thread`
+          );
+        }
+      }
+    });
+    longTaskObserver.observe({ entryTypes: ['longtask'] });
+  } catch {
+    /* longtask not supported */
+  }
+};
+
+// ── Reporting ───────────────────────────────────────────────────────────────
+
+const fmt = (n: number) => Math.round(n * 10) / 10;
+
+const buildReport = (): string => {
+  const lines: string[] = [];
+  const all = [...registry.values()];
+
+  const section = (
+    title: string,
+    kinds: Kind[],
+    sortBy: (s: Stat) => number,
+    cols: (s: Stat) => Record<string, string | number>
+  ) => {
+    const rows = all
+      .filter((s) => kinds.includes(s.kind))
+      .sort((a, b) => sortBy(b) - sortBy(a))
+      .slice(0, 40);
+    if (!rows.length) return;
+    lines.push(`\n## ${title}`);
+    for (const s of rows) {
+      const c = cols(s);
+      lines.push(
+        '  ' +
+          Object.entries(c)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('  ')
+      );
+    }
+    // also print as a table for interactive inspection
+
+    console.log(`%c${title}`, 'font-weight:bold');
+
+    console.table(rows.map((s) => cols(s)));
+  };
+
+  section(
+    'RENDERS (by count) — look for storms: high count + high peak/sec',
+    ['render'],
+    (s) => s.count,
+    (s) => ({
+      component: s.label,
+      renders: s.count,
+      'peak/sec': peakBurst(s),
+      'back2back<16ms': s.depChanges?.[0] ?? 0,
+    })
+  );
+
+  section(
+    'EFFECTS (by total ms) — slow or too-frequent effects',
+    ['effect'],
+    (s) => s.totalMs,
+    (s) => ({
+      effect: s.label,
+      runs: s.count,
+      totalMs: fmt(s.totalMs),
+      maxMs: fmt(s.maxMs),
+      'peak/sec': peakBurst(s),
+      hotDep: s.depChanges
+        ? Object.entries(s.depChanges).sort((a, b) => b[1] - a[1])[0]?.[0]
+        : '',
+    })
+  );
+
+  section(
+    'MEMOS (by total ms) — expensive or thrashing memos',
+    ['memo'],
+    (s) => s.totalMs,
+    (s) => ({
+      memo: s.label,
+      recomputes: s.count,
+      totalMs: fmt(s.totalMs),
+      maxMs: fmt(s.maxMs),
+      'peak/sec': peakBurst(s),
+      hotDep: s.depChanges
+        ? Object.entries(s.depChanges).sort((a, b) => b[1] - a[1])[0]?.[0]
+        : '',
+    })
+  );
+
+  section(
+    'GLOBAL STATE writes (by count) — cascade drivers',
+    ['global'],
+    (s) => s.count,
+    (s) => ({ key: s.label, writes: s.count, 'peak/sec': peakBurst(s) })
+  );
+
+  section(
+    'PLAIN FUNCTIONS (by total ms)',
+    ['fn'],
+    (s) => s.totalMs,
+    (s) => ({
+      fn: s.label,
+      calls: s.count,
+      totalMs: fmt(s.totalMs),
+      maxMs: fmt(s.maxMs),
+    })
+  );
+
+  const lt = registry.get(keyFor('longtask', 'main-thread-block'));
+  if (lt) {
+    lines.push(
+      `\n## LONG TASKS (main-thread blocks ≥50ms — cause of click/dialog delay)`
+    );
+    lines.push(
+      `  count=${lt.count}  totalMs=${fmt(lt.totalMs)}  worstMs=${fmt(lt.maxMs)}  peak/sec=${peakBurst(lt)}`
+    );
+  }
+
+  const header =
+    `# aptPerf report @ ${new Date().toISOString()}\n` +
+    `enabled=${enabled}  tracked=${registry.size} labels`;
+  return header + '\n' + lines.join('\n') + '\n';
+};
+
+const report = (): string => {
+  const text = buildReport();
+
+  console.log(text);
+  try {
+    // best-effort clipboard copy so the report is easy to paste back
+    (navigator as any)?.clipboard?.writeText?.(text);
+
+    console.log('%c[aptPerf] report copied to clipboard', 'color:green');
+  } catch {
+    /* clipboard unavailable */
+  }
+  return text;
+};
+
+const reset = () => {
+  registry.clear();
+
+  console.log('[aptPerf] counters reset');
+};
+
+let autoTimer: ReturnType<typeof setInterval> | undefined;
+const auto = (ms: number) => {
+  if (autoTimer) {
+    clearInterval(autoTimer);
+    autoTimer = undefined;
+  }
+  if (ms > 0) {
+    autoTimer = setInterval(() => {
+      const renders = [...registry.values()]
+        .filter((s) => s.kind === 'render')
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5)
+        .map((s) => `${s.label}:${s.count}`)
+        .join('  ');
+
+      console.log(`[aptPerf] top renders — ${renders}`);
+    }, ms);
+  }
+};
+
+const on = () => {
+  try {
+    localStorage.setItem(FLAG, '1');
+  } catch {
+    /* ignore */
+  }
+  location.reload();
+};
+const off = () => {
+  try {
+    localStorage.removeItem(FLAG);
+  } catch {
+    /* ignore */
+  }
+  location.reload();
+};
+
+// Expose a console API regardless of enabled state so `aptPerf.on()` works.
+if (typeof window !== 'undefined') {
+  (window as any).aptPerf = {
+    on,
+    off,
+    report,
+    reset,
+    auto,
+    enabled: () => enabled,
+    _registry: registry,
+  };
+}
+
+if (enabled) {
+  startLongTaskObserver();
+
+  console.log(
+    '%c[aptPerf] instrumentation ON — reproduce the issue, then run aptPerf.report()',
+    'color:orange;font-weight:bold'
+  );
+}


### PR DESCRIPTION
The original symptom — "too busy to respond, can't click the avatar" — traced to useOrbitData accumulating subscriptions on every render. That's gone: idle is silent and the avatar/menu respond promptly.

Added performance analysis logic aptPerf.on() and aptPerf.report() (from dev console)

* useOrbitData.ts
- Sustained render storm (200 renders/sec, 73s blocking)
- useOrbitData subscribes once per mount instead of every render

* useOrbitData.ts
- Blank/stuck loading
- fresh memory.cache.query reads + catch-up read after subscribe

* Sources.tsx
- Login hang on fresh storage
- Sources() reentrancy guard (no concurrent coordinator teardown)

