### PR TITLE
TT-6473,7395,7396 fix: spell-check step settings consistency

### DIFF
--- a/src/renderer/src/components/StepEditor/TranscribeStepSettings.tsx
+++ b/src/renderer/src/components/StepEditor/TranscribeStepSettings.tsx
@@ -516,15 +516,29 @@ export const TranscribeStepSettings = ({
         initialValue={initialValue}
       />
       {currentSlug === ArtifactTypeSlug.Vernacular ? (
-        <Language
-          key={`vernacular-${vernacularLanguage?.bcp47 ?? 'und'}`}
-          {...vernacularLanguage}
-          onChange={handleVernacularLanguageChange}
-          hideFont
-          required={true}
-          disabled={false}
-          sx={{ ml: 1 }}
-        />
+        <>
+          <Language
+            key={`vernacular-${vernacularLanguage?.bcp47 ?? 'und'}`}
+            {...vernacularLanguage}
+            onChange={handleVernacularLanguageChange}
+            hideFont
+            hideSpelling
+            required={true}
+            disabled={false}
+            sx={{ ml: 1 }}
+          />
+          <FormControlLabel
+            sx={{ ml: 1, display: 'block' }}
+            control={
+              <Checkbox
+                id="transcribe-step-spellCheck"
+                checked={lgState.spellCheck}
+                onChange={(e) => handleSpellCheckOnlyChange(e.target.checked)}
+              />
+            }
+            label={t.spellCheck}
+          />
+        </>
       ) : (
         <>
           {hasLang && (

--- a/src/renderer/src/components/Transcriber.tsx
+++ b/src/renderer/src/components/Transcriber.tsx
@@ -1515,7 +1515,7 @@ export function Transcriber(props: IProps) {
                     <Settings />
                   </IconButton>
                 </LightTooltip>
-                {isElectron && <Spelling />}
+                {isElectron && projData?.spellCheck === true && <Spelling />}
               </Box>
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
                 <LastEdit

--- a/src/renderer/src/crud/stepSpellCheck.test.ts
+++ b/src/renderer/src/crud/stepSpellCheck.test.ts
@@ -70,7 +70,7 @@ describe('resolveStepSpellCheck', () => {
     ).toBe(true);
   });
 
-  test('defaults back translation to false without dictionary', () => {
+  test('defaults back translation to true even without dictionary (Desktop)', () => {
     expect(
       resolveStepSpellCheck(
         {},
@@ -78,7 +78,15 @@ describe('resolveStepSpellCheck', () => {
         'de',
         avail
       )
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      resolveStepSpellCheck(
+        {},
+        ArtifactTypeSlug.PhraseBackTranslation,
+        'und',
+        avail
+      )
+    ).toBe(true);
   });
 
   test('defaults back translation to true when checker languages are unavailable', () => {
@@ -99,7 +107,7 @@ describe('defaultSpellCheckForArtifact', () => {
     expect(
       defaultSpellCheckForArtifact(
         ArtifactTypeSlug.PhraseBackTranslation,
-        'en',
+        'de',
         ['en-US']
       )
     ).toBe(true);

--- a/src/renderer/src/crud/stepSpellCheck.ts
+++ b/src/renderer/src/crud/stepSpellCheck.ts
@@ -26,8 +26,8 @@ export function hasSpellCheckerDictionary(
 /** Default spell check when step settings omit `spellCheck`. */
 export function defaultSpellCheckForArtifact(
   artifactTypeSlug: ArtifactTypeSlug | string | undefined,
-  bcp47: string | undefined,
-  availLangs?: string[]
+  _bcp47?: string,
+  _availLangs?: string[]
 ): boolean {
   if (!artifactTypeSlug || artifactTypeSlug === ArtifactTypeSlug.Vernacular) {
     return false;
@@ -39,9 +39,9 @@ export function defaultSpellCheckForArtifact(
     artifactTypeSlug === ArtifactTypeSlug.PhraseBackTranslation ||
     artifactTypeSlug === ArtifactTypeSlug.WholeBackTranslation
   ) {
-    // When checker languages are unknown (e.g. getArtTypeFontData), default on.
-    if (!availLangs?.length) return true;
-    return hasSpellCheckerDictionary(bcp47, availLangs);
+    // Match Web and offline workflow seeding: PBT/WBT default on.
+    // Dictionary availability should not hide the step checkbox on Desktop.
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
Default PBT/WBT spell check on for Desktop, wire Vernacular to step settings, and hide Spelling languages when spell check is off.