### PR TITLE
TT-7478 fix: keep discussion More menu for Paratext authors

### DIFF
--- a/src/renderer/src/components/Discussions/CommentCard.tsx
+++ b/src/renderer/src/components/Discussions/CommentCard.tsx
@@ -300,6 +300,16 @@ export const CommentCard = (props: IProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [comment, users]);
 
+  // Own-comment gate: compare session user to relationship ids directly.
+  // Looking up `author` via the users table can drift after Paratext sync
+  // when comment attribution lands on a linked identity (TT-7478).
+  const canManageComment =
+    mediaId !== commentPlayId &&
+    !oldVernVer &&
+    (related(comment, 'creatorUser') === user ||
+      related(comment, 'lastModifiedByUser') === user ||
+      getMentorAuthor(comment.attributes?.visible ?? '') === user);
+
   return (
     <StyledWrapper>
       <BoxBorderRow>
@@ -346,9 +356,7 @@ export const CommentCard = (props: IProps) => {
                   </FormLabel>
                 )
               ))}
-            {mediaId !== commentPlayId &&
-              author?.id === user &&
-              !oldVernVer && (
+            {canManageComment && (
                 <Box>
                   <DiscussionMenu
                     action={handleCommentAction}


### PR DESCRIPTION
Gate comment edit/delete on creator/lastModified/mentor ids so Paratext sync identity drift does not hide the menu.