### PR TITLE
TT-7359 fix: name downloads with playable media extensions

### DIFF
--- a/src/renderer/src/components/downloadMediaFileName.test.ts
+++ b/src/renderer/src/components/downloadMediaFileName.test.ts
@@ -1,0 +1,32 @@
+import { downloadMediaFileName } from './downloadMediaFileName';
+import { MediaFileD } from '../model';
+
+describe('downloadMediaFileName', () => {
+  test('uses originalFile stem and contentType when s3file has no extension', () => {
+    const media = {
+      id: 'm1',
+      type: 'mediafile',
+      attributes: {
+        s3file: 'deadbeef',
+        originalFile: 'prompt-section1.ogg',
+        contentType: 'audio/ogg;codecs=opus',
+        versionNumber: 2,
+      },
+    } as MediaFileD;
+    expect(downloadMediaFileName(media, 'm1')).toBe('prompt-section1-ver2.ogg');
+  });
+
+  test('falls back to contentType when originalFile lacks a safe extension', () => {
+    const media = {
+      id: 'm2',
+      type: 'mediafile',
+      attributes: {
+        s3file: 'org/plan/key',
+        originalFile: 'org/plan/key',
+        contentType: 'audio/wav',
+        versionNumber: 1,
+      },
+    } as MediaFileD;
+    expect(downloadMediaFileName(media, 'm2')).toBe('key-ver1.wav');
+  });
+});

--- a/src/renderer/src/components/downloadMediaFileName.ts
+++ b/src/renderer/src/components/downloadMediaFileName.ts
@@ -1,0 +1,34 @@
+import path from 'path-browserify';
+import { MediaFileD } from '../model';
+import { mediaFileName } from '../crud/media';
+import { removeExtension } from '../utils/removeExtension';
+import getMediaExt from '../utils/getMediaExt';
+
+/** Prefer originalFile basename; fall back to mediaFileName for stem. */
+export const downloadMediaStem = (mediaRec: MediaFileD, id: string): string => {
+  const original = mediaRec?.attributes?.originalFile || '';
+  const fromOriginal = path.basename(
+    (original.split('?')[0] || '').replace(/\\/g, '/')
+  );
+  if (fromOriginal) {
+    const { name } = removeExtension(fromOriginal);
+    if (name) return name;
+  }
+  const fullName = mediaFileName(mediaRec) || `media-${id}`;
+  const base = path.basename(
+    (fullName.split('?')[0] || '').replace(/\\/g, '/')
+  );
+  const { name } = removeExtension(base);
+  return name || `media-${id}`;
+};
+
+/** Build a playable download filename (TT-7359). */
+export const downloadMediaFileName = (
+  mediaRec: MediaFileD,
+  id: string
+): string => {
+  const name = downloadMediaStem(mediaRec, id);
+  const ext = getMediaExt(mediaRec);
+  const version = mediaRec?.attributes?.versionNumber || '1';
+  return `${name}-ver${version}.${ext}`;
+};

--- a/src/renderer/src/components/useAudioDownload.tsx
+++ b/src/renderer/src/components/useAudioDownload.tsx
@@ -5,13 +5,13 @@ import {
   remoteIdGuid,
   useFetchMediaUrl,
   MediaSt,
-  mediaFileName,
 } from '../crud';
-import { loadBlob, removeExtension } from '../utils';
+import { loadBlob } from '../utils';
 import { useSnackBar } from '../hoc/SnackBar';
 import { useSelector } from 'react-redux';
 import { sharedSelector } from '../selector';
 import { RecordKeyMap } from '@orbit/records';
+import { downloadMediaFileName } from './downloadMediaFileName';
 
 export interface AudioDownloadApi {
   startDownload: (event?: React.MouseEvent<HTMLElement>) => void;
@@ -69,10 +69,7 @@ export function useAudioDownload(mediaId: string): AudioDownloadApi {
       const mediaRec = memory.cache.query((q) =>
         q.findRecord({ type: 'mediafile', id })
       ) as MediaFileD;
-      const fullName = mediaFileName(mediaRec) || `media-${id}`;
-      const { name, ext } = removeExtension(fullName);
-      const version = mediaRec?.attributes?.versionNumber || '1';
-      setAudName(`${name}-ver${version}.${ext}`);
+      setAudName(downloadMediaFileName(mediaRec, id));
       if (id !== mediaState.id) {
         fetchMediaUrl({ id });
       }
@@ -119,13 +116,7 @@ export function useAudioDownload(mediaId: string): AudioDownloadApi {
   }, [blobUrl, audName]);
 
   const hiddenAnchor = blobUrl ? (
-    <a
-      ref={audAnchor}
-      href={blobUrl}
-      download={audName}
-      target="_blank"
-      rel="noopener noreferrer"
-    />
+    <a ref={audAnchor} href={blobUrl} download={audName} />
   ) : null;
 
   return { startDownload, isDisabled, hiddenAnchor };


### PR DESCRIPTION
Prefer originalFile stem and getMediaExt so Prompt downloads are not saved without a usable audio extension.