### PR TITLE
TT-7440,6646 fix: retain speaker/topic on Careful and Community saves

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -31,6 +31,7 @@ import CarefulSpeechControls, {
   CarefulSpeechPhase,
 } from './carefulSpeech/CarefulSpeechControls';
 import { useGuidedPhraseSegments } from './carefulSpeech/useGuidedPhraseSegments';
+import { resolveSegmentSpeaker } from './carefulSpeech/resolveSegmentSpeaker';
 import {
   CLAUSE_BOUNDARY_THRESHOLD_SEC,
   hasPhraseRegions,
@@ -564,6 +565,16 @@ export function PassageDetailGuidedPhraseRecord({
     },
     [config.speakerLocalKey]
   );
+
+  // TT-7440: existing take keeps its performedBy; new takes use last localStorage speaker
+  useEffect(() => {
+    setSpeaker(
+      resolveSegmentSpeaker(
+        recordingRow?.mediafile?.attributes?.performedBy,
+        config.speakerLocalKey
+      )
+    );
+  }, [recordingRow, currentIndex, config.speakerLocalKey]);
 
   useEffect(() => {
     if (!currentRegion) return;

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/resolveSegmentSpeaker.test.ts
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/resolveSegmentSpeaker.test.ts
@@ -1,0 +1,25 @@
+import { resolveSegmentSpeaker } from './resolveSegmentSpeaker';
+
+describe('resolveSegmentSpeaker', () => {
+  const key = 'test-careful-speaker';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('prefers performedBy from the segment mediafile', () => {
+    localStorage.setItem(key, 'FromStorage');
+    expect(resolveSegmentSpeaker('FromMedia', key)).toBe('FromMedia');
+  });
+
+  it('falls back to localStorage when performedBy is missing', () => {
+    localStorage.setItem(key, 'FromStorage');
+    expect(resolveSegmentSpeaker(undefined, key)).toBe('FromStorage');
+    expect(resolveSegmentSpeaker(null, key)).toBe('FromStorage');
+    expect(resolveSegmentSpeaker('', key)).toBe('FromStorage');
+  });
+
+  it('returns empty string when neither source has a speaker', () => {
+    expect(resolveSegmentSpeaker(undefined, key)).toBe('');
+  });
+});

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/resolveSegmentSpeaker.ts
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/resolveSegmentSpeaker.ts
@@ -1,0 +1,8 @@
+/** Speaker for the current Careful Speech segment (TT-7440). */
+export function resolveSegmentSpeaker(
+  performedBy: string | null | undefined,
+  speakerLocalKey: string
+): string {
+  if (performedBy) return performedBy;
+  return localStorage.getItem(speakerLocalKey) ?? '';
+}

--- a/src/renderer/src/crud/useMediaUpload.test.ts
+++ b/src/renderer/src/crud/useMediaUpload.test.ts
@@ -422,4 +422,41 @@ describe('useMediaUpload', () => {
     expect(uploadComplete).toHaveBeenCalled();
     expect(typeof completeCalls[0][0]).toBe('object');
   });
+
+  it('uses latest performedBy/topic at upload time even if upload fn was captured earlier (TT-6646)', async () => {
+    const afterUploadCb = jest.fn().mockResolvedValue(undefined);
+    const { renderHook, act } = require('@testing-library/react');
+    const { useMediaUpload } = require('./useMediaUpload');
+    const { result, rerender } = renderHook(
+      (props: { performedBy?: string; topic?: string }) =>
+        useMediaUpload({
+          artifactId: 'art-1',
+          passageId: 'psg-1',
+          performedBy: props.performedBy,
+          topic: props.topic,
+          afterUploadCb,
+        }),
+      { initialProps: { performedBy: '', topic: '' } }
+    );
+    const staleUpload = result.current as (files: File[]) => Promise<boolean>;
+
+    act(() => {
+      rerender({ performedBy: 'Dharma', topic: 'Community Q1' });
+    });
+
+    const uploadPromise = staleUpload([makeFile()]);
+    const { nextUpload } = require('../store');
+    expect(nextUpload).toHaveBeenCalled();
+    const uploadProps = (nextUpload as jest.Mock).mock.calls.at(-1)![0];
+    expect(uploadProps.record.performedBy).toBe('Dharma');
+    expect(uploadProps.record.topic).toBe('Community Q1');
+
+    const cb = uploadProps.cb as (
+      n: number,
+      success: boolean,
+      data?: unknown
+    ) => void | Promise<void>;
+    await cb(0, true, { stringId: 'media-1' });
+    await expect(uploadPromise).resolves.toBe(true);
+  });
 });

--- a/src/renderer/src/crud/useMediaUpload.ts
+++ b/src/renderer/src/crud/useMediaUpload.ts
@@ -1,4 +1,4 @@
-import { useRef, useContext } from 'react';
+import { useRef, useContext, useEffect } from 'react';
 import { useGetGlobal, useGlobal } from '../context/useGlobal';
 import {
   pullTableList,
@@ -63,6 +63,15 @@ export const useMediaUpload = ({
   const accessToken = useContext(TokenContext)?.state?.accessToken ?? null;
   const fileList = useRef<File[] | undefined>(undefined);
   const mediaIdRef = useRef('');
+  // TT-6646: MediaRecord's save effect omits performedBy/topic from deps, so
+  // a stale uploadMedia closure can run after the user typed speaker/topic.
+  // Keep latest values in refs (updated in an effect — not during render).
+  const performedByRef = useRef(performedBy);
+  const topicRef = useRef(topic);
+  useEffect(() => {
+    performedByRef.current = performedBy;
+    topicRef.current = topic;
+  }, [performedBy, topic]);
   const { createMedia } = useOfflnMediafileCreate();
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
   const t = useSelector(mediaTabSelector, shallowEqual);
@@ -196,8 +205,8 @@ export const useMediaUpload = ({
         userId: getUserId(),
         sourceMediaId: getSourceMediaId(),
         sourceSegments: sourceSegments ?? '{}',
-        performedBy: performedBy ?? null,
-        topic: topic ?? '',
+        performedBy: performedByRef.current ?? null,
+        topic: topicRef.current ?? '',
         languagebcp47: languagebcp47 ?? '',
         eafUrl: !artifactId
           ? ts.mediaAttached


### PR DESCRIPTION
TT-7440 (Careful Speech): When navigating segments, speaker wasn't initialized from the existing take's performedBy. A new resolveSegmentSpeaker utility resolves the speaker by preferring the segment's performedBy, falling back to localStorage.

TT-6646 (Community upload): useMediaUpload captured performedBy/topic in a stale closure at render time. If the user changed these values after the upload callback was created, the old (empty) values were sent. Fix: store them in refs and read at upload time.