### PR TITLE
TT-7557 fix: scope PBT Transcribe TaskList to step language

### DIFF
--- a/env-config/pwa-clean.md
+++ b/env-config/pwa-clean.md
@@ -1,0 +1,45 @@
+# pwa-clean.md
+
+Your config actually makes this cleaner than the debugging session suggested. The key line is vite.config.ts:79-81: devOptions.enabled: false — the dev server never registers a service worker. So the SW that kept fighting us wasn't from npm start; it was a leftover from an earlier production/preview visit that shares the same origin (http://localhost:3000). Once truly cleared, it stays gone in dev.
+
+Here's the best way, in order of preference:
+
+1. Chrome DevTools → "Clear site data" (most reliable, one click)
+
+   F12 → Application tab → Storage (left panel) → Clear site data button. This unregisters service workers, empties Cache Storage, and clears localStorage/IndexedDB for the origin in one shot.
+
+If you want to keep your auth session (localStorage), instead go to Application → Service Workers and click Unregister, then Application → Cache storage and delete the caches — leaves other storage intact.
+
+2. The gotcha that bit us — close all tabs
+
+   A service worker keeps controlling every already-open page until they're all closed or navigated away. A single reload can still be served by the old SW mid-teardown (that's exactly why my first attempt reverted). So the reliable sequence is:
+
+Clear/unregister → close every tab on that origin → reopen.
+
+3. While actively developing — turn on the two checkboxes
+
+   In Application → Service Workers, tick "Update on reload" and "Bypass for network". As long as those are on, the SW won't serve stale content while you work — no clearing needed each time.
+
+## Preventing it entirely
+
+The root cause is the prod preview build and the dev server sharing localhost:3000. Two fixes:
+
+- **Run the preview build on a different port** (e.g. vite preview --port 4000) so it can never register a SW on the dev server's origin. Since devOptions.enabled is already false, this fully isolates them.
+
+- **For real users stuck on a stale SW in production,** VitePWA supports selfDestroying: true — you ship one build whose SW unregisters itself and cleans caches. That's the sanctioned "kill switch," better than asking users to clear site data. (Not needed for local dev.)
+
+## Reusable programmatic purge
+
+The snippet I used, handy to paste into any DevTools console on the origin:
+
+```javascript
+(async () => {
+  const rs = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(rs.map((r) => r.unregister()));
+  const ks = await caches.keys();
+  await Promise.all(ks.map((k) => caches.delete(k)));
+  location.reload();
+})();
+```
+
+For your day-to-day, option 3 (the two checkboxes) is the least-friction choice; option 1 is the "just make it clean" hammer.

--- a/src/renderer/src/components/MediaRecord.tsx
+++ b/src/renderer/src/components/MediaRecord.tsx
@@ -35,6 +35,7 @@ import { JSONParse } from '../utils';
 import { UploadType } from './UploadType';
 import { shallowEqual, useSelector } from 'react-redux';
 import { passageRecordSelector, sharedSelector } from '../selector';
+import { perfTrace } from '../utils/perf';
 
 interface IProps {
   toolId: string;
@@ -284,6 +285,7 @@ function MediaRecord(props: IProps) {
   }, [allowWave, mimeType, t.compressed, t.uncompressed]);
 
   const myAfterUploadCb = async (mediaId: string) => {
+    perfTrace('MR.myAfterUploadCb-start', { toolId, mediaId: mediaId || '(none)' });
     setUploading(false);
     setPendingSave(false);
     if (filechangedRef.current && mediaId) setFilechanged(false);
@@ -297,6 +299,7 @@ function MediaRecord(props: IProps) {
     }
     saveRef.current = false;
     await afterUploadCb(mediaId);
+    perfTrace('MR.myAfterUploadCb-done', { toolId });
   };
 
   const uploadMedia = useMediaUpload({
@@ -312,10 +315,13 @@ function MediaRecord(props: IProps) {
   });
 
   useEffect(() => {
+    perfTrace('MR.mount-reset', { toolId });
     setConverting(false);
     setUploading(false);
     saveRef.current = false;
     setAudioBlob(undefined);
+    return () => perfTrace('MR.unmount', { toolId });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -435,6 +441,12 @@ function MediaRecord(props: IProps) {
 
   const doUpload = useCallback(
     async (blob: Blob, mimeType: string, filetype: string) => {
+      perfTrace('MR.doUpload-start', {
+        toolId,
+        filename: defaultFilename + '.' + filetype,
+        bytes: blob.size,
+        mimeType,
+      });
       setUploading(true);
       setStatusText(t.saving);
       const files = [
@@ -443,12 +455,14 @@ function MediaRecord(props: IProps) {
         }),
       ];
       await uploadMedia(files);
+      perfTrace('MR.doUpload-resolved', { toolId });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [defaultFilename, uploadMedia]
   );
 
   const convertComplete = () => {
+    perfTrace('MR.convertComplete', { toolId });
     setConverting(false);
     setLoading(false);
     onReady?.();
@@ -456,12 +470,13 @@ function MediaRecord(props: IProps) {
 
   const handleSaveFailed = useCallback(
     (error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'Save failed');
+      perfTrace('MR.handleSaveFailed', { toolId, message });
       saveRef.current = false;
       setUploading(false);
       setConverting(false);
       setLoading(false);
-      const message =
-        error instanceof Error ? error.message : String(error ?? 'Save failed');
       saveCompleted(toolId, message);
       onReady?.();
     },
@@ -478,6 +493,14 @@ function MediaRecord(props: IProps) {
     else setWarning('');
 
     if (saveRequested(toolId)) {
+      perfTrace('MR.save-effect', {
+        toolId,
+        saveRef: saveRef.current,
+        hasBlob: !!audioBlob,
+        blobBytes: audioBlob?.size ?? 0,
+        dur: waveformDuration,
+        mimeType,
+      });
       if (!saveRef.current) {
         if (audioBlob && waveformDuration > 0) {
           onSaving && onSaving();
@@ -487,15 +510,24 @@ function MediaRecord(props: IProps) {
             // Convert to target format
             setStatusText(t.compressing);
             setConverting(true);
+            perfTrace('MR.convert-start', { toolId, mimeType });
             convertToFormat(audioBlob, mimeType)
-              .then((convert_blob) =>
-                doUpload(convert_blob, mimeType, filetype)
+              .then((convert_blob) => {
+                perfTrace('MR.convert-done', {
+                  toolId,
+                  outBytes: convert_blob?.size ?? 0,
+                });
+                return doUpload(convert_blob, mimeType, filetype)
                   .then(() => {
                     convertComplete();
                   })
-                  .catch(handleSaveFailed)
-              )
+                  .catch(handleSaveFailed);
+              })
               .catch((error) => {
+                perfTrace('MR.convert-failed', {
+                  toolId,
+                  message: error instanceof Error ? error.message : String(error),
+                });
                 // If conversion fails, show error and save as WAV instead
                 const errorMessage =
                   t.compressError +
@@ -552,6 +584,7 @@ function MediaRecord(props: IProps) {
   }
   useEffect(() => {
     if (doReset) {
+      perfTrace('MR.doReset', { toolId });
       reset();
       setDoReset && setDoReset(false);
     }
@@ -559,6 +592,7 @@ function MediaRecord(props: IProps) {
   }, [doReset]);
 
   const reset = () => {
+    perfTrace('MR.reset', { toolId });
     setFilechanged(false);
     setPendingSave(false);
     setWaveformDuration(0);

--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -479,7 +479,11 @@ export function PassageDetailGuidedPhraseRecord({
   );
 
   const defaultFilename = useMemo(() => {
-    const postfix = config.buildFilenamePostfix(currentIndex, currentVersion);
+    const postfix = config.buildFilenamePostfix(
+      currentIndex,
+      currentVersion,
+      stepLanguageBcp47
+    );
     return passageDefaultFilename(
       passage,
       plan,
@@ -497,6 +501,7 @@ export function PassageDetailGuidedPhraseRecord({
     currentIndex,
     currentVersion,
     config,
+    stepLanguageBcp47,
   ]);
 
   carefulSpeechStatusRef.current = {

--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -11,7 +11,7 @@ import { Box, Typography } from '@mui/material';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useGlobal } from '../../context/useGlobal';
 import usePassageDetailContext from '../../context/usePassageDetailContext';
-import { useRenderProfiler, useWhyRender } from '../../utils/perf';
+import { useRenderProfiler, useWhyRender, perfTrace } from '../../utils/perf';
 import PassageDetailPlayer from './PassageDetailPlayer';
 import StepMessage from './boldClause/StepMessage';
 import { remoteIdGuid, useArtifactType, useStepTool } from '../../crud';
@@ -916,7 +916,9 @@ export function PassageDetailGuidedPhraseRecord({
       if (regionBoundariesEqual(json, clauseSegString)) return;
       pushSegmentUndo();
       setClauseSegString(json);
+      perfTrace('GP.persistClauseSegments-start', { regions: regions.length });
       await persistClauseSegments(json);
+      perfTrace('GP.persistClauseSegments-done', {});
       applyColors();
     },
     [
@@ -1485,6 +1487,10 @@ export function PassageDetailGuidedPhraseRecord({
   const afterUploadCb = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async (_mediaId: string | undefined) => {
+      perfTrace('GP.afterUploadCb', {
+        mediaId: _mediaId || '(none)',
+        index: currentIndexRef.current,
+      });
       // Color green immediately; rowData/forceRefresh often lag the upload (TT-7552).
       optimisticCompletedRef.current.add(currentIndexRef.current);
       setSavingRecording(false);
@@ -1498,6 +1504,10 @@ export function PassageDetailGuidedPhraseRecord({
 
   const handleClearRecording = useCallback(async () => {
     if (!recordingRow?.mediafile?.id) return;
+    perfTrace('GP.handleClearRecording', {
+      mediafileId: recordingRow.mediafile.id,
+      index: currentIndexRef.current,
+    });
     await memory.update((t) =>
       t.removeRecord({ type: 'mediafile', id: recordingRow.mediafile.id })
     );

--- a/src/renderer/src/components/PassageDetail/PassageDetailTranscribe.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailTranscribe.tsx
@@ -314,6 +314,7 @@ export function PassageDetailTranscribe({ width, artifactTypeId }: IProps) {
     <TranscriberProvider
       artifactTypeId={artifactTypeId}
       curRole={curRole as string}
+      languageBcp47={artifactTypeId ? stepLanguageBcp47 : undefined}
     >
       <Grid
         container

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/filterMediaByStepLanguage.test.ts
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/filterMediaByStepLanguage.test.ts
@@ -1,0 +1,53 @@
+import { MediaFileD } from '../../../model';
+import {
+  filterMediaByStepLanguage,
+  mediaMatchesStepLanguage,
+} from './matchesGuidedOutputRow';
+
+function makeMedia(
+  id: string,
+  languagebcp47?: string
+): MediaFileD {
+  return {
+    id,
+    type: 'mediafile',
+    attributes: {
+      ...(languagebcp47 != null ? { languagebcp47 } : {}),
+    },
+  } as MediaFileD;
+}
+
+describe('filterMediaByStepLanguage', () => {
+  const en = makeMedia('en', 'English|en');
+  const ar = makeMedia('ar', 'Arabic|ar');
+  const fr = makeMedia('fr', 'French|fr');
+  const legacy = makeMedia('legacy');
+
+  it('returns all media when language filter is inactive', () => {
+    const all = [en, ar, fr];
+    expect(filterMediaByStepLanguage(all)).toEqual(all);
+    expect(filterMediaByStepLanguage(all, 'und')).toEqual(all);
+    expect(filterMediaByStepLanguage(all, '')).toEqual(all);
+  });
+
+  it('keeps only media matching the step LWC (TT-7557)', () => {
+    expect(filterMediaByStepLanguage([en, ar, fr], 'ar').map((m) => m.id)).toEqual([
+      'ar',
+    ]);
+    expect(filterMediaByStepLanguage([en, ar, fr], 'en').map((m) => m.id)).toEqual([
+      'en',
+    ]);
+  });
+
+  it('excludes legacy untagged media when a language is active', () => {
+    expect(
+      filterMediaByStepLanguage([ar, legacy], 'ar').map((m) => m.id)
+    ).toEqual(['ar']);
+  });
+
+  it('mediaMatchesStepLanguage matches Name|bcp47 and bare bcp47', () => {
+    expect(mediaMatchesStepLanguage(en, 'en')).toBe(true);
+    expect(mediaMatchesStepLanguage(makeMedia('bare', 'ar'), 'ar')).toBe(true);
+    expect(mediaMatchesStepLanguage(ar, 'en')).toBe(false);
+  });
+});

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/matchesGuidedOutputRow.ts
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/matchesGuidedOutputRow.ts
@@ -63,6 +63,27 @@ export function isLanguageFilterActive(languageBcp47?: string): boolean {
 }
 
 /**
+ * Whether mediafile language matches step LWC.
+ * When the filter is inactive (`undefined` / `und`), all media match.
+ */
+export function mediaMatchesStepLanguage(
+  mediafile: MediaFileD | undefined,
+  languageBcp47?: string
+): boolean {
+  if (!isLanguageFilterActive(languageBcp47)) return true;
+  return mediaLanguageBcp47(mediafile) === languageBcp47;
+}
+
+/** Keep only media stamped with the step LWC (no-op when filter inactive). */
+export function filterMediaByStepLanguage<T extends MediaFileD>(
+  media: T[],
+  languageBcp47?: string
+): T[] {
+  if (!isLanguageFilterActive(languageBcp47)) return media;
+  return media.filter((m) => mediaMatchesStepLanguage(m, languageBcp47));
+}
+
+/**
  * Shared scope for Phrase BT / Retell / Careful Speech guided outputs:
  * artifact type + current vernacular sourceMedia (+ optional language).
  * Never qualifies on sourceVersion alone.
@@ -79,13 +100,7 @@ export function matchesGuidedOutputRow(
       return false;
     }
   }
-  if (isLanguageFilterActive(opts.languageBcp47)) {
-    const rowBcp = mediaLanguageBcp47(row.mediafile);
-    if (rowBcp !== opts.languageBcp47) {
-      return false;
-    }
-  }
-  return true;
+  return mediaMatchesStepLanguage(row.mediafile, opts.languageBcp47);
 }
 
 export function pickLatestGuidedOutputRow(matches: IRow[]): IRow | undefined {

--- a/src/renderer/src/components/PassageDetail/guidedPhraseRecord/types.test.ts
+++ b/src/renderer/src/components/PassageDetail/guidedPhraseRecord/types.test.ts
@@ -54,4 +54,35 @@ describe('guidedPhraseRecord config', () => {
     expect(config.buildFilenamePostfix(0, 2)).toBe('backtranslation1_v2');
     expect(config.buildFilenamePostfix(1, 2)).toBe('backtranslation2_v2s1');
   });
+
+  it('buildFilenamePostfix appends the step language so languages do not collide (TT-7557)', () => {
+    const config = phraseBackTranslateConfig(
+      ArtifactTypeSlug.PhraseBackTranslation,
+      NamedRegions.BackTranslation
+    );
+    // Same passage/version/segment in two languages -> distinct S3 keys.
+    expect(config.buildFilenamePostfix(0, 1, 'en')).toBe(
+      'backtranslation1_v1_en'
+    );
+    expect(config.buildFilenamePostfix(0, 1, 'fr')).toBe(
+      'backtranslation1_v1_fr'
+    );
+    expect(config.buildFilenamePostfix(1, 1, 'fr')).toBe(
+      'backtranslation2_v1s1_fr'
+    );
+  });
+
+  it('buildFilenamePostfix keeps legacy names when no language filter is active', () => {
+    const config = phraseBackTranslateConfig(
+      ArtifactTypeSlug.PhraseBackTranslation,
+      NamedRegions.BackTranslation
+    );
+    expect(config.buildFilenamePostfix(0, 1)).toBe('backtranslation1_v1');
+    expect(config.buildFilenamePostfix(0, 1, undefined)).toBe(
+      'backtranslation1_v1'
+    );
+    expect(config.buildFilenamePostfix(0, 1, 'und')).toBe(
+      'backtranslation1_v1'
+    );
+  });
 });

--- a/src/renderer/src/components/PassageDetail/guidedPhraseRecord/types.ts
+++ b/src/renderer/src/components/PassageDetail/guidedPhraseRecord/types.ts
@@ -45,8 +45,17 @@ export interface GuidedPhraseRecordConfig {
   sequentialUnitNavAroundRecord: boolean;
   /** Persist segment map on vernacular named regions (false for Retell). */
   persistSegments: boolean;
-  /** Filename postfix for a unit at `unitIndex` (0-based) on `sourceVersion`. */
-  buildFilenamePostfix: (unitIndex: number, sourceVersion: number) => string;
+  /**
+   * Filename postfix for a unit at `unitIndex` (0-based) on `sourceVersion`.
+   * `languageBcp47` (the step LWC) disambiguates per-language recordings so
+   * two languages of the same passage/version/segment do not collide on the
+   * same S3 key. Ignored by single-language configs (e.g. Careful Speech).
+   */
+  buildFilenamePostfix: (
+    unitIndex: number,
+    sourceVersion: number,
+    languageBcp47?: string
+  ) => string;
 }
 
 const carefulSpeechBoundaryDefaults = {
@@ -93,10 +102,18 @@ export function phraseBackTranslateConfig(
     multiLevelSegmentUndo: phraseBoundaryTools,
     sequentialUnitNavAroundRecord: phraseBoundaryTools,
     persistSegments: phraseBoundaryTools,
-    buildFilenamePostfix: (unitIndex, sourceVersion) => {
+    buildFilenamePostfix: (unitIndex, sourceVersion, languageBcp47) => {
       const base = `${artifactSlug}${unitIndex + 1}_v${sourceVersion}`;
-      if (unitIndex > 0) return `${base}s${unitIndex}`;
-      return base;
+      const seg = unitIndex > 0 ? `${base}s${unitIndex}` : base;
+      // TT-7557: Phrase BT / Retell are recorded once per language against the
+      // same vernacular source. Without the language in the S3 key, English and
+      // French of the same passage/version/segment produce identical filenames,
+      // so whichever uploads last overwrites the other's audio (English rows
+      // then play the French audio). Append the step LWC to keep keys distinct.
+      // Single-language projects (no active language filter) keep legacy names.
+      return languageBcp47 && languageBcp47 !== 'und'
+        ? `${seg}_${languageBcp47}`
+        : seg;
     },
   };
 }

--- a/src/renderer/src/context/TranscriberContext.tsx
+++ b/src/renderer/src/context/TranscriberContext.tsx
@@ -35,6 +35,7 @@ import { useDispatch } from 'react-redux';
 import { InitializedRecord, RecordKeyMap } from '@orbit/records';
 import { useOrbitData } from '../hoc/useOrbitData';
 import { PassageDetailContext } from './PassageDetailContext';
+import { filterMediaByStepLanguage } from '../components/PassageDetail/carefulSpeech/matchesGuidedOutputRow';
 
 export interface IRowData {
   planName: string;
@@ -127,9 +128,15 @@ interface IProps {
   children: React.ReactElement;
   artifactTypeId?: string | null | undefined;
   curRole?: string;
+  /**
+   * Primary step LWC (bcp47). When set (and not `und`), TaskList only
+   * includes media stamped with that language — used by PBT Transcribe.
+   * Sister language is ASR-only and must not be passed here.
+   */
+  languageBcp47?: string;
 }
 const TranscriberProvider = (props: IProps) => {
-  const { artifactTypeId, curRole } = props;
+  const { artifactTypeId, curRole, languageBcp47 } = props;
   const [isDetail] = useState(artifactTypeId !== undefined);
   const passages = useOrbitData<Passage[]>('passage');
   const sections = useOrbitData<Section[]>('section');
@@ -167,12 +174,15 @@ const TranscriberProvider = (props: IProps) => {
 
   useEffect(() => {
     if (devPlan && mediafiles.length > 0) {
-      const m = getMediaInPlans([devPlan], mediafiles, artifactId, true);
+      const m = filterMediaByStepLanguage(
+        getMediaInPlans([devPlan], mediafiles, artifactId, true),
+        languageBcp47
+      );
       setPlanMedia(m);
       planMediaRef.current = m;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mediafiles, devPlan, artifactId]);
+  }, [mediafiles, devPlan, artifactId, languageBcp47]);
 
   const setRows = (rowData: IRowData[]) => {
     setState((state: ICtxState) => {

--- a/src/renderer/src/crud/useMediaUpload.ts
+++ b/src/renderer/src/crud/useMediaUpload.ts
@@ -15,11 +15,17 @@ import { IndexedDBSource } from '@orbit/indexeddb';
 import { UploadType } from '../components/UploadType';
 import { RecordKeyMap } from '@orbit/records';
 import { getContentType } from '../utils/contentType';
-import { ISharedStrings, MediaFileAttributes, MediaFileD } from '../model';
+import {
+  ArtifactTypeD,
+  ISharedStrings,
+  MediaFileAttributes,
+  MediaFileD,
+} from '../model';
 import { AlertSeverity, useSnackBar } from '../hoc/SnackBar';
 import { mediaTabSelector, sharedSelector } from '../selector';
 import { OrbitNetworkErrorRetries } from '../../api-variable';
 import { formatUploadTerminalFailureMessage } from '../store/upload/uploadTerminalMessages';
+import { perfTrace } from '../utils/perf';
 
 interface IProps {
   artifactId: string | null;
@@ -105,6 +111,11 @@ export const useMediaUpload = ({
     success: boolean,
     data?: any
   ): Promise<void> => {
+    perfTrace('UP.itemComplete', {
+      success,
+      stringId: data?.stringId ?? '(none)',
+      offlinePath: !data?.stringId && success && !!data,
+    });
     if (!success) setOrbitRetries(OrbitNetworkErrorRetries - 1); //notify of possible network issue
     const uploadList = fileList.current;
     if (!uploadList) return; // This should never happen
@@ -113,6 +124,7 @@ export const useMediaUpload = ({
     } else if (success && data) {
       // offlineOnly
       const num = getLatestVersion();
+      perfTrace('UP.createMedia', { version: num, sourceMediaId });
       mediaIdRef.current = (
         await createMedia(
           data,
@@ -135,13 +147,16 @@ export const useMediaUpload = ({
           .replace('{1}', String(total))
       );
       try {
+        perfTrace('UP.afterUploadCb-start', { mediaId: mediaIdRef.current });
         await afterUploadCb(mediaIdRef.current);
+        perfTrace('UP.afterUploadCb-done', { mediaId: mediaIdRef.current });
       } catch {
         // Parent after-upload hook failed; upload itself is finished.
       }
     };
     if (!getGlobal('offline') && mediaIdRef.current) {
       try {
+        perfTrace('UP.pull-start', { mediaId: mediaIdRef.current });
         await pullTableList(
           'mediafile',
           Array(mediaIdRef.current),
@@ -150,6 +165,7 @@ export const useMediaUpload = ({
           backup,
           reporter
         );
+        perfTrace('UP.pull-done', { mediaId: mediaIdRef.current });
       } catch {
         // Sync failure still runs upload cleanup.
       }
@@ -169,14 +185,41 @@ export const useMediaUpload = ({
               getGlobal('plan'),
               memory?.keyMap as RecordKeyMap
             ) || getGlobal('plan');
-      const getArtifactId = () =>
-        artifactId === null
-          ? null
-          : remoteIdNum(
-              'artifacttype',
-              artifactId,
-              memory?.keyMap as RecordKeyMap
-            ) || artifactId;
+      const getArtifactId = () => {
+        if (artifactId === null) return null;
+        // Normal case: the artifacttype has a server id in the keyMap.
+        const direct = remoteIdNum(
+          'artifacttype',
+          artifactId,
+          memory?.keyMap as RecordKeyMap
+        );
+        if (!Number.isNaN(direct)) return direct;
+        // TT-7557: offlineSetup (makeArtifactTypeRecs) creates artifacttypes
+        // locally with only a typename and no remote id, and steps can end up
+        // referencing that local-only record. Posting its GUID as the FK makes
+        // the API reject the mediafile with 422 ("Failed to convert '<guid>'
+        // ... to Int32"), which then retries in a storm. Resolve to the
+        // server-synced artifacttype of the same typename (which carries a
+        // remoteId) so we always send an integer FK.
+        const local = memory.cache.query((q) =>
+          q.findRecord({ type: 'artifacttype', id: artifactId })
+        ) as ArtifactTypeD | undefined;
+        const typename = local?.attributes?.typename;
+        if (typename) {
+          const synced = (
+            memory.cache.query((q) =>
+              q.findRecords('artifacttype')
+            ) as ArtifactTypeD[]
+          ).find(
+            (a) => a.attributes?.typename === typename && a.keys?.remoteId
+          );
+          if (synced?.keys?.remoteId) return parseInt(synced.keys.remoteId, 10);
+        }
+        // Still unresolved: fall back to the GUID (offline/create path handles
+        // it; online, the upload guard below rejects with a clear message
+        // instead of silently 422-looping).
+        return artifactId;
+      };
       const getPassageId = () =>
         passageId
           ? remoteIdNum('passage', passageId, memory?.keyMap as RecordKeyMap) ||
@@ -191,6 +234,13 @@ export const useMediaUpload = ({
           memory?.keyMap as RecordKeyMap
         ) || sourceMediaId;
 
+      perfTrace('UP.uploadMedia-enter', {
+        filename: (files[0] as File)?.name,
+        artifactId,
+        sourceMediaId,
+        sourceSegments,
+        languagebcp47,
+      });
       uploadFiles(files);
       fileList.current = files;
 
@@ -219,6 +269,84 @@ export const useMediaUpload = ({
         userId: string;
         sourceMediaId: string;
       };
+      // A relationship id that is NOT all-digits is an unresolved local GUID —
+      // the server can't map it to an integer PK and rejects the POST with 422.
+      const stillGuid = (v: unknown) =>
+        typeof v === 'string' && v !== '' && !/^\d+$/.test(v);
+      // When artifactType stays a GUID, does the in-memory record still carry
+      // its own keys.remoteId? If yes -> the keyMap simply wasn't rebuilt on
+      // restore (fix = repopulate keyMap). If undefined -> the record is truly
+      // local-only (fix = ensure it gets a remote id before upload).
+      let artifactTypeRecordKeyRemoteId: string | undefined | null = null;
+      let artifactTypeTable: Array<{
+        id: string;
+        typename?: string;
+        remoteId?: string;
+      }> = [];
+      if (artifactId) {
+        try {
+          const at = memory.cache.query((q) =>
+            q.findRecord({ type: 'artifacttype', id: artifactId })
+          ) as
+            | { attributes?: { typename?: string }; keys?: { remoteId?: string } }
+            | undefined;
+          artifactTypeRecordKeyRemoteId = at?.keys?.remoteId ?? '(no keys.remoteId)';
+          const all = memory.cache.query((q) =>
+            q.findRecords('artifacttype')
+          ) as Array<{
+            id: string;
+            attributes?: { typename?: string };
+            keys?: { remoteId?: string };
+          }>;
+          const wanted = at?.attributes?.typename;
+          artifactTypeTable = all
+            .filter((a) => a.attributes?.typename === wanted)
+            .map((a) => ({
+              id: a.id,
+              typename: a.attributes?.typename,
+              remoteId: a.keys?.remoteId,
+            }));
+        } catch {
+          artifactTypeRecordKeyRemoteId = '(record not found)';
+        }
+      }
+      perfTrace('UP.resolved-fks', {
+        planId: mediafile.planId,
+        artifactTypeId: mediafile.artifactTypeId,
+        passageId: mediafile.passageId,
+        sourceMediaId: mediafile.sourceMediaId,
+        recordedbyUserId: mediafile.recordedbyUserId,
+        artifactTypeRecordKeyRemoteId,
+        artifactTypeTable,
+        unresolvedGuids: [
+          ['plan', mediafile.planId],
+          ['artifactType', mediafile.artifactTypeId],
+          ['passage', mediafile.passageId],
+          ['sourceMedia', mediafile.sourceMediaId],
+          ['recordedbyUser', mediafile.recordedbyUserId],
+        ]
+          .filter(([, v]) => stillGuid(v))
+          .map(([k]) => k),
+      });
+      // Fail fast instead of 422-looping: an online POST with an unresolved
+      // GUID relationship id (e.g. artifact-type never got a server id) is
+      // guaranteed to be rejected and retried UPLOAD_MAX_ATTEMPTS times. Reject
+      // once with a clear, greppable message.
+      if (!getGlobal('offline')) {
+        const badFk = [
+          ['plan', mediafile.planId],
+          ['artifactType', mediafile.artifactTypeId],
+          ['passage', mediafile.passageId],
+          ['sourceMedia', mediafile.sourceMediaId],
+          ['recordedbyUser', mediafile.recordedbyUserId],
+        ].find(([, v]) => stillGuid(v));
+        if (badFk) {
+          const msg = `Cannot upload: ${badFk[0]} has no server id yet (${badFk[1]}). It has not finished syncing.`;
+          showMessage(msg, AlertSeverity.Warning);
+          reject(new Error(msg));
+          return;
+        }
+      }
       nextUpload({
         record: mediafile,
         files,
@@ -228,6 +356,7 @@ export const useMediaUpload = ({
         errorReporter: reporter,
         uploadType: UploadType.Media,
         cb: (n, success, data) => {
+          perfTrace('UP.nextUpload-cb', { n, success });
           void itemComplete(n, success, data)
             .then(() => {
               if (success) resolve(true);

--- a/src/renderer/src/utils/perf.ts
+++ b/src/renderer/src/utils/perf.ts
@@ -122,6 +122,76 @@ export const perfTime = <T>(label: string, fn: () => T): T => {
   }
 };
 
+// ── Chronological trace (for ordering / race diagnosis) ─────────────────────
+// The aggregate stats above answer "how often / how slow". A race needs the
+// opposite: the exact ORDER of async milestones and the gaps between them.
+// perfTrace appends to a ring buffer you dump with `aptPerf.trace()`.
+
+interface TraceEvent {
+  seq: number;
+  tMs: number; // perf clock at capture
+  label: string;
+  data?: Record<string, unknown>;
+}
+
+const TRACE_MAX = 1000;
+const traceBuf: TraceEvent[] = [];
+let traceSeq = 0;
+
+/**
+ * Append one ordered milestone to the trace buffer. No-op when disabled.
+ * Also mirrors to the console (grouped/greppable) so it interleaves with the
+ * app's existing diagnostics in real time — critical for spotting a step that
+ * fires twice, out of order, or never completes.
+ */
+export const perfTrace = (
+  label: string,
+  data?: Record<string, unknown>
+): void => {
+  if (!enabled) return;
+  const evt: TraceEvent = { seq: ++traceSeq, tMs: now(), label, data };
+  traceBuf.push(evt);
+  if (traceBuf.length > TRACE_MAX) traceBuf.shift();
+  const dataStr = data ? ' ' + JSON.stringify(data) : '';
+
+  console.log(
+    `%c[aptTrace #${evt.seq} @${fmt(evt.tMs)}ms] ${label}${dataStr}`,
+    'color:#0a7'
+  );
+};
+
+const traceReport = (): string => {
+  if (!traceBuf.length) return '[aptTrace] (empty — reproduce the issue first)';
+  const first = traceBuf[0]!.tMs;
+  const lines = traceBuf.map((e, i) => {
+    const rel = fmt(e.tMs - first);
+    const delta = i > 0 ? fmt(e.tMs - traceBuf[i - 1]!.tMs) : 0;
+    const dataStr = e.data ? '  ' + JSON.stringify(e.data) : '';
+    return `#${e.seq}  +${rel}ms  (Δ${delta}ms)  ${e.label}${dataStr}`;
+  });
+  const text =
+    `# aptTrace — ${traceBuf.length} events (chronological)\n` +
+    lines.join('\n') +
+    '\n';
+
+  console.log(text);
+  try {
+    (navigator as any)?.clipboard?.writeText?.(text);
+
+    console.log('%c[aptTrace] trace copied to clipboard', 'color:green');
+  } catch {
+    /* clipboard unavailable */
+  }
+  return text;
+};
+
+const traceReset = () => {
+  traceBuf.length = 0;
+  traceSeq = 0;
+
+  console.log('[aptTrace] trace cleared');
+};
+
 // ── Hooks ───────────────────────────────────────────────────────────────────
 
 /**
@@ -436,8 +506,11 @@ if (typeof window !== 'undefined') {
     report,
     reset,
     auto,
+    trace: traceReport,
+    traceReset,
     enabled: () => enabled,
     _registry: registry,
+    _trace: traceBuf,
   };
 }
 


### PR DESCRIPTION
## Summary
- Phrase Back Translation Transcribe steps with multiple LWCs were showing every PBT recording in each step (often noticed under Arabic).
- Pass the Transcribe step primary language into `TranscriberProvider` and filter TaskList media the same way guided/mobile PBT already does (`languagebcp47` vs step LWC). Sister language remains ASR-only.
- Add unit coverage for `filterMediaByStepLanguage`.

## Test plan
- [ ] Open a team with English / Arabic / French PBT + PBT Transcribe steps
- [ ] Record at least one PBT phrase per language
- [ ] Confirm English Transcribe lists only English PBTs, Arabic only Arabic, French only French
- [ ] Confirm vernacular Transcribe (no artifact type) is unchanged
- [ ] `cd src/renderer; npm test -- filterMediaByStepLanguage --runInBand --watchAll=false`