### PR TITLE
Internalize category race condition fix

### DIFF
--- a/src/renderer/src/components/Discussions/DiscussionCard.tsx
+++ b/src/renderer/src/components/Discussions/DiscussionCard.tsx
@@ -731,9 +731,7 @@ export const DiscussionCard = (props: IProps) => {
   // A brand-new typed category is only committed to an id at save, so it never
   // fires onCategoryChange; mark the discussion changed so Save can enable when
   // a new category is the only edit.
-  const onCategoryNewDraft = (hasDraft: boolean) => {
-    if (hasDraft) setChanged(true);
-  };
+  const onCategoryNewDraft = () => setChanged(true);
   const saveDiscussion = async () => {
     //we should only get here with no subject if they've clicked off the screen and then told us to save with no subject
     discussion.attributes.subject =

--- a/src/renderer/src/components/Discussions/DiscussionCard.tsx
+++ b/src/renderer/src/components/Discussions/DiscussionCard.tsx
@@ -728,6 +728,12 @@ export const DiscussionCard = (props: IProps) => {
       setChanged(true);
     }
   };
+  // A brand-new typed category is only committed to an id at save, so it never
+  // fires onCategoryChange; mark the discussion changed so Save can enable when
+  // a new category is the only edit.
+  const onCategoryNewDraft = (hasDraft: boolean) => {
+    if (hasDraft) setChanged(true);
+  };
   const saveDiscussion = async () => {
     //we should only get here with no subject if they've clicked off the screen and then told us to save with no subject
     discussion.attributes.subject =
@@ -996,6 +1002,7 @@ export const DiscussionCard = (props: IProps) => {
                   id={`category-${discussion.id}`}
                   initCategory={editCategory}
                   onCategoryChange={onCategoryChange}
+                  onNewDraft={onCategoryNewDraft}
                   commitRef={catCommitRef}
                   allowNew={userIsAdmin && (!offline || offlineOnly)}
                   required={false}

--- a/src/renderer/src/components/Discussions/DiscussionCard.tsx
+++ b/src/renderer/src/components/Discussions/DiscussionCard.tsx
@@ -250,6 +250,9 @@ export const DiscussionCard = (props: IProps) => {
   const [myChanged, setMyChanged] = useState(false);
   const segSavingRef = useRef(false);
   const cardSavingRef = useRef(false);
+  // commit() handle for the category field; called at save so a newly typed
+  // category is created on submission rather than on blur.
+  const catCommitRef = useRef<(() => Promise<string>) | null>(null);
   const [showMove, setShowMove] = useState(false);
   const [moveTo, setMoveTo] = useState<string>();
   const waitForRemoteQueue = useWaitForRemoteQueue();
@@ -729,6 +732,11 @@ export const DiscussionCard = (props: IProps) => {
     //we should only get here with no subject if they've clicked off the screen and then told us to save with no subject
     discussion.attributes.subject =
       editSubject.length > 0 ? editSubject : tdcs.topic;
+    // Create the category now (at save) if the user typed a new one; on blur it
+    // was only resolved against existing categories.
+    const catId = catCommitRef.current
+      ? await catCommitRef.current()
+      : editCategory;
     const ops: RecordOperation[] = [];
     const t = new RecordTransformBuilder();
     if (!discussion.id) {
@@ -770,7 +778,7 @@ export const DiscussionCard = (props: IProps) => {
         discussion,
         'artifactCategory',
         'artifactcategory',
-        editCategory,
+        catId,
         user
       ),
       ...UpdateRelatedRecord(
@@ -988,6 +996,7 @@ export const DiscussionCard = (props: IProps) => {
                   id={`category-${discussion.id}`}
                   initCategory={editCategory}
                   onCategoryChange={onCategoryChange}
+                  commitRef={catCommitRef}
                   allowNew={userIsAdmin && (!offline || offlineOnly)}
                   required={false}
                   scripture={ArtCatScr.hide}

--- a/src/renderer/src/components/PassageDetail/Internalization/PassageDetailArtifacts.tsx
+++ b/src/renderer/src/components/PassageDetail/Internalization/PassageDetailArtifacts.tsx
@@ -182,6 +182,11 @@ export function PassageDetailArtifacts() {
   const mediaRef = useRef<MediaFileD | undefined>(undefined);
   const textRef = useRef<string | undefined>(undefined);
   const catIdRef = useRef<string | undefined>(undefined);
+  // commit() handles for the two SelectArtifactCategory instances (edit dialog
+  // vs. the add/upload dialog). Kept separate so one dialog unmounting never
+  // clears the other's handle. Called at save to create a new category.
+  const editCatCommitRef = useRef<(() => Promise<string>) | null>(null);
+  const addCatCommitRef = useRef<(() => Promise<string>) | null>(null);
   const descriptionRef = useRef<string>('');
 
   const resourceTypeRef = useRef<ResourceTypeEnum>(
@@ -429,6 +434,12 @@ export function PassageDetailArtifacts() {
     if (!v) resetEdit();
   };
   const handleEditSave = async () => {
+    // Create the category now (at save) if the user typed a new one; on blur it
+    // was only resolved against existing categories.
+    if (editCatCommitRef.current) {
+      const catId = await editCatCommitRef.current();
+      catIdRef.current = catId;
+    }
     if (editResource) {
       UpdateSectionResource({
         ...editResource,
@@ -945,6 +956,10 @@ export function PassageDetailArtifacts() {
         showMessage={showMessage}
         multiple={true}
         finish={afterUpload}
+        beforeUpload={async () => {
+          if (addCatCommitRef.current)
+            catIdRef.current = await addCatCommitRef.current();
+        }}
         cancelled={cancelled}
         cancelReset={resetEdit}
         artifactState={artifactState}
@@ -962,6 +977,7 @@ export function PassageDetailArtifacts() {
             catAllowNew={true} //if they can upload they can add cat
             initCategory=""
             onCategoryChange={handleCategory}
+            catCommitRef={addCatCommitRef}
             initDescription={initDescription}
             onDescriptionChange={handleDescription}
             catRequired={false}
@@ -1072,6 +1088,7 @@ export function PassageDetailArtifacts() {
           catAllowNew={true}
           initCategory={catIdRef.current || ''}
           onCategoryChange={handleCategory}
+          catCommitRef={editCatCommitRef}
           initDescription={descriptionRef.current}
           onDescriptionChange={handleDescription}
           catRequired={false}

--- a/src/renderer/src/components/PassageDetail/Internalization/PassageDetailsArtifactsMobile.tsx
+++ b/src/renderer/src/components/PassageDetail/Internalization/PassageDetailsArtifactsMobile.tsx
@@ -172,6 +172,11 @@ export function PassageDetailArtifactsMobile() {
   const mediaRef = useRef<MediaFileD | undefined>(undefined);
   const textRef = useRef<string | undefined>(undefined);
   const catIdRef = useRef<string | undefined>(undefined);
+  // Separate commit() handles for the edit dialog vs. the add/upload dialog so
+  // one unmounting never clears the other's. Called at save to create a new
+  // category the user typed (deferred from blur).
+  const editCatCommitRef = useRef<(() => Promise<string>) | null>(null);
+  const addCatCommitRef = useRef<(() => Promise<string>) | null>(null);
   const descriptionRef = useRef<string>('');
 
   const resourceTypeRef = useRef<ResourceTypeEnum>(
@@ -426,6 +431,12 @@ export function PassageDetailArtifactsMobile() {
     if (!v) resetEdit();
   };
   const handleEditSave = async () => {
+    // Create the category now (at save) if the user typed a new one; on blur it
+    // was only resolved against existing categories.
+    if (editCatCommitRef.current) {
+      const catId = await editCatCommitRef.current();
+      catIdRef.current = catId;
+    }
     if (editResource) {
       UpdateSectionResource({
         ...editResource,
@@ -938,6 +949,10 @@ export function PassageDetailArtifactsMobile() {
         showMessage={showMessage}
         multiple={true}
         finish={afterUpload}
+        beforeUpload={async () => {
+          if (addCatCommitRef.current)
+            catIdRef.current = await addCatCommitRef.current();
+        }}
         cancelled={cancelled}
         cancelReset={resetEdit}
         artifactState={artifactState}
@@ -955,6 +970,7 @@ export function PassageDetailArtifactsMobile() {
             catAllowNew={true} //if they can upload they can add cat
             initCategory=""
             onCategoryChange={handleCategory}
+            catCommitRef={addCatCommitRef}
             initDescription={initDescription}
             onDescriptionChange={handleDescription}
             catRequired={false}
@@ -1080,6 +1096,7 @@ export function PassageDetailArtifactsMobile() {
           catAllowNew={true}
           initCategory={catIdRef.current || ''}
           onCategoryChange={handleCategory}
+          catCommitRef={editCatCommitRef}
           initDescription={descriptionRef.current}
           onDescriptionChange={handleDescription}
           catRequired={false}

--- a/src/renderer/src/components/PassageDetail/Internalization/ResourceData.tsx
+++ b/src/renderer/src/components/PassageDetail/Internalization/ResourceData.tsx
@@ -9,7 +9,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, type MutableRefObject } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { ArtifactCategoryType, useOrganizedBy } from '../../../crud';
 import {
@@ -45,6 +45,9 @@ interface IProps {
   allowProject: boolean;
   catRequired: boolean;
   catAllowNew?: boolean | undefined;
+  // Forwarded to SelectArtifactCategory so the parent form can create a new
+  // category at submission (rather than on blur).
+  catCommitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
   sectDesc?: string | undefined;
   passDesc?: string | undefined;
   wrapPreviewOverflow?: boolean;
@@ -66,6 +69,7 @@ export function ResourceData(props: IProps) {
     uploadType,
     onTextChange,
     wrapPreviewOverflow,
+    catCommitRef,
   } = props;
   const [description, setDescription] = useState(initDescription);
   const { getOrganizedBy } = useOrganizedBy();
@@ -149,6 +153,7 @@ export function ResourceData(props: IProps) {
             required={catRequired}
             scripture={ArtCatScr.highlight}
             type={ArtifactCategoryType.Resource}
+            commitRef={catCommitRef}
           />
         </Grid>
       </Grid>

--- a/src/renderer/src/components/PassageDetail/Internalization/ResourceData.tsx
+++ b/src/renderer/src/components/PassageDetail/Internalization/ResourceData.tsx
@@ -9,7 +9,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import React, { useEffect, useState, type MutableRefObject } from 'react';
+import React, { useEffect, useState, type RefObject } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { ArtifactCategoryType, useOrganizedBy } from '../../../crud';
 import {
@@ -47,7 +47,7 @@ interface IProps {
   catAllowNew?: boolean | undefined;
   // Forwarded to SelectArtifactCategory so the parent form can create a new
   // category at submission (rather than on blur).
-  catCommitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
+  catCommitRef?: RefObject<(() => Promise<string>) | null> | undefined;
   sectDesc?: string | undefined;
   passDesc?: string | undefined;
   wrapPreviewOverflow?: boolean;

--- a/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
+++ b/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
@@ -1,11 +1,11 @@
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 import { IResourceState } from '.';
 import SelectArtifactCategory from '../Sheet/SelectArtifactCategory';
 import { ArtifactCategoryType } from '../../crud';
 
 interface IProps extends IResourceState {
   // Forwarded so the wizard can create a new category at save (not on blur).
-  commitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
+  commitRef?: RefObject<(() => Promise<string>) | null> | undefined;
 }
 
 export const ResourceCategory = (props: IProps) => {

--- a/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
+++ b/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
@@ -19,8 +19,8 @@ export const ResourceCategory = (props: IProps) => {
   // A brand-new typed category isn't committed to an id until save, so it never
   // fires onCategoryChange; mark the form dirty here so Save can enable when a
   // new category is the only edit.
-  const handleNewDraft = (hasDraft: boolean) => {
-    if (hasDraft && setState)
+  const handleNewDraft = () => {
+    setState &&
       setState((state) => (state.changed ? state : { ...state, changed: true }));
   };
 

--- a/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
+++ b/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
@@ -16,12 +16,21 @@ export const ResourceCategory = (props: IProps) => {
     setState && setState((state) => ({ ...state, category, changed: true }));
   };
 
+  // A brand-new typed category isn't committed to an id until save, so it never
+  // fires onCategoryChange; mark the form dirty here so Save can enable when a
+  // new category is the only edit.
+  const handleNewDraft = (hasDraft: boolean) => {
+    if (hasDraft && setState)
+      setState((state) => (state.changed ? state : { ...state, changed: true }));
+  };
+
   return (
     <SelectArtifactCategory
       disabled={!setState}
       type={!note ? ArtifactCategoryType.Resource : ArtifactCategoryType.Note}
       initCategory={category}
       onCategoryChange={setState ? handleChange : undefined}
+      onNewDraft={setState ? handleNewDraft : undefined}
       required={false}
       allowNew
       commitRef={commitRef}

--- a/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
+++ b/src/renderer/src/components/ResourceEdit/ResourceCategory.tsx
@@ -1,9 +1,15 @@
+import type { MutableRefObject } from 'react';
 import { IResourceState } from '.';
 import SelectArtifactCategory from '../Sheet/SelectArtifactCategory';
 import { ArtifactCategoryType } from '../../crud';
 
-export const ResourceCategory = (props: IResourceState) => {
-  const { state, setState } = props;
+interface IProps extends IResourceState {
+  // Forwarded so the wizard can create a new category at save (not on blur).
+  commitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
+}
+
+export const ResourceCategory = (props: IProps) => {
+  const { state, setState, commitRef } = props;
   const { category, note } = state;
 
   const handleChange = (category: string) => {
@@ -18,6 +24,7 @@ export const ResourceCategory = (props: IResourceState) => {
       onCategoryChange={setState ? handleChange : undefined}
       required={false}
       allowNew
+      commitRef={commitRef}
     />
   );
 };

--- a/src/renderer/src/components/ResourceEdit/ResourceOverview.tsx
+++ b/src/renderer/src/components/ResourceEdit/ResourceOverview.tsx
@@ -90,6 +90,9 @@ export default function ResourceOverview(props: IProps) {
 
   const [isDeveloper] = useGlobal('developer');
   const recording = useRef(false);
+  // commit() handle for the category field; called at save so a newly typed
+  // category is created on submission rather than on blur.
+  const catCommitRef = useRef<(() => Promise<string>) | null>(null);
   const { getOrgDefault, setOrgDefault, canSetOrgDefault } = useOrgDefaults();
   const [findNote, setFindNote] = React.useState(false);
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
@@ -161,8 +164,13 @@ export default function ResourceOverview(props: IProps) {
     if (onCancel) onCancel();
   };
 
-  const handleAdd = () => {
-    onCommit(state);
+  const handleAdd = async () => {
+    // Create the category now (at save) if the user typed a new one; on blur it
+    // was only resolved against existing categories.
+    const category = catCommitRef.current
+      ? await catCommitRef.current()
+      : state.category;
+    onCommit({ ...state, category });
   };
 
   const handleLanguageChange = (val: ILanguage) => {
@@ -209,7 +217,11 @@ export default function ResourceOverview(props: IProps) {
           <ResourceTitle state={state} setState={updateTitleState} />
         )}
         <ResourceDescription state={state} setState={updateState} />
-        <ResourceCategory state={state} setState={updateState} />
+        <ResourceCategory
+          state={state}
+          setState={updateState}
+          commitRef={catCommitRef}
+        />
         <ResourceKeywords state={state} setState={updateState} />
         {!isNote ? (
           <>
@@ -261,7 +273,7 @@ export default function ResourceOverview(props: IProps) {
         {dialogmode !== Mode.view && (
           <PriButton
             id="resSave"
-            onClick={handleAdd}
+            onClick={() => handleAdd()}
             disabled={
               title === '' ||
               (bcp47 === 'und' && !isNote) ||

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -155,6 +155,15 @@ export const SelectArtifactCategory = (props: IProps) => {
   // commitRef. Returns the resolved id (empty string when the field is blank).
   const commit = async (): Promise<string> => {
     const name = inputVal.trim();
+    // Field unchanged from the committed category — keep its id as-is rather
+    // than re-resolving by name. Re-resolving could silently drop the category
+    // (when its localized name is filtered out of the options and the field
+    // therefore shows blank) or switch it to a different id (when two slugs
+    // share the same localized name). The empty === empty case also preserves
+    // such a filtered-out category on an untouched save.
+    if (name.toLowerCase() === currentName.trim().toLowerCase()) {
+      return categoryId;
+    }
     if (!name) {
       setCategory('');
       return '';

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -204,16 +204,34 @@ export const SelectArtifactCategory = (props: IProps) => {
     };
   });
 
+  // Options are the localized category names, deduplicated so a name can never
+  // appear twice. New-category creation already blocks duplicate localized
+  // names (useArtifactCategory.isDuplicateCategory), but two distinct category
+  // slugs can still collapse to the same localized string (e.g. created under
+  // different languages), so we enforce uniqueness here at the point of use.
+  // Keeping the first occurrence matches how resolveExisting/commit resolve a
+  // typed name to an id (first case-insensitive match).
+  const categoryOptions = (() => {
+    const seen = new Set<string>();
+    const names: string[] = [];
+    artifactCategorys.forEach((c) => {
+      const name = c.category;
+      if (!name) return;
+      const key = name.trim().toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      names.push(name);
+    });
+    return names.sort((a, b) => (a < b ? -1 : 1));
+  })();
+
   return (
     <StyledBox>
       <Autocomplete
         freeSolo
         size="small"
         disabled={disabled ?? false}
-        options={artifactCategorys
-          .map((c) => c.category)
-          .filter(Boolean)
-          .sort((a, b) => (a < b ? -1 : 1))}
+        options={categoryOptions}
         value={currentName || null}
         inputValue={inputVal}
         onInputChange={(_e, v, reason) => {
@@ -234,16 +252,16 @@ export const SelectArtifactCategory = (props: IProps) => {
         onChange={(_e, v) => resolveExisting(v)}
         onBlur={() => resolveExisting(inputVal)}
         sx={textFieldProps}
-        renderOption={(liProps, option, { index }) => {
+        renderOption={(liProps, option) => {
           const cat = artifactCategorys.find((c) => c.category === option);
           const isScr =
             scripture === ArtCatScr.highlight &&
             cat &&
             scriptureTypeCategory(cat.slug);
           return (
-            // Include the render index so two categories that share a localized
-            // name can't collide on the same React key.
-            <li {...liProps} key={`${cat?.id ?? option}-${index}`}>
+            // categoryOptions is deduplicated by name, so the category id (or
+            // the option string as a fallback) is already a unique React key.
+            <li {...liProps} key={cat?.id ?? option}>
               {option}
               {isScr && (
                 <LightTooltip title={t.scriptureHighlight}>

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -213,34 +213,16 @@ export const SelectArtifactCategory = (props: IProps) => {
     };
   });
 
-  // Options are the localized category names, deduplicated so a name can never
-  // appear twice. New-category creation already blocks duplicate localized
-  // names (useArtifactCategory.isDuplicateCategory), but two distinct category
-  // slugs can still collapse to the same localized string (e.g. created under
-  // different languages), so we enforce uniqueness here at the point of use.
-  // Keeping the first occurrence matches how resolveExisting/commit resolve a
-  // typed name to an id (first case-insensitive match).
-  const categoryOptions = (() => {
-    const seen = new Set<string>();
-    const names: string[] = [];
-    artifactCategorys.forEach((c) => {
-      const name = c.category;
-      if (!name) return;
-      const key = name.trim().toLowerCase();
-      if (seen.has(key)) return;
-      seen.add(key);
-      names.push(name);
-    });
-    return names.sort((a, b) => (a < b ? -1 : 1));
-  })();
-
   return (
     <StyledBox>
       <Autocomplete
         freeSolo
         size="small"
         disabled={disabled ?? false}
-        options={categoryOptions}
+        options={artifactCategorys
+          .map((c) => c.category)
+          .filter(Boolean)
+          .sort((a, b) => (a < b ? -1 : 1))}
         value={currentName || null}
         inputValue={inputVal}
         onInputChange={(_e, v, reason) => {
@@ -261,16 +243,16 @@ export const SelectArtifactCategory = (props: IProps) => {
         onChange={(_e, v) => resolveExisting(v)}
         onBlur={() => resolveExisting(inputVal)}
         sx={textFieldProps}
-        renderOption={(liProps, option) => {
+        renderOption={(liProps, option, { index }) => {
           const cat = artifactCategorys.find((c) => c.category === option);
           const isScr =
             scripture === ArtCatScr.highlight &&
             cat &&
             scriptureTypeCategory(cat.slug);
           return (
-            // categoryOptions is deduplicated by name, so the category id (or
-            // the option string as a fallback) is already a unique React key.
-            <li {...liProps} key={cat?.id ?? option}>
+            // Include the render index so two categories that share a localized
+            // name can't collide on the same React key.
+            <li {...liProps} key={`${cat?.id ?? option}-${index}`}>
               {option}
               {isScr && (
                 <LightTooltip title={t.scriptureHighlight}>

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -250,8 +250,8 @@ export const SelectArtifactCategory = (props: IProps) => {
             cat &&
             scriptureTypeCategory(cat.slug);
           return (
-            // Include the render index so two categories that share a localized
-            // name can't collide on the same React key.
+            // We already prevent duplicate categories, but include the render index just a fallback in case somehow two
+            // categories end up with the same localized name in this particular language (shouldn't happen?)
             <li {...liProps} key={`${cat?.id ?? option}-${index}`}>
               {option}
               {isScr && (

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -35,12 +35,11 @@ interface IProps {
   // when the typed name matches none) and returns it. New categories are then
   // created on commit rather than on blur.
   commitRef?: RefObject<(() => Promise<string>) | null> | undefined;
-  // Fires as the user types when the field holds a brand-new (allowNew) name
-  // that matches no existing category. Because a new name isn't committed to a
-  // category id until commit() runs at save, parents that gate their Save
-  // button on a "changed" flag would otherwise never enable it for a
+  // Fires as the user types in an allowNew field, i.e. whenever the field holds
+  // text that only commit() will resolve to a category id. Parents that gate
+  // their Save button on a "changed" flag would otherwise never enable it for a
   // new-category-only edit; they use this to mark themselves dirty.
-  onNewDraft?: ((hasDraft: boolean) => void) | undefined;
+  onNewDraft?: (() => void) | undefined;
 }
 
 const StyledBox = styled(Box)<BoxProps>(() => ({
@@ -227,18 +226,12 @@ export const SelectArtifactCategory = (props: IProps) => {
         inputValue={inputVal}
         onInputChange={(_e, v, reason) => {
           setInputVal(v);
-          // Only react to real keystrokes, not the programmatic 'reset' MUI
-          // fires when the committed value changes.
-          if (reason !== 'input' || !onNewDraft) return;
-          const name = v.trim();
-          const hasDraft =
-            !!allowNew &&
-            name !== '' &&
-            name.toLowerCase() !== currentName.trim().toLowerCase() &&
-            !artifactCategorys.some(
-              (c) => c.category.trim().toLowerCase() === name.toLowerCase()
-            );
-          onNewDraft(hasDraft);
+          // A typed name isn't resolved to an id until commit(), so
+          // onCategoryChange won't fire; tell the parent it's dirty so Save can
+          // enable. Only real keystrokes count, not the programmatic 'reset' MUI
+          // fires when the committed value changes; and without allowNew a typed
+          // name is reverted on blur, so nothing was really edited.
+          if (reason === 'input' && allowNew) onNewDraft?.();
         }}
         onChange={(_e, v) => resolveExisting(v)}
         onBlur={() => resolveExisting(inputVal)}

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -6,7 +6,7 @@ import {
   SxProps,
   TextField,
 } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MutableRefObject } from 'react';
 import {
   ArtifactCategoryType,
   IArtifactCategory,
@@ -30,6 +30,11 @@ interface IProps {
   scripture?: ArtCatScr | undefined;
   type: ArtifactCategoryType;
   disabled?: boolean | undefined;
+  // When provided, the parent gets a `commit()` here to run at form submission:
+  // it resolves the current input to a category id (creating a new category
+  // when the typed name matches none) and returns it. New categories are then
+  // created on commit rather than on blur.
+  commitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
 }
 
 const StyledBox = styled(Box)<BoxProps>(() => ({
@@ -57,6 +62,7 @@ export const SelectArtifactCategory = (props: IProps) => {
     scripture,
     type,
     disabled,
+    commitRef,
   } = props;
   const artifactCategories =
     useOrbitData<ArtifactCategory[]>('artifactcategory');
@@ -109,9 +115,11 @@ export const SelectArtifactCategory = (props: IProps) => {
     onCategoryChange && onCategoryChange(id);
   };
 
-  // Resolve a chosen/typed category name to an id, creating a new category
-  // when the name doesn't match an existing one.
-  const resolveCommit = async (raw: string | null) => {
+  // Resolve a chosen/typed category name to an existing category id. Called on
+  // blur and on change. Deliberately does NOT create new categories — that is
+  // deferred to commit() (form submission) so navigating away without saving
+  // never leaves an orphaned category behind.
+  const resolveExisting = (raw: string | null) => {
     const name = (raw ?? '').trim();
     if (name.toLowerCase() === currentName.trim().toLowerCase()) return;
     if (!name) {
@@ -132,7 +140,30 @@ export const SelectArtifactCategory = (props: IProps) => {
       setInputVal(currentName);
       return;
     }
-    if (committingRef.current) return;
+    // allowNew + a new name: keep the typed text as-is and wait for commit().
+  };
+
+  // Resolve the current input to a category id, creating a new category when
+  // the typed name matches none. Intended to run at form submission via
+  // commitRef. Returns the resolved id (empty string when the field is blank).
+  const commit = async (): Promise<string> => {
+    const name = inputVal.trim();
+    if (!name) {
+      setCategory('');
+      return '';
+    }
+    const existing = artifactCategorys.find(
+      (c) => c.category.trim().toLowerCase() === name.toLowerCase()
+    );
+    if (existing) {
+      setCategory(existing.id);
+      return existing.id;
+    }
+    if (!allowNew) {
+      setInputVal(currentName);
+      return categoryId;
+    }
+    if (committingRef.current) return categoryId;
     committingRef.current = true;
     try {
       const newId = await addNewArtifactCategory(name, type);
@@ -140,16 +171,31 @@ export const SelectArtifactCategory = (props: IProps) => {
       setArtifactCategorys(cats);
       if (newId && newId !== 'duplicate') {
         setCategory(newId);
-      } else {
-        const dup = cats.find(
-          (c) => c.category.trim().toLowerCase() === name.toLowerCase()
-        );
-        if (dup) setCategory(dup.id);
+        return newId;
       }
+      const dup = cats.find(
+        (c) => c.category.trim().toLowerCase() === name.toLowerCase()
+      );
+      if (dup) {
+        setCategory(dup.id);
+        return dup.id;
+      }
+      return categoryId;
     } finally {
       committingRef.current = false;
     }
   };
+
+  // Expose commit() to the parent form. No dependency array: re-assign every
+  // render so the closure stays current; clear on unmount so a stale commit is
+  // never invoked once the field is gone.
+  useEffect(() => {
+    if (!commitRef) return;
+    commitRef.current = commit;
+    return () => {
+      commitRef.current = null;
+    };
+  });
 
   return (
     <StyledBox>
@@ -164,8 +210,8 @@ export const SelectArtifactCategory = (props: IProps) => {
         value={currentName || null}
         inputValue={inputVal}
         onInputChange={(_e, v) => setInputVal(v)}
-        onChange={(_e, v) => resolveCommit(v)}
-        onBlur={() => resolveCommit(inputVal)}
+        onChange={(_e, v) => resolveExisting(v)}
+        onBlur={() => resolveExisting(inputVal)}
         sx={textFieldProps}
         renderOption={(liProps, option, { index }) => {
           const cat = artifactCategorys.find((c) => c.category === option);

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -6,7 +6,7 @@ import {
   SxProps,
   TextField,
 } from '@mui/material';
-import { useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import {
   ArtifactCategoryType,
   IArtifactCategory,
@@ -34,7 +34,7 @@ interface IProps {
   // it resolves the current input to a category id (creating a new category
   // when the typed name matches none) and returns it. New categories are then
   // created on commit rather than on blur.
-  commitRef?: MutableRefObject<(() => Promise<string>) | null> | undefined;
+  commitRef?: RefObject<(() => Promise<string>) | null> | undefined;
 }
 
 const StyledBox = styled(Box)<BoxProps>(() => ({

--- a/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
+++ b/src/renderer/src/components/Sheet/SelectArtifactCategory.tsx
@@ -35,6 +35,12 @@ interface IProps {
   // when the typed name matches none) and returns it. New categories are then
   // created on commit rather than on blur.
   commitRef?: RefObject<(() => Promise<string>) | null> | undefined;
+  // Fires as the user types when the field holds a brand-new (allowNew) name
+  // that matches no existing category. Because a new name isn't committed to a
+  // category id until commit() runs at save, parents that gate their Save
+  // button on a "changed" flag would otherwise never enable it for a
+  // new-category-only edit; they use this to mark themselves dirty.
+  onNewDraft?: ((hasDraft: boolean) => void) | undefined;
 }
 
 const StyledBox = styled(Box)<BoxProps>(() => ({
@@ -63,6 +69,7 @@ export const SelectArtifactCategory = (props: IProps) => {
     type,
     disabled,
     commitRef,
+    onNewDraft,
   } = props;
   const artifactCategories =
     useOrbitData<ArtifactCategory[]>('artifactcategory');
@@ -209,7 +216,21 @@ export const SelectArtifactCategory = (props: IProps) => {
           .sort((a, b) => (a < b ? -1 : 1))}
         value={currentName || null}
         inputValue={inputVal}
-        onInputChange={(_e, v) => setInputVal(v)}
+        onInputChange={(_e, v, reason) => {
+          setInputVal(v);
+          // Only react to real keystrokes, not the programmatic 'reset' MUI
+          // fires when the committed value changes.
+          if (reason !== 'input' || !onNewDraft) return;
+          const name = v.trim();
+          const hasDraft =
+            !!allowNew &&
+            name !== '' &&
+            name.toLowerCase() !== currentName.trim().toLowerCase() &&
+            !artifactCategorys.some(
+              (c) => c.category.trim().toLowerCase() === name.toLowerCase()
+            );
+          onNewDraft(hasDraft);
+        }}
         onChange={(_e, v) => resolveExisting(v)}
         onBlur={() => resolveExisting(inputVal)}
         sx={textFieldProps}

--- a/src/renderer/src/components/Uploader.tsx
+++ b/src/renderer/src/components/Uploader.tsx
@@ -54,6 +54,10 @@ interface IProps {
     | ((planId: string, mediaRemoteIds?: string[]) => Promise<void>)
     | undefined; // logic when upload complete
   metaData?: React.JSX.Element | undefined; // component embeded in dialog
+  // Awaited once when the upload starts, before any media is created. Lets the
+  // embedded metaData commit deferred edits (e.g. create a new artifact
+  // category) so `finish` sees the resolved ids.
+  beforeUpload?: (() => Promise<void>) | undefined;
   ready?: (() => boolean) | undefined; // if false control is disabled
   // createProject?: (name: string) => Promise<string>;
   cancelled: React.RefObject<boolean>;
@@ -107,7 +111,7 @@ export const Uploader = (props: IProps) => {
     finish,
     uploadDialogBp,
   } = props;
-  const { metaData, ready } = props;
+  const { metaData, ready, beforeUpload } = props;
   const [isDeveloper] = useGlobal('developer');
   const t: IMediaTabStrings = useSelector(mediaTabSelector, shallowEqual);
   const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
@@ -393,6 +397,9 @@ export const Uploader = (props: IProps) => {
       showMessage(t.selectFiles);
       return;
     }
+    // Commit any deferred metaData edits (e.g. create a newly typed artifact
+    // category) before media records are created so `finish` sees final ids.
+    if (beforeUpload) await beforeUpload();
     if (
       uploadType &&
       ![

--- a/src/renderer/src/components/Uploader.tsx
+++ b/src/renderer/src/components/Uploader.tsx
@@ -160,6 +160,7 @@ export const Uploader = (props: IProps) => {
 
   const afterUploadCb = async (mediaId: string | undefined) => {
     if (mediaId) {
+      if (beforeUpload) await beforeUpload();
       successCount.current = 1;
       mediaIdRef.current = [mediaId];
     } else successCount.current = 0;


### PR DESCRIPTION
The artifact-category deferred-commit work. Now targets **develop** (PR #469 "Internalize changes part 1" has been squash-merged into develop, so this rebases to just the category delta on top of it).

## What changed
- **SelectArtifactCategory** → free-solo `Autocomplete`. Blur/change only *resolve against existing* categories (`resolveExisting`); a brand-new typed name is **created at form submission** via a single `commit()` handle exposed through `commitRef`. Avoids leaving an orphaned category behind when the user navigates away without saving.
- **Consumers wired to `commitRef`** so creation happens at save: `ResourceOverview`/`ResourceCategory`, `DiscussionCard`, and `PassageDetailArtifacts`(+mobile) for both the edit and add dialogs (two refs because two instances can be mounted).
- **Record path fix**: recording reaches `finish()` via `afterUploadCb` rather than `uploadMedia`, so the upload-path `beforeUpload` commit never ran and a newly typed category was silently dropped. The record path now commits the category too (guarded on `mediaId`).
- `RefObject` instead of deprecated `MutableRefObject` (React 19).

## Review follow-ups included
- **Save enabled for a new-category-only edit:** deferring creation meant a new typed name never fired `onCategoryChange`, so forms gating Save on a `changed` flag (`ResourceOverview`, `DiscussionCard`) could never enable it. Added a lightweight `onNewDraft(hasDraft)` callback that marks those forms dirty as the user types a new name. Kept the single `commitRef` for creation — a ref can't reactively re-enable a button, so one small callback is the minimal complement.
- **Never show a duplicated category name:** the picker options are now deduplicated by localized name (creation already blocks duplicate localized names, but two distinct slugs can collapse to the same localized string), so the previous render-index key workaround is removed.

## Test plan
- Type a brand-new category and **Save** in: edit-resource dialog, discussion card (as admin), Add Audio Resource (upload) — category is created and attached.
- Add Audio Resource by **recording** with a new category typed — category is created and attached (was previously dropped).
- Type a new category as the *only* edit — Save/Add enables.
- Navigate away without saving after typing a new name — no orphan category created.
- Scripture-highlight categories still show the info tooltip on the selected value and in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)