### PR TITLE
TT-7271 TT-7272: hide Configure General in Internalize on small screens

### DIFF
--- a/src/renderer/src/components/PassageDetail/Internalization/PassageDetailArtifacts.tsx
+++ b/src/renderer/src/components/PassageDetail/Internalization/PassageDetailArtifacts.tsx
@@ -74,6 +74,7 @@ import {
   removeExtension,
   isVisual,
   isUrl,
+  useMobile,
 } from '../../../utils';
 import { useOrbitData } from '../../../hoc/useOrbitData';
 import {
@@ -859,6 +860,7 @@ export function PassageDetailArtifacts() {
   };
 
   const [hasProjRes, setHasProjRes] = useState(false);
+  const { isMobileWidth } = useMobile();
 
   useEffect(() => {
     getProjectResources().then((res) => setHasProjRes(res.length > 0));
@@ -896,7 +898,7 @@ export function PassageDetailArtifacts() {
               <Grid>
                 <AddResource action={handleAction} />
               </Grid>
-              {hasProjRes && (
+              {hasProjRes && !isMobileWidth && (
                 <Grid>
                   <AltButton onClick={() => setProjectResourceVisible(true)}>
                     {t.configure}


### PR DESCRIPTION
## Summary
- use the shared `useMobile` small-screen detection in Internalize artifacts
- hide the `Configure General` action when screen width is small
- keep existing behavior unchanged on non-small screens

## Tickets
- TT-7271
- TT-7272 (also solved by this change)

## Validation
- attempted type-check, but local dependency/tooling was not available in this workspace (`tsc` not found)
