### PR TITLE
TT-7427 fix: disable combine with next while saving

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -1232,6 +1232,7 @@ export function PassageDetailGuidedPhraseRecord({
   ]);
 
   const handleSplitClause = useCallback(async () => {
+    if (savingRecording) return;
     const region = clauseRegions[currentIndex];
     if (!region) return;
     const splitPoint = playerControlsRef.current?.findClauseSplitPoint?.(
@@ -1264,6 +1265,7 @@ export function PassageDetailGuidedPhraseRecord({
     currentIndex,
     clauseRegions,
     completedIndices,
+    savingRecording,
     clauseSegString,
     phraseSegParams,
     setClauseSegString,

--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -1276,6 +1276,7 @@ export function PassageDetailGuidedPhraseRecord({
   ]);
 
   const handleCombineWithNext = useCallback(async () => {
+    if (savingRecording) return;
     if (!canCombineWithNext(currentIndex, clauseRegions, completedIndices)) {
       return;
     }
@@ -1296,6 +1297,7 @@ export function PassageDetailGuidedPhraseRecord({
     currentIndex,
     clauseRegions,
     completedIndices,
+    savingRecording,
     clauseSegString,
     phraseSegParams,
     setClauseSegString,

--- a/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailGuidedPhraseRecord.tsx
@@ -1311,6 +1311,7 @@ export function PassageDetailGuidedPhraseRecord({
   ]);
 
   const handleUndoCombine = useCallback(async () => {
+    if (savingRecording) return;
     if (!combineUndo) return;
     setClauseSegString(combineUndo);
     await persistClauseSegments(combineUndo);
@@ -1320,6 +1321,7 @@ export function PassageDetailGuidedPhraseRecord({
     void playCurrentClause(currentIndex);
   }, [
     combineUndo,
+    savingRecording,
     setClauseSegString,
     persistClauseSegments,
     applyColors,

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
@@ -157,6 +157,21 @@ describe('CarefulSpeechControls — Next Clause completion state', () => {
     expect(split?.disabled).toBe(true);
   });
 
+  it('Undo Combine is disabled while the recording upload is in progress', () => {
+    const { container } = render(
+      <CarefulSpeechControls
+        {...baseProps}
+        showUndoCombine
+        savingRecording
+      />
+    );
+    const undo = container.querySelector(
+      '#careful-speech-undo-combine'
+    ) as HTMLButtonElement | null;
+    expect(undo).toBeTruthy();
+    expect(undo?.disabled).toBe(true);
+  });
+
   it('hides Next Clause when sequential unit nav is enabled', () => {
     const { container } = render(
       <CarefulSpeechControls

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
@@ -131,6 +131,21 @@ describe('CarefulSpeechControls — Next Clause completion state', () => {
     expect(next?.disabled).toBe(true);
   });
 
+  it('Combine with Next Clause is disabled while the recording upload is in progress', () => {
+    const { container } = render(
+      <CarefulSpeechControls
+        {...baseProps}
+        canCombineWithNext
+        savingRecording
+      />
+    );
+    const combine = container.querySelector(
+      '#careful-speech-combine'
+    ) as HTMLButtonElement | null;
+    expect(combine).toBeTruthy();
+    expect(combine?.disabled).toBe(true);
+  });
+
   it('hides Next Clause when sequential unit nav is enabled', () => {
     const { container } = render(
       <CarefulSpeechControls

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.test.tsx
@@ -146,6 +146,17 @@ describe('CarefulSpeechControls — Next Clause completion state', () => {
     expect(combine?.disabled).toBe(true);
   });
 
+  it('Split Clause is disabled while the recording upload is in progress', () => {
+    const { container } = render(
+      <CarefulSpeechControls {...baseProps} canSplitClause savingRecording />
+    );
+    const split = container.querySelector(
+      '#careful-speech-split'
+    ) as HTMLButtonElement | null;
+    expect(split).toBeTruthy();
+    expect(split?.disabled).toBe(true);
+  });
+
   it('hides Next Clause when sequential unit nav is enabled', () => {
     const { container } = render(
       <CarefulSpeechControls

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
@@ -253,7 +253,7 @@ export default function CarefulSpeechControls({
         >
           <PriButton
             id={`${controlIdPrefix}-split`}
-            disabled={!canSplitClause || phase === 'recording'}
+            disabled={!canSplitClause || phase === 'recording' || savingRecording}
             onClick={onSplitClause}
             variant="outlined"
             color="inherit"

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
@@ -278,6 +278,7 @@ export default function CarefulSpeechControls({
               id={`${controlIdPrefix}-undo-combine`}
               aria-label={strings.undo}
               onClick={onUndoCombine}
+              disabled={savingRecording}
               size="small"
             >
               <UndoIcon />

--- a/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
+++ b/src/renderer/src/components/PassageDetail/carefulSpeech/CarefulSpeechControls.tsx
@@ -263,7 +263,9 @@ export default function CarefulSpeechControls({
           </PriButton>
           <PriButton
             id={`${controlIdPrefix}-combine`}
-            disabled={!canCombineWithNext || phase === 'recording'}
+            disabled={
+              !canCombineWithNext || phase === 'recording' || savingRecording
+            }
             onClick={onCombineWithNext}
             variant="outlined"
             color="inherit"


### PR DESCRIPTION
## Summary
- disable Combine with Next Clause, Split Clause, and Undo Combine while a Careful Speech recording is saving
- guard each boundary mutation callback against invocation during an active save
- add regression coverage for every disabled boundary control

## Test plan
- `npm test -- CarefulSpeechControls --runInBand --watchAll=false`
- `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)