### PR TITLE
TT-7524 test: lock BOLD record Versions hide and trash clear control

### DIFF
--- a/src/renderer/src/components/PassageDetail/PassageDetailRecord.test.tsx
+++ b/src/renderer/src/components/PassageDetail/PassageDetailRecord.test.tsx
@@ -10,7 +10,11 @@ const mockMemoryUpdate = jest.fn().mockResolvedValue(undefined);
 let capturedMediaRecordProps: {
   afterUploadCb: (mediaId: string | undefined) => Promise<void>;
   onRecordingCleared?: () => void | Promise<void>;
+  onVersions?: () => void;
+  trackState?: (state: { id: string; status: string }) => void;
 } | null = null;
+
+let vernacularVersionCount = 1;
 
 const passageDetailCtx = {
   passage: { id: 'p1', type: 'passage' },
@@ -35,6 +39,8 @@ jest.mock('../MediaRecord', () => ({
   default: (props: {
     afterUploadCb: (mediaId: string | undefined) => Promise<void>;
     onRecordingCleared?: () => void | Promise<void>;
+    onVersions?: () => void;
+    trackState?: (state: { id: string; status: string }) => void;
   }) => {
     capturedMediaRecordProps = props;
     return <div data-testid="media-record" />;
@@ -47,7 +53,7 @@ jest.mock('../../hoc/BigDialog', () => () => null);
 jest.mock('../AudioTab/VersionDlg', () => () => null);
 jest.mock('../SpeakerName', () => () => null);
 jest.mock('../AudioTab/usePassageVersionAudioRows', () => ({
-  usePassageVernacularVersionCount: () => 1,
+  usePassageVernacularVersionCount: () => vernacularVersionCount,
 }));
 jest.mock('../../control', () => ({
   AltButton: () => null,
@@ -150,12 +156,22 @@ describe('PassageDetailRecord BOLD step completion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedMediaRecordProps = null;
+    vernacularVersionCount = 1;
     passageDetailCtx.isBoldWorkflow = true;
     passageDetailCtx.mediafileId = 'mf1';
     passageDetailCtx.currentstep = 'step-record';
   });
 
   const renderRecord = () => render(<PassageDetailRecord width={400} />);
+
+  const markExistingVersionFetched = async () => {
+    await act(async () => {
+      capturedMediaRecordProps!.trackState?.({
+        id: 'mf1',
+        status: 'FETCHED',
+      });
+    });
+  };
 
   it('auto-completes and advances after successful save when BOLD', async () => {
     renderRecord();
@@ -210,5 +226,20 @@ describe('PassageDetailRecord BOLD step completion', () => {
     passageDetailCtx.isBoldWorkflow = false;
     renderRecord();
     expect(capturedMediaRecordProps?.onRecordingCleared).toBeUndefined();
+  });
+
+  it('does not pass onVersions when BOLD even with multiple vernacular versions', async () => {
+    vernacularVersionCount = 3;
+    renderRecord();
+    await markExistingVersionFetched();
+    expect(capturedMediaRecordProps?.onVersions).toBeUndefined();
+  });
+
+  it('passes onVersions when not BOLD with multiple vernacular versions', async () => {
+    passageDetailCtx.isBoldWorkflow = false;
+    vernacularVersionCount = 3;
+    renderRecord();
+    await markExistingVersionFetched();
+    expect(capturedMediaRecordProps?.onVersions).toBeDefined();
   });
 });

--- a/src/renderer/src/components/WSAudioPlayer.hotkeys.test.tsx
+++ b/src/renderer/src/components/WSAudioPlayer.hotkeys.test.tsx
@@ -152,8 +152,22 @@ jest.mock('../utils', () => ({
 }));
 
 jest.mock('../control', () => ({
-  AltButton: ({ children }: { children?: React.ReactNode }) => (
-    <button type="button">{children}</button>
+  AltButton: ({
+    children,
+    id,
+    onClick,
+    title,
+    disabled,
+  }: {
+    children?: React.ReactNode;
+    id?: string;
+    onClick?: () => void;
+    title?: string;
+    disabled?: boolean;
+  }) => (
+    <button type="button" id={id} onClick={onClick} title={title} disabled={disabled}>
+      {children}
+    </button>
   ),
   PriButton: ({ children }: { children?: React.ReactNode }) => (
     <button type="button">{children}</button>
@@ -305,5 +319,41 @@ describe('WSAudioPlayer record hotkeys', () => {
     );
 
     expect(queryByText('Loading')).toBeNull();
+  });
+
+  it('renders clear as a trash icon button, not a Clear text button', () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/wav' });
+    const { container } = render(
+      <WSAudioPlayer {...defaultProps} loading={false} blob={blob} />
+    );
+
+    act(() => {
+      capturedOnWSReady?.(10, false);
+    });
+
+    const clearBtn = container.querySelector('#wsAudioClear');
+    expect(clearBtn).toBeTruthy();
+    expect(clearBtn?.getAttribute('aria-label')).toBe('Clear');
+    expect(clearBtn?.querySelector('svg')).toBeTruthy();
+    // Old control was an AltButton whose visible label was the reset/Clear string.
+    expect(clearBtn?.textContent?.replace(/\s/g, '')).toBe('');
+  });
+
+  it('shows Versions only when onVersions is provided', () => {
+    const { container, rerender } = render(
+      <WSAudioPlayer {...defaultProps} loading={false} />
+    );
+
+    expect(container.querySelector('#pdRecordVersions')).toBeNull();
+
+    rerender(
+      <WSAudioPlayer
+        {...defaultProps}
+        loading={false}
+        onVersions={jest.fn()}
+      />
+    );
+
+    expect(container.querySelector('#pdRecordVersions')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Production polish for TT-7524 already merged in #429 (hide Versions on BOLD record; Clear → trash icon in `WSAudioPlayer`).
- QA reopened against build `4.6.0-alpha.0` before that merge landed; this PR adds regression tests so the behavior stays locked.
- `PassageDetailRecord`: asserts `onVersions` is omitted for BOLD even with multiple vernacular versions, and still passed when not BOLD.
- `WSAudioPlayer`: asserts clear is an icon button (no Clear text label) and Versions only renders when `onVersions` is provided.

## Test plan
- [x] `cd src/renderer && npm test -- PassageDetailRecord WSAudioPlayer.hotkeys --runInBand --watchAll=false`
- [ ] On a BOLD team Record step with existing audio + multiple versions: no Versions button; clear control is trash icon (opens Clear Recording confirm).
- [ ] On a non-BOLD record step with multiple versions: Versions still available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)