### PR TITLE
improve mobile edit-reference wheel picker

### DIFF
--- a/src/renderer/package-lock.json
+++ b/src/renderer/package-lock.json
@@ -25,6 +25,7 @@
         "@mui/material": "^7.3.4",
         "@mui/x-data-grid": "^8.11.0",
         "@mui/x-tree-view": "^8.11.0",
+        "@ncdai/react-wheel-picker": "^1.2.2",
         "@orbit/coordinator": "^0.17.0",
         "@orbit/core": "^0.17.0",
         "@orbit/indexeddb": "^0.17.2",
@@ -5044,6 +5045,18 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@ncdai/react-wheel-picker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@ncdai/react-wheel-picker/-/react-wheel-picker-1.2.2.tgz",
+      "integrity": "sha512-5BUA3ZsF6vCSSmshJml0ScjoDkzMTLc8cs7HtFHazERbhxdMEbBJKD01kLZNtnTgZ9DNL/e/+8WZnwBzOrIO4A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ncdai"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -44,6 +44,7 @@
     "@mui/material": "^7.3.4",
     "@mui/x-data-grid": "^8.11.0",
     "@mui/x-tree-view": "^8.11.0",
+    "@ncdai/react-wheel-picker": "^1.2.2",
     "@orbit/coordinator": "^0.17.0",
     "@orbit/core": "^0.17.0",
     "@orbit/indexeddb": "^0.17.2",

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
@@ -88,11 +88,7 @@ const optionValues = async (user: UserEvent, label: string) => {
 };
 
 /** Choose a MUI Select option by its data-value. */
-const selectByLabel = async (
-  user: UserEvent,
-  label: string,
-  value: string
-) => {
+const selectByLabel = async (user: UserEvent, label: string, value: string) => {
   await user.click(within(dialog()).getByLabelText(label));
   const listbox = await screen.findByRole('listbox');
   const match = within(listbox)

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
@@ -9,12 +9,45 @@ import {
   toPassageVerseKey,
 } from '../../../../utils/markVersesPassageVerses';
 
+const mockUseMobile = jest.fn(() => ({
+  isMobile: false,
+  isMobileView: false,
+  isMobileWidth: false,
+}));
+
 jest.mock('../../../../utils/useMobile', () => ({
-  useMobile: () => ({
-    isMobile: false,
-    isMobileView: false,
-    isMobileWidth: false,
-  }),
+  useMobile: () => mockUseMobile(),
+}));
+
+/** Stub the wheel as a native select so mobile-path tests stay deterministic. */
+jest.mock('@ncdai/react-wheel-picker', () => ({
+  WheelPickerWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="wheel-wrapper">{children}</div>
+  ),
+  WheelPicker: ({
+    options,
+    value,
+    onValueChange,
+  }: {
+    options: { value: string; label: React.ReactNode }[];
+    value: string;
+    onValueChange: (next: string) => void;
+  }) => (
+    <select
+      data-testid="wheel-select"
+      value={value}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option
+          key={option.value === '' ? 'empty' : option.value}
+          value={option.value}
+        >
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
 }));
 
 const option = (chapter: number, verse: number): PassageVerseOption => ({
@@ -105,6 +138,29 @@ const selectByLabel = async (user: UserEvent, label: string, value: string) => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 };
+
+/** Native-select option values inside a mobile wheel group. */
+const wheelOptionValues = (label: string) => {
+  const group = within(dialog()).getByRole('group', { name: label });
+  return within(group).getByTestId('wheel-select').querySelectorAll('option');
+};
+
+const selectWheelByLabel = async (
+  user: UserEvent,
+  label: string,
+  value: string
+) => {
+  const group = within(dialog()).getByRole('group', { name: label });
+  await user.selectOptions(within(group).getByTestId('wheel-select'), value);
+};
+
+beforeEach(() => {
+  mockUseMobile.mockReturnValue({
+    isMobile: false,
+    isMobileView: false,
+    isMobileWidth: false,
+  });
+});
 
 describe('EditReferenceDropdown unrestricted with multiple chapters', () => {
   test('renders discrete chapter and verse dropdowns for both endpoints', async () => {
@@ -241,5 +297,69 @@ describe('EditReferenceDropdown with a fixed start (unrestricted off)', () => {
     expect(
       within(dialog()).getByLabelText('end verse number')
     ).toBeInTheDocument();
+  });
+});
+
+describe('EditReferenceDropdown mobile wheel path', () => {
+  beforeEach(() => {
+    mockUseMobile.mockReturnValue({
+      isMobile: true,
+      isMobileView: true,
+      isMobileWidth: true,
+    });
+  });
+
+  test('renders wheel groups with the current values and option lists', () => {
+    renderDialog();
+
+    const startChapter = within(dialog()).getByRole('group', {
+      name: 'start chapter number',
+    });
+    expect(startChapter).toHaveAttribute('aria-valuetext', '1');
+    expect(within(startChapter).getByTestId('wheel-select')).toHaveValue('1');
+    expect(
+      [...wheelOptionValues('start verse number')].map((el) => el.value)
+    ).toEqual(['78', '79', '80']);
+    expect(
+      [...wheelOptionValues('end verse number')].map((el) => el.value)
+    ).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  test('changing the start chapter re-scopes and clamps the start verse wheel', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await selectWheelByLabel(user, 'start chapter number', '2');
+
+    const startVerse = within(dialog()).getByRole('group', {
+      name: 'start verse number',
+    });
+    expect(
+      [
+        ...within(startVerse)
+          .getByTestId('wheel-select')
+          .querySelectorAll('option'),
+      ].map((el) => el.value)
+    ).toEqual(['1', '2', '3', '4', '5']);
+    expect(within(startVerse).getByTestId('wheel-select')).toHaveValue('1');
+    expect(startVerse).toHaveAttribute('aria-valuetext', '1');
+  });
+
+  test('saves after editing via wheels', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog();
+
+    await selectWheelByLabel(user, 'start verse number', '79');
+    await selectWheelByLabel(user, 'end verse number', '3');
+    await user.click(within(dialog()).getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startChapter: 1,
+        startVerse: 79,
+        endChapter: 2,
+        endVerse: 3,
+      })
+    );
   });
 });

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
-import { render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
 import EditReferenceDropdown, {
   type EditReferenceValue,
 } from './EditReferenceDropdown';
@@ -8,6 +8,14 @@ import {
   type PassageVerseOption,
   toPassageVerseKey,
 } from '../../../../utils/markVersesPassageVerses';
+
+jest.mock('../../../../utils/useMobile', () => ({
+  useMobile: () => ({
+    isMobile: false,
+    isMobileView: false,
+    isMobileWidth: false,
+  }),
+}));
 
 const option = (chapter: number, verse: number): PassageVerseOption => ({
   chapter,
@@ -65,67 +73,106 @@ const renderDialog = (
 
 const dialog = () => screen.getByRole('dialog');
 
-const optionValues = (select: HTMLElement) =>
-  within(select)
+/** Open a MUI Select and return its menu option data-values. */
+const optionValues = async (user: UserEvent, label: string) => {
+  await user.click(within(dialog()).getByLabelText(label));
+  const listbox = await screen.findByRole('listbox');
+  const values = within(listbox)
     .getAllByRole('option')
-    .map((o) => (o as HTMLOptionElement).value);
+    .map((el) => el.getAttribute('data-value') ?? '');
+  await user.keyboard('{Escape}');
+  await waitFor(() => {
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+  return values;
+};
+
+/** Choose a MUI Select option by its data-value. */
+const selectByLabel = async (
+  user: UserEvent,
+  label: string,
+  value: string
+) => {
+  await user.click(within(dialog()).getByLabelText(label));
+  const listbox = await screen.findByRole('listbox');
+  const match = within(listbox)
+    .getAllByRole('option')
+    .find(
+      (el) =>
+        el.getAttribute('data-value') === value || el.textContent === value
+    );
+  if (!match) {
+    throw new Error(`No option matching "${value}" for "${label}"`);
+  }
+  await user.click(match);
+  await waitFor(() => {
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+};
 
 describe('EditReferenceDropdown unrestricted with multiple chapters', () => {
-  test('renders discrete chapter and verse dropdowns for both endpoints', () => {
+  test('renders discrete chapter and verse dropdowns for both endpoints', async () => {
+    const user = userEvent.setup();
     renderDialog();
 
-    const startChapter = within(dialog()).getByLabelText(
-      'start chapter number'
-    );
-    const endChapter = within(dialog()).getByLabelText('end chapter number');
-    expect(optionValues(startChapter)).toEqual(['1', '2']);
-    expect(optionValues(endChapter)).toEqual(['1', '2']);
-    expect((startChapter as HTMLSelectElement).value).toBe('1');
-    expect((endChapter as HTMLSelectElement).value).toBe('2');
+    expect(await optionValues(user, 'start chapter number')).toEqual([
+      '1',
+      '2',
+    ]);
+    expect(await optionValues(user, 'end chapter number')).toEqual(['1', '2']);
+    expect(
+      within(dialog()).getByLabelText('start chapter number')
+    ).toHaveTextContent('1');
+    expect(
+      within(dialog()).getByLabelText('end chapter number')
+    ).toHaveTextContent('2');
   });
 
-  test('verse options are scoped to the selected chapter', () => {
+  test('verse options are scoped to the selected chapter', async () => {
+    const user = userEvent.setup();
     renderDialog();
 
     // Start chapter 1 -> verses 78,79,80.
-    expect(
-      optionValues(within(dialog()).getByLabelText('start verse number'))
-    ).toEqual(['78', '79', '80']);
+    expect(await optionValues(user, 'start verse number')).toEqual([
+      '78',
+      '79',
+      '80',
+    ]);
     // End chapter 2 -> verses 1..5.
-    expect(
-      optionValues(within(dialog()).getByLabelText('end verse number'))
-    ).toEqual(['1', '2', '3', '4', '5']);
+    expect(await optionValues(user, 'end verse number')).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+    ]);
   });
 
   test('changing the start chapter re-scopes and clamps the start verse', async () => {
     const user = userEvent.setup();
     renderDialog();
 
-    await user.selectOptions(
-      within(dialog()).getByLabelText('start chapter number'),
-      '2'
-    );
+    await selectByLabel(user, 'start chapter number', '2');
 
-    const startVerse = within(dialog()).getByLabelText(
-      'start verse number'
-    ) as HTMLSelectElement;
-    expect(optionValues(startVerse)).toEqual(['1', '2', '3', '4', '5']);
+    expect(await optionValues(user, 'start verse number')).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+    ]);
     // 78 is not a verse of chapter 2, so the verse clamps to the chapter's first.
-    expect(startVerse.value).toBe('1');
+    expect(
+      within(dialog()).getByLabelText('start verse number')
+    ).toHaveTextContent('1');
   });
 
   test('saves the edited chapter:verse - chapter:verse reference', async () => {
     const user = userEvent.setup();
     const { onSave } = renderDialog();
 
-    await user.selectOptions(
-      within(dialog()).getByLabelText('start verse number'),
-      '79'
-    );
-    await user.selectOptions(
-      within(dialog()).getByLabelText('end verse number'),
-      '3'
-    );
+    await selectByLabel(user, 'start verse number', '79');
+    await selectByLabel(user, 'end verse number', '3');
     await user.click(within(dialog()).getByRole('button', { name: 'Save' }));
 
     expect(onSave).toHaveBeenCalledTimes(1);
@@ -141,7 +188,8 @@ describe('EditReferenceDropdown unrestricted with multiple chapters', () => {
 });
 
 describe('EditReferenceDropdown unrestricted with a single chapter', () => {
-  test('shows the chapter as fixed text, verses as dropdowns', () => {
+  test('shows the chapter as fixed text, verses as dropdowns', async () => {
+    const user = userEvent.setup();
     renderDialog({
       endVerseOptions: singleChapterOptions,
       value: {
@@ -159,12 +207,18 @@ describe('EditReferenceDropdown unrestricted with a single chapter', () => {
     expect(
       within(dialog()).queryByLabelText('end chapter number')
     ).not.toBeInTheDocument();
-    expect(
-      optionValues(within(dialog()).getByLabelText('start verse number'))
-    ).toEqual(['1', '2', '3', '4']);
-    expect(
-      optionValues(within(dialog()).getByLabelText('end verse number'))
-    ).toEqual(['1', '2', '3', '4']);
+    expect(await optionValues(user, 'start verse number')).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+    ]);
+    expect(await optionValues(user, 'end verse number')).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+    ]);
   });
 });
 

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -91,10 +91,14 @@ const wheelColumnWidth = (options: { label: ReactNode }[]) => {
   return `calc(${maxChars}ch + 12px)`;
 };
 
-/** Content-sized column; overrides library width:100% / flex:1 growth. */
+/**
+ * Content-sized column; overrides library width:100% / flex:1 growth.
+ * fontSize on the column itself so `ch` in wheelColumnWidth matches option text.
+ */
 const wheelColumnSx = {
   flex: '0 0 auto',
   maxWidth: '100%',
+  ...wheelFontSx,
   '& [data-rwp-wrapper]': {
     width: '100%',
   },
@@ -331,15 +335,26 @@ export default function EditReferenceDropdown({
         value: option.value,
         label: option.label,
       }));
+      // Remount when the option set changes so the cylinder re-centers after
+      // chapter switches clamp/re-scope the verse list.
+      const optionsKey = wheelOptions.map((option) => option.value).join('|');
+      const selected = options.find((option) => option.value === pickerValue);
+      const valueText =
+        typeof selected?.label === 'string' ||
+        typeof selected?.label === 'number'
+          ? String(selected.label).replace(/\u00A0/g, ' ')
+          : pickerValue || 'none';
       return (
         <Box
           sx={{ ...wheelColumnSx, width: wheelColumnWidth(options) }}
           aria-label={ariaLabel}
+          aria-valuetext={valueText}
           title={ariaLabel}
           role="group"
         >
           <WheelPickerWrapper>
             <WheelPicker
+              key={`${ariaLabel}:${optionsKey}`}
               options={wheelOptions}
               value={pickerValue}
               onValueChange={onChange}

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -7,45 +7,97 @@ import {
   DialogContent,
   DialogTitle,
   FormControlLabel,
-  NativeSelect,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
   Typography,
 } from '@mui/material';
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  WheelPicker,
+  WheelPickerWrapper,
+  type WheelPickerOption,
+} from '@ncdai/react-wheel-picker';
+import '@ncdai/react-wheel-picker/style.css';
 import {
   editReferenceValuesEqual,
   normalizeEditReferenceDraft,
   type PassageVerseOption,
   toPassageVerseKey,
 } from '../../../../utils/markVersesPassageVerses';
+import { useMobile } from '../../../../utils/useMobile';
 
 const suffixOptions = ['', 'a', 'b', 'c', 'd', 'e'];
 const selectSx = {
   width: 'auto',
-  '& .MuiNativeSelect-select': {
+  minWidth: 0,
+  '& .MuiSelect-select': {
     fontSize: '1.25rem',
     lineHeight: 1.2,
     textAlign: 'center',
     py: 0.5,
   },
-  '& .MuiNativeSelect-icon': {
+  '& .MuiSelect-icon': {
     fontSize: '1.25rem',
     right: 0,
   },
 };
 const verseSelectSx = {
   ...selectSx,
-  '& .MuiNativeSelect-select': {
-    ...selectSx['& .MuiNativeSelect-select'],
+  '& .MuiSelect-select': {
+    ...selectSx['& .MuiSelect-select'],
     fontSize: '1.1rem',
   },
 };
-const suffixOptionStyle = {
+/** Match readonly chapter/verse labels to editable Select size. */
+const labelSx = {
   fontSize: '1.1rem',
+  lineHeight: 1.2,
+  py: 0.5,
 };
-const verseOptionStyle = {
-  fontSize: '1rem',
+
+/** Narrow width for a single wheel column in the horizontal reference row. */
+const wheelColumnSx = {
+  width: 44,
+  minWidth: 0,
+  flex: '0 1 auto',
+  // Library wrapper defaults to width:100%; constrain it to the column.
+  '& [data-rwp-wrapper]': {
+    width: '100%',
+  },
 };
+const wheelSuffixColumnSx = {
+  ...wheelColumnSx,
+  width: 36,
+};
+const wheelVerseColumnSx = {
+  ...wheelColumnSx,
+  width: 52,
+};
+
+/** Compact wheel sizing so the dialog stays short. */
+const wheelPickerProps = {
+  visibleCount: 8 as const,
+  optionItemHeight: 28,
+};
+
+interface PickerOption {
+  value: string;
+  label: ReactNode;
+}
+
+interface ValuePickerProps {
+  value: string;
+  options: PickerOption[];
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  /** When true, use the slightly narrower suffix column on mobile. */
+  narrow?: boolean;
+  /** When true, use the slightly wider verse column on mobile. */
+  wide?: boolean;
+  selectSx?: typeof selectSx;
+}
 
 export interface EditReferenceValue {
   splitVerse: boolean;
@@ -92,6 +144,7 @@ export default function EditReferenceDropdown({
   onCancel,
   onSave,
 }: EditReferenceDropdownProps) {
+  const { isMobileWidth } = useMobile();
   const [draft, setDraft] = useState<EditReferenceValue>(value);
   const [initialSnapshot, setInitialSnapshot] =
     useState<EditReferenceValue>(value);
@@ -162,19 +215,17 @@ export default function EditReferenceDropdown({
   };
 
   const handleSuffixChange =
-    (key: 'startSuffix' | 'endSuffix') =>
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      const nextSuffix = event.target.value.toLowerCase();
+    (key: 'startSuffix' | 'endSuffix') => (nextSuffix: string) => {
       setDraft((current) => ({
         ...current,
-        [key]: nextSuffix,
+        [key]: nextSuffix.toLowerCase(),
       }));
     };
 
   // Changing a chapter may leave the current verse out of that chapter's range;
   // fall back to the chapter's first verse so the endpoint stays valid.
-  const handleStartChapterChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const chapter = Number(event.target.value);
+  const handleStartChapterChange = (next: string) => {
+    const chapter = Number(next);
     const verses = versesForChapter(chapter);
     setDraft((current) => ({
       ...current,
@@ -185,15 +236,12 @@ export default function EditReferenceDropdown({
     }));
   };
 
-  const handleStartVerseNumberChange = (
-    event: ChangeEvent<HTMLSelectElement>
-  ) => {
-    const verse = Number(event.target.value);
-    setDraft((current) => ({ ...current, startVerse: verse }));
+  const handleStartVerseNumberChange = (next: string) => {
+    setDraft((current) => ({ ...current, startVerse: Number(next) }));
   };
 
-  const handleEndChapterChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const chapter = Number(event.target.value);
+  const handleEndChapterChange = (next: string) => {
+    const chapter = Number(next);
     const verses = versesForChapter(chapter);
     setDraft((current) => ({
       ...current,
@@ -204,19 +252,14 @@ export default function EditReferenceDropdown({
     }));
   };
 
-  const handleEndVerseNumberChange = (
-    event: ChangeEvent<HTMLSelectElement>
-  ) => {
-    const verse = Number(event.target.value);
-    setDraft((current) => ({ ...current, endVerse: verse }));
+  const handleEndVerseNumberChange = (next: string) => {
+    setDraft((current) => ({ ...current, endVerse: Number(next) }));
   };
 
   // Restricted end: the combined chapter:verse dropdown keyed on the passage
   // verse list.
-  const handleEndVerseChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const selected = resolvedEndOptions.find(
-      (option) => option.key === event.target.value
-    );
+  const handleEndVerseChange = (next: string) => {
+    const selected = resolvedEndOptions.find((option) => option.key === next);
     if (!selected) return;
 
     setDraft((current) => ({
@@ -226,28 +269,89 @@ export default function EditReferenceDropdown({
     }));
   };
 
+  /**
+   * Mobile: iOS-style wheel. Otherwise: MUI Select.
+   * Drop the mobile branch (and the style.css import) if we abandon the wheel.
+   */
+  const renderValuePicker = ({
+    value: pickerValue,
+    options,
+    onChange,
+    ariaLabel,
+    narrow,
+    wide,
+    selectSx: pickerSelectSx = selectSx,
+  }: ValuePickerProps) => {
+    if (isMobileWidth) {
+      const wheelOptions: WheelPickerOption[] = options.map((option) => ({
+        value: option.value,
+        label: option.label,
+      }));
+      const columnSx = narrow
+        ? wheelSuffixColumnSx
+        : wide
+          ? wheelVerseColumnSx
+          : wheelColumnSx;
+      return (
+        <Box
+          sx={columnSx}
+          aria-label={ariaLabel}
+          title={ariaLabel}
+          role="group"
+        >
+          <WheelPickerWrapper>
+            <WheelPicker
+              options={wheelOptions}
+              value={pickerValue}
+              onValueChange={onChange}
+              {...wheelPickerProps}
+            />
+          </WheelPickerWrapper>
+        </Box>
+      );
+    }
+
+    const handleSelectChange = (event: SelectChangeEvent<string>) => {
+      onChange(event.target.value);
+    };
+
+    return (
+      <Select
+        variant="standard"
+        displayEmpty
+        value={pickerValue}
+        onChange={handleSelectChange}
+        inputProps={{ 'aria-label': ariaLabel, title: ariaLabel }}
+        sx={pickerSelectSx}
+      >
+        {options.map((option) => (
+          <MenuItem
+            key={option.value === '' ? `empty-${ariaLabel}` : option.value}
+            value={option.value}
+            sx={{ fontSize: '1.1rem', justifyContent: 'center' }}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    );
+  };
+
   const renderSuffixSelect = (side: 'start' | 'end') => {
     const isStart = side === 'start';
     const suffix = isStart ? draft.startSuffix : draft.endSuffix;
     const suffixLabel = `${side} verse suffix`;
-    return (
-      <NativeSelect
-        value={suffix}
-        onChange={handleSuffixChange(isStart ? 'startSuffix' : 'endSuffix')}
-        inputProps={{ 'aria-label': suffixLabel, title: suffixLabel }}
-        sx={selectSx}
-      >
-        {suffixOptions.map((option) => (
-          <option
-            key={option || `none-${side}`}
-            value={option}
-            style={suffixOptionStyle}
-          >
-            {option || ' '}
-          </option>
-        ))}
-      </NativeSelect>
-    );
+    return renderValuePicker({
+      value: suffix,
+      options: suffixOptions.map((option) => ({
+        value: option,
+        // Non-breaking space so the empty (no suffix) choice stays tappable.
+        label: option || '\u00A0',
+      })),
+      onChange: handleSuffixChange(isStart ? 'startSuffix' : 'endSuffix'),
+      ariaLabel: suffixLabel,
+      narrow: true,
+    });
   };
 
   /**
@@ -263,7 +367,7 @@ export default function EditReferenceDropdown({
     const chapterLabel = `${side} chapter number`;
     const verseLabel = `${side} verse number`;
     return (
-      <Box sx={{ textAlign: 'center', minWidth: 96 }}>
+      <Box sx={{ textAlign: 'center', minWidth: isMobileWidth ? 0 : 96 }}>
         <Box
           sx={{
             display: 'flex',
@@ -273,48 +377,35 @@ export default function EditReferenceDropdown({
           }}
         >
           {hasMultipleChapters ? (
-            <NativeSelect
-              value={String(chapter)}
-              onChange={
-                isStart ? handleStartChapterChange : handleEndChapterChange
-              }
-              inputProps={{ 'aria-label': chapterLabel, title: chapterLabel }}
-              sx={verseSelectSx}
-            >
-              {chapterOptions.map((option) => (
-                <option
-                  key={`${side}-chapter-${option}`}
-                  value={String(option)}
-                  style={verseOptionStyle}
-                >
-                  {option}
-                </option>
-              ))}
-            </NativeSelect>
+            renderValuePicker({
+              value: String(chapter),
+              options: chapterOptions.map((option) => ({
+                value: String(option),
+                label: String(option),
+              })),
+              onChange: isStart
+                ? handleStartChapterChange
+                : handleEndChapterChange,
+              ariaLabel: chapterLabel,
+              selectSx: verseSelectSx,
+            })
           ) : (
-            <Typography sx={{ fontSize: 24 }}>{chapter}</Typography>
+            <Typography sx={labelSx}>{chapter}</Typography>
           )}
-          <Typography sx={{ fontSize: 24 }}>:</Typography>
-          <NativeSelect
-            value={String(verse)}
-            onChange={
-              isStart
-                ? handleStartVerseNumberChange
-                : handleEndVerseNumberChange
-            }
-            inputProps={{ 'aria-label': verseLabel, title: verseLabel }}
-            sx={verseSelectSx}
-          >
-            {verseOptions.map((option) => (
-              <option
-                key={`${side}-verse-${option}`}
-                value={String(option)}
-                style={verseOptionStyle}
-              >
-                {option}
-              </option>
-            ))}
-          </NativeSelect>
+          <Typography sx={labelSx}>:</Typography>
+          {renderValuePicker({
+            value: String(verse),
+            options: verseOptions.map((option) => ({
+              value: String(option),
+              label: String(option),
+            })),
+            onChange: isStart
+              ? handleStartVerseNumberChange
+              : handleEndVerseNumberChange,
+            ariaLabel: verseLabel,
+            wide: true,
+            selectSx: verseSelectSx,
+          })}
           {draft.splitVerse ? renderSuffixSelect(side) : null}
         </Box>
       </Box>
@@ -346,7 +437,7 @@ export default function EditReferenceDropdown({
           {unrestricted ? (
             renderEditableEndpoint('start')
           ) : (
-            <Box sx={{ textAlign: 'center', minWidth: 96 }}>
+            <Box sx={{ textAlign: 'center', minWidth: isMobileWidth ? 0 : 96 }}>
               <Box
                 sx={{
                   display: 'flex',
@@ -358,7 +449,7 @@ export default function EditReferenceDropdown({
                 <Typography
                   component="div"
                   aria-label="start verse reference"
-                  sx={{ fontSize: 28, lineHeight: 1.2, py: 0.5 }}
+                  sx={labelSx}
                 >
                   {`${draft.startChapter}:${draft.startVerse}`}
                 </Typography>
@@ -370,7 +461,7 @@ export default function EditReferenceDropdown({
           {unrestricted ? (
             renderEditableEndpoint('end')
           ) : (
-            <Box sx={{ textAlign: 'center', minWidth: 96 }}>
+            <Box sx={{ textAlign: 'center', minWidth: isMobileWidth ? 0 : 96 }}>
               <Box
                 sx={{
                   display: 'flex',
@@ -380,29 +471,21 @@ export default function EditReferenceDropdown({
                 }}
               >
                 {showChapterPrefix ? (
-                  <Typography sx={{ fontSize: 24 }}>
+                  <Typography sx={labelSx}>
                     {`${draft.endChapter}:`}
                   </Typography>
                 ) : null}
-                <NativeSelect
-                  value={endSelectValue}
-                  onChange={handleEndVerseChange}
-                  inputProps={{
-                    'aria-label': 'end verse number',
-                    title: 'end verse number',
-                  }}
-                  sx={verseSelectSx}
-                >
-                  {resolvedEndOptions.map((option) => (
-                    <option
-                      key={`end-verse-${option.key}`}
-                      value={option.key}
-                      style={verseOptionStyle}
-                    >
-                      {option.verse}
-                    </option>
-                  ))}
-                </NativeSelect>
+                {renderValuePicker({
+                  value: endSelectValue,
+                  options: resolvedEndOptions.map((option) => ({
+                    value: option.key,
+                    label: String(option.verse),
+                  })),
+                  onChange: handleEndVerseChange,
+                  ariaLabel: 'end verse number',
+                  wide: true,
+                  selectSx: verseSelectSx,
+                })}
                 {draft.splitVerse ? renderSuffixSelect('end') : null}
               </Box>
             </Box>

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -57,6 +57,16 @@ const labelSx = {
   py: 0.5,
 };
 
+/**
+ * Match wheel option/highlight text to labelSx (1.1rem, normal weight).
+ * Library defaults are 0.875rem options and 1rem / weight 500 for the highlight.
+ */
+const wheelFontSx = {
+  fontSize: '1.1rem',
+  fontWeight: 400,
+  fontFamily: 'inherit',
+};
+
 /** Narrow width for a single wheel column in the horizontal reference row. */
 const wheelColumnSx = {
   width: 44,
@@ -66,6 +76,9 @@ const wheelColumnSx = {
   '& [data-rwp-wrapper]': {
     width: '100%',
   },
+  '& [data-rwp-option]': wheelFontSx,
+  '& [data-rwp-highlight-wrapper]': wheelFontSx,
+  '& [data-rwp-highlight-item]': wheelFontSx,
 };
 const wheelSuffixColumnSx = {
   ...wheelColumnSx,
@@ -76,10 +89,13 @@ const wheelVerseColumnSx = {
   width: 52,
 };
 
-/** Compact wheel sizing so the dialog stays short. */
+/**
+ * Mid-height cylinder — taller than the original compact 8/28, shorter than 16/32.
+ * visibleCount must be a multiple of 4 (library constraint).
+ */
 const wheelPickerProps = {
-  visibleCount: 8 as const,
-  optionItemHeight: 28,
+  visibleCount: 12 as const,
+  optionItemHeight: 30,
 };
 
 interface PickerOption {

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/EditReferenceDropdown.tsx
@@ -67,26 +67,60 @@ const wheelFontSx = {
   fontFamily: 'inherit',
 };
 
-/** Narrow width for a single wheel column in the horizontal reference row. */
+/**
+ * Wheel options are absolutely positioned, so columns have no intrinsic width.
+ * Size each column from its longest label (+ padding) and never grow.
+ */
+const wheelColumnWidth = (options: { label: ReactNode }[]) => {
+  const maxChars = Math.max(
+    2, // At least ~2 character widths (e.g. "12", "a ") so it's not too hard to scroll
+    ...options.map((option) => {
+      if (
+        typeof option.label === 'string' ||
+        typeof option.label === 'number'
+      ) {
+        return (
+          String(option.label)
+            .replace(/\u00A0/g, ' ')
+            .trim().length || 1
+        );
+      }
+      return 1;
+    })
+  );
+  return `calc(${maxChars}ch + 12px)`;
+};
+
+/** Content-sized column; overrides library width:100% / flex:1 growth. */
 const wheelColumnSx = {
-  width: 44,
-  minWidth: 0,
-  flex: '0 1 auto',
-  // Library wrapper defaults to width:100%; constrain it to the column.
+  flex: '0 0 auto',
+  maxWidth: '100%',
   '& [data-rwp-wrapper]': {
     width: '100%',
   },
-  '& [data-rwp-option]': wheelFontSx,
-  '& [data-rwp-highlight-wrapper]': wheelFontSx,
-  '& [data-rwp-highlight-item]': wheelFontSx,
-};
-const wheelSuffixColumnSx = {
-  ...wheelColumnSx,
-  width: 36,
-};
-const wheelVerseColumnSx = {
-  ...wheelColumnSx,
-  width: 52,
+  '& [data-rwp]': {
+    flex: '0 0 auto',
+    width: '100%',
+  },
+  // Unselected 3D options: muted/faded vs the selected highlight.
+  '& [data-rwp-option]': {
+    ...wheelFontSx,
+    color: 'text.secondary',
+    opacity: 0.45,
+  },
+  '& [data-rwp-highlight-wrapper]': {
+    ...wheelFontSx,
+    color: 'text.primary',
+    // Hairlines frame the selection (iOS-style).
+    borderTop: '1px solid',
+    borderBottom: '1px solid',
+    borderColor: 'grey.400',
+    bgcolor: 'transparent',
+  },
+  '& [data-rwp-highlight-item]': {
+    ...wheelFontSx,
+    color: 'text.primary',
+  },
 };
 
 /**
@@ -108,10 +142,6 @@ interface ValuePickerProps {
   options: PickerOption[];
   onChange: (value: string) => void;
   ariaLabel: string;
-  /** When true, use the slightly narrower suffix column on mobile. */
-  narrow?: boolean;
-  /** When true, use the slightly wider verse column on mobile. */
-  wide?: boolean;
   selectSx?: typeof selectSx;
 }
 
@@ -294,8 +324,6 @@ export default function EditReferenceDropdown({
     options,
     onChange,
     ariaLabel,
-    narrow,
-    wide,
     selectSx: pickerSelectSx = selectSx,
   }: ValuePickerProps) => {
     if (isMobileWidth) {
@@ -303,14 +331,9 @@ export default function EditReferenceDropdown({
         value: option.value,
         label: option.label,
       }));
-      const columnSx = narrow
-        ? wheelSuffixColumnSx
-        : wide
-          ? wheelVerseColumnSx
-          : wheelColumnSx;
       return (
         <Box
-          sx={columnSx}
+          sx={{ ...wheelColumnSx, width: wheelColumnWidth(options) }}
           aria-label={ariaLabel}
           title={ariaLabel}
           role="group"
@@ -366,7 +389,6 @@ export default function EditReferenceDropdown({
       })),
       onChange: handleSuffixChange(isStart ? 'startSuffix' : 'endSuffix'),
       ariaLabel: suffixLabel,
-      narrow: true,
     });
   };
 
@@ -419,7 +441,6 @@ export default function EditReferenceDropdown({
               ? handleStartVerseNumberChange
               : handleEndVerseNumberChange,
             ariaLabel: verseLabel,
-            wide: true,
             selectSx: verseSelectSx,
           })}
           {draft.splitVerse ? renderSuffixSelect(side) : null}
@@ -473,7 +494,9 @@ export default function EditReferenceDropdown({
               </Box>
             </Box>
           )}
-          <Typography variant="h6">-</Typography>
+          <Typography variant="h6" sx={{ mx: 1 }}>
+            -
+          </Typography>
           {unrestricted ? (
             renderEditableEndpoint('end')
           ) : (
@@ -487,9 +510,7 @@ export default function EditReferenceDropdown({
                 }}
               >
                 {showChapterPrefix ? (
-                  <Typography sx={labelSx}>
-                    {`${draft.endChapter}:`}
-                  </Typography>
+                  <Typography sx={labelSx}>{`${draft.endChapter}:`}</Typography>
                 ) : null}
                 {renderValuePicker({
                   value: endSelectValue,
@@ -499,7 +520,6 @@ export default function EditReferenceDropdown({
                   })),
                   onChange: handleEndVerseChange,
                   ariaLabel: 'end verse number',
-                  wide: true,
                   selectSx: verseSelectSx,
                 })}
                 {draft.splitVerse ? renderSuffixSelect('end') : null}

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVerses.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVerses.test.tsx
@@ -341,11 +341,7 @@ const confirmReset = async (user: UserEvent) => {
 const editReferenceDialog = () => screen.getByRole('dialog');
 
 /** Choose a MUI Select option by aria-label and data-value. */
-const selectByLabel = async (
-  user: UserEvent,
-  label: string,
-  value: string
-) => {
+const selectByLabel = async (user: UserEvent, label: string, value: string) => {
   await user.click(within(editReferenceDialog()).getByLabelText(label));
   const listbox = await screen.findByRole('listbox');
   // Match data-value (e.g. "1:2") or visible label (e.g. "2"), same as

--- a/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVerses.test.tsx
+++ b/src/renderer/src/components/PassageDetail/mobile/MarkVerses/PassageDetailMarkVerses.test.tsx
@@ -32,6 +32,15 @@ jest.mock('../../../../context/useGlobal', () => ({
   useGetGlobal: jest.fn(),
 }));
 
+// Force the MUI Select path in EditReferenceDropdown (not the mobile wheel).
+jest.mock('../../../../utils/useMobile', () => ({
+  useMobile: () => ({
+    isMobile: false,
+    isMobileView: false,
+    isMobileWidth: false,
+  }),
+}));
+
 interface IRow {
   id: string;
   sequenceNum: number;
@@ -331,6 +340,31 @@ const confirmReset = async (user: UserEvent) => {
 
 const editReferenceDialog = () => screen.getByRole('dialog');
 
+/** Choose a MUI Select option by aria-label and data-value. */
+const selectByLabel = async (
+  user: UserEvent,
+  label: string,
+  value: string
+) => {
+  await user.click(within(editReferenceDialog()).getByLabelText(label));
+  const listbox = await screen.findByRole('listbox');
+  // Match data-value (e.g. "1:2") or visible label (e.g. "2"), same as
+  // the old native selectOptions(string) behavior.
+  const match = within(listbox)
+    .getAllByRole('option')
+    .find(
+      (el) =>
+        el.getAttribute('data-value') === value || el.textContent === value
+    );
+  if (!match) {
+    throw new Error(`No option matching "${value}" for "${label}"`);
+  }
+  await user.click(match);
+  await waitFor(() => {
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+};
+
 /**
  * Click the in-row "Edit Reference" button. It now renders as a compact icon
  * button inside the current table row (visible text "Edit"), so its accessible
@@ -483,10 +517,7 @@ test('highlights the matching waveform region when a row is edited', async () =>
   await user.click(
     within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
   );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('start verse suffix'),
-    'a'
-  );
+  await selectByLabel(user, 'start verse suffix', 'a');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -604,8 +635,20 @@ test('opens and cancels the split verse dialog', async () => {
   expect(screen.getByLabelText('start verse reference')).toHaveTextContent(
     '1:1'
   );
-  expect(screen.getAllByRole('option', { name: '4' })).toHaveLength(1);
-  expect(screen.queryAllByRole('option', { name: '5' })).toHaveLength(0);
+  await user.click(
+    within(editReferenceDialog()).getByLabelText('end verse number')
+  );
+  const endVerseListbox = await screen.findByRole('listbox');
+  expect(
+    within(endVerseListbox).getAllByRole('option', { name: '4' })
+  ).toHaveLength(1);
+  expect(
+    within(endVerseListbox).queryAllByRole('option', { name: '5' })
+  ).toHaveLength(0);
+  await user.keyboard('{Escape}');
+  await waitFor(() => {
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
   expect(screen.queryByLabelText('start verse suffix')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('end verse suffix')).not.toBeInTheDocument();
 
@@ -643,16 +686,10 @@ test('disables Save on Edit Reference until the reference changes', async () => 
   });
   expect(saveButton).toBeDisabled();
 
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '2'
-  );
+  await selectByLabel(user, 'end verse number', '2');
   expect(saveButton).not.toBeDisabled();
 
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '1'
-  );
+  await selectByLabel(user, 'end verse number', '1');
   expect(saveButton).toBeDisabled();
 });
 
@@ -715,18 +752,9 @@ test('saves a split verse range and shifts following references up', async () =>
   expect(
     within(editReferenceDialog()).getByLabelText('end verse number')
   ).not.toBeDisabled();
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '2'
-  );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('start verse suffix'),
-    'a'
-  );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse suffix'),
-    'e'
-  );
+  await selectByLabel(user, 'end verse number', '2');
+  await selectByLabel(user, 'start verse suffix', 'a');
+  await selectByLabel(user, 'end verse suffix', 'e');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -755,10 +783,7 @@ test('opens split verse unchecked for a numeric range like 1:1-4', async () => {
 
   await clickMarkVersesRowByLimitsText(user, lim(0, 69));
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '4'
-  );
+  await selectByLabel(user, 'end verse number', '4');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -789,10 +814,7 @@ test('adds rows when narrowing a wide reference on a single segment', async () =
 
   await clickMarkVersesRowByLimitsText(user, lim(0, 69));
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '4'
-  );
+  await selectByLabel(user, 'end verse number', '4');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -800,10 +822,7 @@ test('adds rows when narrowing a wide reference on a single segment', async () =
   expect(screen.getByLabelText('verse-reference-1')).toHaveTextContent('1:1-4');
 
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '1'
-  );
+  await selectByLabel(user, 'end verse number', '1');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -834,10 +853,7 @@ test('adds rows when the first row range is narrowed after spanning the passage'
 
   await clickMarkVersesRowByLimitsText(user, lim(0, 10));
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '4'
-  );
+  await selectByLabel(user, 'end verse number', '4');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -845,10 +861,7 @@ test('adds rows when the first row range is narrowed after spanning the passage'
   expect(screen.getByLabelText('verse-reference-1')).toHaveTextContent('1:1-4');
 
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '1'
-  );
+  await selectByLabel(user, 'end verse number', '1');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -877,10 +890,7 @@ test('saving an ending verse without split creates a range and shifts following 
 
   await clickMarkVersesRowByLimitsText(user, lim(0, 10));
   await clickEditReference(user);
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '2'
-  );
+  await selectByLabel(user, 'end verse number', '2');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -914,10 +924,7 @@ test('split uses the selected left and right verses rather than the dialog row',
   await user.click(
     within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
   );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '4'
-  );
+  await selectByLabel(user, 'end verse number', '4');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -952,18 +959,9 @@ test('shows undo after dialog save and restores the previous table', async () =>
   await user.click(
     within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
   );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse number'),
-    '2'
-  );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('start verse suffix'),
-    'a'
-  );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('end verse suffix'),
-    'e'
-  );
+  await selectByLabel(user, 'end verse number', '2');
+  await selectByLabel(user, 'start verse suffix', 'a');
+  await selectByLabel(user, 'end verse suffix', 'e');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );
@@ -1004,10 +1002,7 @@ test('reset clears markers and restores the original reference table', async () 
   await user.click(
     within(editReferenceDialog()).getByRole('checkbox', { name: 'Split Verse' })
   );
-  await user.selectOptions(
-    within(editReferenceDialog()).getByLabelText('start verse suffix'),
-    'b'
-  );
+  await selectByLabel(user, 'start verse suffix', 'b');
   await user.click(
     within(editReferenceDialog()).getByRole('button', { name: 'Save' })
   );


### PR DESCRIPTION
## Summary
- Replace native selects with a mobile wheel picker (`@ncdai/react-wheel-picker`) for Mark Verses edit-reference, keeping MUI Select on wider viewports.
- Size wheel columns from content (longest label) instead of fixed widths, match surrounding label font/height, and restyle the selection band with muted neighbors for clearer scrolling.

## Test plan
- [ ] On a narrow/mobile viewport, open Mark Verses → edit a segment reference and confirm start/end wheels scroll and select cleanly
- [ ] Confirm chapter/verse/suffix columns are not overly wide or cramped for single- and multi-digit values
- [ ] On desktop width, confirm MUI Selects still work for the same dialog
- [ ] (Optional) Load https://ideology-affront-contrite.ngrok-free.dev on a phone and exercise the picker over the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)