### PR TITLE
Add reusable layout `sx` values and use them to standardize header rows

### DIFF
--- a/src/renderer/src/components/App/AppHead.tsx
+++ b/src/renderer/src/components/App/AppHead.tsx
@@ -327,17 +327,17 @@ export function AppHead({
     <AppBar
       position={position}
       color="inherit"
-      sx={{
+      sx={(theme) => ({
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'center',
-        p: 1.5,
+        p: theme.layout.gap,
         backgroundColor: 'custom.headerBackground',
         ...(drawBottomBorder && {
           borderBottom: '1px solid',
           borderColor: 'divider',
         }),
-      }}
+      })}
     >
       {progressVariant && (
         <LinearProgress

--- a/src/renderer/src/components/App/AppHead.tsx
+++ b/src/renderer/src/components/App/AppHead.tsx
@@ -29,6 +29,7 @@ import { useSnackBar } from '../../hoc/SnackBar';
 import { withBucket } from '../../hoc/withBucket';
 import { viewModeSelector } from '../../selector';
 import { ApmLogo } from '../../control/ApmLogo';
+import { spreadSx, rowSx, flexibleSx, rigidSx } from '../../control';
 import HelpMenu from '../HelpMenu';
 import PolicyDialog from '../PolicyDialog';
 import ProjectDownloadAlert from '../ProjectDownloadAlert';
@@ -345,24 +346,8 @@ export function AppHead({
           sx={{ position: 'absolute', top: 0, left: 0, right: 0 }}
         />
       )}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          gap: (theme) => theme.layout.gap,
-          width: '100%',
-          minWidth: 0,
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: (theme) => theme.layout.gap,
-            flex: '1 1 auto',
-            minWidth: 0,
-          }}
-        >
+      <Box sx={spreadSx}>
+        <Box sx={[rowSx, flexibleSx]}>
           {!isDetail ? (
             <IconButton
               aria-label={tv.home}
@@ -381,14 +366,7 @@ export function AppHead({
           )}
           {isDetail ? <DetailTitle /> : <OrgHead />}
         </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: (theme) => theme.layout.gap,
-            flexShrink: 0,
-          }}
-        >
+        <Box sx={[rowSx, rigidSx]}>
           {!isMobileWidth && (
             <HeadStatus
               handleMenu={handleMenu}

--- a/src/renderer/src/components/App/ContentLayout.tsx
+++ b/src/renderer/src/components/App/ContentLayout.tsx
@@ -1,15 +1,18 @@
-import { Box, SxProps } from '@mui/material';
+import { Box, SxProps, Theme } from '@mui/material';
+
+// Normalize sx (object | callback | array | undefined) to an array so it can be spread after base styles
+const asSxArray = (sx?: SxProps<Theme>) => (Array.isArray(sx) ? sx : [sx]);
 
 interface ContentLayoutProps {
   header: React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;
   footerAbove?: React.ReactNode;
-  headerSx?: SxProps;
+  headerSx?: SxProps<Theme>;
   drawBottomBorder?: boolean;
-  contentSx?: SxProps;
-  footerSx?: SxProps;
-  footerAboveSx?: SxProps;
+  contentSx?: SxProps<Theme>;
+  footerSx?: SxProps<Theme>;
+  footerAboveSx?: SxProps<Theme>;
   contentRef?: React.Ref<HTMLDivElement>;
 }
 
@@ -37,46 +40,52 @@ export default function ContentLayout({
       }}
     >
       <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          flexShrink: 0,
-          minWidth: 0,
-          px: 1.5,
-          pb: 1.5,
-          backgroundColor: 'custom.headerBackground',
-          ...(drawBottomBorder && {
-            borderBottom: '1px solid',
-            borderColor: 'divider',
+        sx={[
+          (theme) => ({
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexShrink: 0,
+            minWidth: 0,
+            px: theme.layout.gap,
+            pb: theme.layout.gap,
+            backgroundColor: 'custom.headerBackground',
+            ...(drawBottomBorder && {
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+            }),
           }),
-          ...headerSx,
-        }}
+          ...asSxArray(headerSx),
+        ]}
       >
         {header}
       </Box>
       <Box
         ref={contentRef}
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minWidth: 0,
-          minHeight: 0,
-          overflowX: 'hidden',
-          overflowY: 'auto',
-          ...contentSx,
-        }}
+        sx={[
+          {
+            display: 'flex',
+            flexDirection: 'column',
+            flex: 1,
+            minWidth: 0,
+            minHeight: 0,
+            overflowX: 'hidden',
+            overflowY: 'auto',
+          },
+          ...asSxArray(contentSx),
+        ]}
       >
         {children}
       </Box>
       {footerAbove && (
-        <Box sx={{ flexShrink: 0, minWidth: 0, ...footerAboveSx }}>
+        <Box sx={[{ flexShrink: 0, minWidth: 0 }, ...asSxArray(footerAboveSx)]}>
           {footerAbove}
         </Box>
       )}
       {footer && (
-        <Box sx={{ flexShrink: 0, minWidth: 0, ...footerSx }}>{footer}</Box>
+        <Box sx={[{ flexShrink: 0, minWidth: 0 }, ...asSxArray(footerSx)]}>
+          {footer}
+        </Box>
       )}
     </Box>
   );

--- a/src/renderer/src/components/App/OrgHead.tsx
+++ b/src/renderer/src/components/App/OrgHead.tsx
@@ -20,6 +20,7 @@ import BigDialog from '../../hoc/BigDialog';
 import { BigDialogBp } from '../../hoc/BigDialogBp';
 import { useOrbitData } from '../../hoc/useOrbitData';
 import { cardsSelector } from '../../selector';
+import { rowSx } from '../../control';
 import Confirm from '../AlertDialog';
 import GroupTabs from '../GroupTabs';
 import { StepEditor } from '../StepEditor';
@@ -167,15 +168,7 @@ export const OrgHead = () => {
   const handleDeleteRefused = () => setDeleteItem(undefined);
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: (theme) => theme.layout.gap,
-        flex: '1 1 auto',
-        minWidth: 0,
-      }}
-    >
+    <Box sx={[rowSx, { alignItems: 'center' }]}>
       <Typography
         noWrap
         sx={{

--- a/src/renderer/src/components/AssignmentTable.tsx
+++ b/src/renderer/src/components/AssignmentTable.tsx
@@ -534,7 +534,7 @@ export function AssignmentTable() {
         </Box>
       }
       drawBottomBorder={true}
-      contentSx={{ p: 1.5 }}
+      contentSx={(theme) => ({ p: theme.layout.gap })}
     >
       <AssignmentDiv ref={boxRef} id="AssignmentTable">
         <TreeDataGrid

--- a/src/renderer/src/components/AssignmentTable.tsx
+++ b/src/renderer/src/components/AssignmentTable.tsx
@@ -60,7 +60,7 @@ import {
   assignmentSelector,
   sharedSelector,
 } from '../selector';
-import { GrowingSpacer, LightTooltip } from '../control';
+import { LightTooltip, spreadSx, rowSx } from '../control';
 import ContentLayout from './App/ContentLayout';
 import { GetReference } from './AudioTab/GetReference';
 import { PlanTabSelect } from './Sheet/PlanTabSelect';
@@ -503,12 +503,12 @@ export function AssignmentTable() {
   return (
     <ContentLayout
       header={
-        <>
+        <Box sx={spreadSx}>
           {isMobile ? (
             <PlanTabSelect />
           ) : (
             userIsAdmin && (
-              <Box sx={{ display: 'flex', gap: 1.5 }}>
+              <Box sx={rowSx}>
                 <Button
                   id="assignAdd"
                   key="assign"
@@ -531,8 +531,7 @@ export function AssignmentTable() {
               </Box>
             )
           )}
-          <GrowingSpacer />
-        </>
+        </Box>
       }
       drawBottomBorder={true}
       contentSx={{ p: 1.5 }}

--- a/src/renderer/src/components/AudioTab/AudioTab.tsx
+++ b/src/renderer/src/components/AudioTab/AudioTab.tsx
@@ -368,7 +368,7 @@ export function AudioTab() {
         </Box>
       }
       drawBottomBorder={true}
-      contentSx={{ p: 1.5 }}
+      contentSx={(theme) => ({ p: theme.layout.gap })}
     >
       <Box width="100%">
         {autoMatch && (

--- a/src/renderer/src/components/AudioTab/AudioTab.tsx
+++ b/src/renderer/src/components/AudioTab/AudioTab.tsx
@@ -29,7 +29,7 @@ import BigDialog from '../../hoc/BigDialog';
 import { useSnackBar } from '../../hoc/SnackBar';
 import { useOrbitData } from '../../hoc/useOrbitData';
 import { mediaTabSelector, sharedSelector } from '../../selector';
-import { GrowingSpacer } from '../../control';
+import { spreadSx, rowSx } from '../../control';
 import ContentLayout from '../App/ContentLayout';
 import Uploader from '../Uploader';
 import { getMedia, IAttachMap, IGetMedia, IPRow, IRow } from '.';
@@ -327,9 +327,9 @@ export function AudioTab() {
   return (
     <ContentLayout
       header={
-        <>
+        <Box sx={spreadSx}>
           {canEditAudio && (
-            <Box sx={{ display: 'flex', gap: 1.5 }}>
+            <Box sx={rowSx}>
               <Button
                 id="audUpload"
                 key="upload"
@@ -351,7 +351,6 @@ export function AudioTab() {
               </Button>
             </Box>
           )}
-          <GrowingSpacer />
           {complete !== 0 &&
             complete !== 100 &&
             !cloudSync.current &&
@@ -366,7 +365,7 @@ export function AudioTab() {
                 {ts.cancel}
               </Button>
             )}
-        </>
+        </Box>
       }
       drawBottomBorder={true}
       contentSx={{ p: 1.5 }}

--- a/src/renderer/src/components/Sheet/PlanBar.tsx
+++ b/src/renderer/src/components/Sheet/PlanBar.tsx
@@ -8,6 +8,7 @@ import { useGlobal } from '../../context/useGlobal';
 import { PlanContext } from '../../context/PlanContext';
 import { planSheetSelector } from '../../selector';
 import { LightTooltip } from '../../control/LightTooltip';
+import { spreadSx, rowSx, rigidSx } from '../../control';
 import FilterMenu, { ISTFilterState } from './filterMenu';
 import { PlanTabSelect } from './PlanTabSelect';
 
@@ -50,23 +51,9 @@ export const PlanBar = (props: IProps) => {
   const t: IPlanSheetStrings = useSelector(planSheetSelector, shallowEqual);
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        gap: (theme) => theme.layout.gap,
-        width: '100%',
-      }}
-    >
+    <Box sx={spreadSx}>
       <PlanTabSelect />
-      <Box
-        sx={{
-          display: 'flex',
-          gap: (theme) => theme.layout.gap,
-          flexShrink: 0,
-        }}
-      >
+      <Box sx={[rowSx, rigidSx]}>
         {data.length > 1 && !offline && !flat && (
           <LightTooltip
             title={

--- a/src/renderer/src/components/Sheet/PlanSheet.tsx
+++ b/src/renderer/src/components/Sheet/PlanSheet.tsx
@@ -1217,7 +1217,7 @@ export function PlanSheet(props: IProps) {
         </Box>
       }
       drawBottomBorder={true}
-      contentSx={{ position: 'relative', p: 1.5 }}
+      contentSx={(theme) => ({ p: theme.layout.gap, position: 'relative' })}
       contentRef={scrollRef}
     >
       <Dialog open={goToOpen} onClose={() => setGoToOpen(false)} maxWidth="sm">

--- a/src/renderer/src/components/Sheet/PlanSheet.tsx
+++ b/src/renderer/src/components/Sheet/PlanSheet.tsx
@@ -68,8 +68,9 @@ import { planSheetSelector, sharedSelector } from '../../selector';
 import {
   AddSectionPassageButtons,
   ProjButtons,
-  GrowingSpacer,
   LightTooltip,
+  spreadSx,
+  rowSx,
 } from '../../control';
 import Confirm from '../AlertDialog';
 import ContentLayout from '../App/ContentLayout';
@@ -1108,9 +1109,9 @@ export function PlanSheet(props: IProps) {
   return (
     <ContentLayout
       header={
-        <>
+        <Box sx={spreadSx}>
           {!readonly && (
-            <Box sx={{ display: 'flex', gap: 1.5 }}>
+            <Box sx={rowSx}>
               <AddSectionPassageButtons
                 inlinePassages={inlinePassages}
                 numRows={rowInfo.length}
@@ -1153,8 +1154,7 @@ export function PlanSheet(props: IProps) {
               )}
             </Box>
           )}
-          <GrowingSpacer />
-          <Box sx={{ display: 'flex', gap: 1.5 }}>
+          <Box sx={rowSx}>
             {data.length > 1 &&
               !offline &&
               !inlinePassages &&
@@ -1214,7 +1214,7 @@ export function PlanSheet(props: IProps) {
               </Button>
             )}
           </Box>
-        </>
+        </Box>
       }
       drawBottomBorder={true}
       contentSx={{ position: 'relative', p: 1.5 }}

--- a/src/renderer/src/components/Sheet/ScriptureTable.tsx
+++ b/src/renderer/src/components/Sheet/ScriptureTable.tsx
@@ -2249,7 +2249,7 @@ export function ScriptureTable(props: IProps) {
             />
           }
           drawBottomBorder={true}
-          contentSx={{ p: 1.5 }}
+          contentSx={(theme) => ({ p: theme.layout.gap })}
         >
           <PlanView
             rowInfo={rowinfo}

--- a/src/renderer/src/components/TranscriptionTab.tsx
+++ b/src/renderer/src/components/TranscriptionTab.tsx
@@ -68,7 +68,7 @@ import {
   sharedSelector,
   transcriptionTabSelector,
 } from '../selector';
-import { GrowingSpacer } from '../control';
+import { spreadSx, rowSx } from '../control';
 import { isPublishingTitle } from '../control/passageTypeFromRef';
 import ContentLayout from './App/ContentLayout';
 import { getSection } from './AudioTab/getSection';
@@ -651,43 +651,44 @@ export function TranscriptionTab(props: IProps) {
   return (
     <ContentLayout
       header={
-        <>
-          {(planColumn || floatTop) && (
-            <Button
-              id="transExp"
-              key="export"
-              aria-label={t.exportProject}
-              variant="outlined"
-              onClick={handleProjectExport}
-              title={t.exportProject}
-              disabled={busy}
-            >
-              {t.exportProject}
-            </Button>
-          )}
-          {step && (
-            <AudioExportMenu
-              key="audioexport"
-              action={handleAudioExportMenu}
-              localizedArtifact={localizedArtifact}
-              isScripture={isScripture}
-              disabled={!ready}
-            />
-          )}
-          {planColumn && offline && projects.length > 1 && (
-            <Button
-              id="transBackup"
-              key="backup"
-              aria-label={t.electronBackup}
-              variant="outlined"
-              onClick={handleBackup}
-              title={t.electronBackup}
-            >
-              {t.electronBackup}
-            </Button>
-          )}
-          <GrowingSpacer />
-          <Box sx={{ display: 'flex', gap: 1.5 }}>
+        <Box sx={spreadSx}>
+          <Box sx={rowSx}>
+            {(planColumn || floatTop) && (
+              <Button
+                id="transExp"
+                key="export"
+                aria-label={t.exportProject}
+                variant="outlined"
+                onClick={handleProjectExport}
+                title={t.exportProject}
+                disabled={busy}
+              >
+                {t.exportProject}
+              </Button>
+            )}
+            {step && (
+              <AudioExportMenu
+                key="audioexport"
+                action={handleAudioExportMenu}
+                localizedArtifact={localizedArtifact}
+                isScripture={isScripture}
+                disabled={!ready}
+              />
+            )}
+            {planColumn && offline && projects.length > 1 && (
+              <Button
+                id="transBackup"
+                key="backup"
+                aria-label={t.electronBackup}
+                variant="outlined"
+                onClick={handleBackup}
+                title={t.electronBackup}
+              >
+                {t.electronBackup}
+              </Button>
+            )}
+          </Box>
+          <Box sx={rowSx}>
             <Button
               id="transCopy"
               key="copy"
@@ -733,7 +734,7 @@ export function TranscriptionTab(props: IProps) {
               ))}
             </Menu>
           </Box>
-        </>
+        </Box>
       }
       drawBottomBorder={true}
       contentSx={{ p: 1.5 }}

--- a/src/renderer/src/components/TranscriptionTab.tsx
+++ b/src/renderer/src/components/TranscriptionTab.tsx
@@ -737,7 +737,7 @@ export function TranscriptionTab(props: IProps) {
         </Box>
       }
       drawBottomBorder={true}
-      contentSx={{ p: 1.5 }}
+      contentSx={(theme) => ({ p: theme.layout.gap })}
     >
       <Box ref={boxRef} id="TranscriptionTab" sx={{ display: 'flex' }}>
         {alertOpen && (

--- a/src/renderer/src/control/index.ts
+++ b/src/renderer/src/control/index.ts
@@ -38,3 +38,4 @@ export * from './TeamPaper';
 export * from './TemplateEditor';
 export * from './smallBtnProps';
 export * from './WrapTitle';
+export * from './layoutSx';

--- a/src/renderer/src/control/layoutSx.ts
+++ b/src/renderer/src/control/layoutSx.ts
@@ -13,7 +13,7 @@ export const spreadSx = (theme: Theme) => ({
 });
 
 // For flexible content (e.g., contains text that can truncate)
-export const growSx = { flex: '1 1 auto', minWidth: 0 };
+export const flexibleSx = { flex: '1 1 auto', minWidth: 0 };
 
 // For rigid content (e.g., only contains icon buttons)
 export const rigidSx = { flexShrink: 0 };

--- a/src/renderer/src/control/layoutSx.ts
+++ b/src/renderer/src/control/layoutSx.ts
@@ -1,0 +1,19 @@
+import { Theme } from '@mui/material';
+
+export const rowSx = (theme: Theme) => ({
+  display: 'flex',
+  gap: theme.layout.gap,
+  minWidth: 0,
+});
+
+export const spreadSx = (theme: Theme) => ({
+  ...rowSx(theme),
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+// For flexible content (e.g., contains text that can truncate)
+export const growSx = { flex: '1 1 auto', minWidth: 0 };
+
+// For rigid content (e.g., only contains icon buttons)
+export const rigidSx = { flexShrink: 0 };


### PR DESCRIPTION
Changes:

- New `control/layoutSx.ts`: `rowSx` (flex row + theme gap), `spreadSx` (row + space-between), `flexibleSx` / `rigidSx` (absorb slack vs. don't)
- Header rows converted in `AppHead`, `OrgHead`, `PlanBar`, `PlanSheet`,`TranscriptionTab`, `AudioTab`, `AssignmentTable` will now have explicit left/right row groups instead of `<GrowingSpacer />` between loose siblings. `GrowingSpacer` stays for its other (non-header) uses.
- `ContentLayout` merges `headerSx`, `contentSx`, `footerSx`, `footerAboveSx` as arrays instead of object-spread, so callers can pass theme callbacks and have them compose with the base styles
- Hard-coded `1.5` padding/gaps replaced with `theme.layout.gap`